### PR TITLE
On parse error, print bad input

### DIFF
--- a/src/main/scala/com/atomist/project/edit/Impact.scala
+++ b/src/main/scala/com/atomist/project/edit/Impact.scala
@@ -38,7 +38,8 @@ case class NoModificationNeeded(comment: String) extends ModificationAttempt
   *
   * @param failureExplanation description of what went wrong
   */
-case class FailedModificationAttempt(failureExplanation: String) extends ModificationAttempt
+case class FailedModificationAttempt(failureExplanation: String,
+                                     cause: Option[Throwable] = None) extends ModificationAttempt
 
 /**
   * Indicates whether this can be applied to a particular ArtifactSource.

--- a/src/main/scala/com/atomist/rug/kind/dynamic/ViewFinder.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/ViewFinder.scala
@@ -36,7 +36,7 @@ trait ContextlessViewFinder extends ViewFinder with ChildResolver {
 }
 
 /**
-  * Find views in a context, with project knowledge. Used to drive with block execution.
+  * Find views in a context, with project knowledge. Used to drive `with` block execution.
   */
 trait ViewFinder {
 
@@ -53,7 +53,10 @@ trait ViewFinder {
     }
     catch {
       case npe: NullPointerException =>
-        val msg = s"Internal error in Rug type with alias '${selected.alias}': A view was returned as null"
+        val msg = s"""Internal error in Rug type with alias '${selected.alias}': A view was returned as null.
+                      | The context is: ${context}
+                      | This is what is available: ${findAllIn(rugAs, selected, context, poa, identifierMap)}
+                      |"""
         throw new RugRuntimeException(null, msg, npe)
     }
   }

--- a/src/main/scala/com/atomist/rug/kind/elm/ElmParserCombinator.scala
+++ b/src/main/scala/com/atomist/rug/kind/elm/ElmParserCombinator.scala
@@ -257,7 +257,7 @@ private[elm] object ElmParserCombinator
 
       def field: Parser[ElmRecordField] = positionedStructure(fieldStructure)
 
-      def record: Parser[ElmRecord] = "{" ~> repsep(field, ",") <~ "}" ^^ (fields => new ElmRecord(fields))
+      def record: Parser[ElmRecord] = "{" ~> repsep(field, ",") <~ opt(NewLineWithLessIndentation) ~ "}" ^^ (fields => new ElmRecord(fields))
 
       private def recordSuchThatStructure: Parser[ElmRecordUpdate] = "{" ~> functionName ~ "|" ~ rep1sep(field, CommaThatMightGoLeft) <~ opt(NewLineWithLessIndentation) ~ "}" ^^ {
         case startingRecord ~ _ ~ changedFields => ElmRecordUpdate(startingRecord, changedFields)

--- a/src/main/scala/com/atomist/rug/kind/elm/ElmParserCombinator.scala
+++ b/src/main/scala/com/atomist/rug/kind/elm/ElmParserCombinator.scala
@@ -257,7 +257,9 @@ private[elm] object ElmParserCombinator
 
       def field: Parser[ElmRecordField] = positionedStructure(fieldStructure)
 
-      def record: Parser[ElmRecord] = "{" ~> repsep(field, ",") <~ opt(NewLineWithLessIndentation) ~ "}" ^^ (fields => new ElmRecord(fields))
+      private def recordElementSeparator: Parser[String] = opt(NewLineWithLessIndentation) ~> ","
+
+      def record: Parser[ElmRecord] = "{" ~> repsep(field, recordElementSeparator) <~ opt(NewLineWithLessIndentation) ~ "}" ^^ (fields => new ElmRecord(fields))
 
       private def recordSuchThatStructure: Parser[ElmRecordUpdate] = "{" ~> functionName ~ "|" ~ rep1sep(field, CommaThatMightGoLeft) <~ opt(NewLineWithLessIndentation) ~ "}" ^^ {
         case startingRecord ~ _ ~ changedFields => ElmRecordUpdate(startingRecord, changedFields)

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmAddDependencyTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmAddDependencyTest.scala
@@ -1,0 +1,5 @@
+package com.atomist.rug.kind.elm
+
+class ElmAddDependencyTest {
+
+}


### PR DESCRIPTION
This replaces a particular exception with a FailedModificationAttempt

and fixes the Elm Parser problem that triggered this confusion

Suggestions on a better place to put this error parsing are welcome. Perhaps it should more generally return FailedModificationAttempt instead of throwing?