### PR TITLE
Enforce anchors and fix all the tests #31

### DIFF
--- a/src/main/scala/com/atomist/param/ParameterValidationPatterns.scala
+++ b/src/main/scala/com/atomist/param/ParameterValidationPatterns.scala
@@ -9,18 +9,19 @@ object ParameterValidationPatterns {
   // so make sure any special characters are valid in both.  For example, you can use
   // \w but not \p{Alpha} (Java only).
 
-  val MatchAll = ".*"
+  val MatchAll = "^.*$"
   val ProjectName = "^[-\\w.]+$"
   val JavaIdentifier = "^[A-Za-z_$][\\w$]*$"
   val JavaPackage = "^(?:(?:[A-Za-z_$][\\w$]*\\.)*[A-Za-z_$][\\w$]*)*$"
   val JavaClass = JavaIdentifier
-  val MavenStarter = ".*"
   val GroupName = "^(?:[A-Za-z_][\\w]*\\.)*[-A-Za-z_][-\\w]*$"
   val ArtifactId = "^[a-z][-a-z0-9_]*$"
 
+  val RubyClass = "^[A-Z][A-Za-z0-9_]*$"
+  val RubyIdentifier = "^[A-Za-z_][A-Za-z0-9_]*$"
+
   // True semantic version http://semver.org
   val Version = "^v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-(?:[1-9]\\d*|[-A-Za-z\\d]*[-A-Za-z][-A-Za-z\\d]*)(?:\\.(?:[1-9]\\d*|[-A-Za-z\\d]*[-A-Za-z][-A-Za-z\\d]*))*)?(?:\\+[-A-Za-z\\d]+(?:\\.[-A-Za-z\\d]+)*)?$"
-  //val Version = "^v?[0-9]+\\.[0-9]+\\.[0-9]+(-([0-9TZ]+|SNAPSHOT))?$"
 
   val NonNegativeInteger = "^(?:0|[1-9]\\d*)$"
   val Url = "^(?:https?|ftp)://[^\\s]+$"

--- a/src/main/scala/com/atomist/rug/BadRugException.scala
+++ b/src/main/scala/com/atomist/rug/BadRugException.scala
@@ -57,3 +57,6 @@ class UnusedUsesException(op: String, msg: String, val unusedUses: Seq[String])
 
 class InvalidRugUsesException(op: String, msg: String, val uses: String)
   extends RugReferenceException(op, msg, null)
+
+class InvalidRugParameterPatternException(msg: String)
+   extends BadRugException(msg)

--- a/src/main/scala/com/atomist/rug/parser/DefaultIdentifierResolver.scala
+++ b/src/main/scala/com/atomist/rug/parser/DefaultIdentifierResolver.scala
@@ -5,6 +5,7 @@ object DefaultIdentifierResolver extends IdentifierResolver {
   import com.atomist.param.ParameterValidationPatterns._
 
   val knownIds = Map(
+    "all" -> MatchAll,
     "artifact_id" -> ArtifactId,
     "group_id" -> GroupName,
     "java_class" -> JavaClass,
@@ -12,8 +13,8 @@ object DefaultIdentifierResolver extends IdentifierResolver {
     "java_package" -> JavaPackage,
     "project_name" -> ProjectName,
     "port" -> Port,
-    "ruby_class" -> "[A-Z][A-Za-z0-9_]*",
-    "ruby_identifier" -> "[A-Za-z_][A-Za-z0-9_]*",
+    "ruby_class" -> RubyClass,
+    "ruby_identifier" -> RubyIdentifier,
     "semantic_version" -> Version,
     "url" -> Url,
     "uuid" -> Uuid

--- a/src/main/scala/com/atomist/rug/parser/ParserCombinatorRugParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/ParserCombinatorRugParser.scala
@@ -29,6 +29,7 @@ class ParserCombinatorRugParser(
     })
 
   private def paramPattern: Parser[ParameterPattern] = (stringArray | regexParamPattern) ^^ {
+    case s: String if !s.startsWith("^") || !s.endsWith("$") => throw new InvalidRugParameterPatternException(s"Parameter pattern must contain anchors: $s")
     case p: String => RegexParameterPattern(p)
     case values: Seq[String @unchecked] => AllowedValuesParameterPattern(values)
   }

--- a/src/test/resources/elm-start-static-page/.atomist/editors/NewStaticPage.rug
+++ b/src/test/resources/elm-start-static-page/.atomist/editors/NewStaticPage.rug
@@ -29,7 +29,7 @@ param version: @semantic_version
 @description "Summary of the new project"
 @displayName "description"
 @validInput "Under 80 characters"
-param description: .*
+param description: ^.*$
 
 
 SwitchProjectName
@@ -41,7 +41,7 @@ SetSummary
 @description "Change the description in elm-package.json"
 editor SetSummary
 
-param description: .*
+param description: ^.*$
 
 let descriptionField = $(/[name='elm-package.json']->json/summary)
 

--- a/src/test/scala/com/atomist/param/ParameterTest.scala
+++ b/src/test/scala/com/atomist/param/ParameterTest.scala
@@ -44,8 +44,8 @@ class ParameterTest extends FlatSpec with Matchers {
     shouldReject(AllowedValuesParam, Seq("ff", "long_parameter"))
   }
 
-  it should "don't reject parameter that matches the pattern" in {
-    shouldAccept(InputParam, Seq("FavoriteColour"))
+  it should "reject a param that doesn't match anchored regexp" in {
+    shouldReject(Parameter("foo","""^[a-z][\w]*$"""), Seq("FavoriteColour"))
   }
 
   it should "don't reject parameter that matches a stricter pattern" in {

--- a/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
+++ b/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
@@ -38,8 +38,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "A very short tempered editor"
         |editor Caspar
         |
-        |param text: ^.*$
-        |param message: ^.*$
+        |param text: @all
+        |param message: @all
         |
         |with file f
         | when name = "Dog.java"
@@ -55,8 +55,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "A very short tempered editor"
         |editor Caspar
         |
-        |param text: ^.*$
-        |param message: ^.*$
+        |param text: @all
+        |param message: @all
         |
         |with file f
         | when true

--- a/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
+++ b/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
@@ -38,8 +38,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "A very short tempered editor"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when name = "Dog.java"
@@ -55,8 +55,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "A very short tempered editor"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when true
@@ -72,8 +72,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "A very short tempered editor"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when true
@@ -91,8 +91,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "A very short tempered editor"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when true
@@ -111,8 +111,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "I can get you a toe!"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         |do
@@ -127,8 +127,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "I can get you a toe!"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when true
@@ -146,7 +146,7 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description 'A very short tempered editor'
         |editor Caspar
         |
-        |param message: .*
+        |param message: ^.*$
         |
         |let text = "// I'm talkin' about ethics"
         |
@@ -164,7 +164,7 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description 'A very short tempered editor'
         |editor Caspar
         |
-        |param message: .*
+        |param message: ^.*$
         |
         |let text = { "// I'm talkin' about ethics" }
         |let random = { "" + message }
@@ -259,8 +259,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
          |@description "That's over the line!"
          |editor Caspar
          |
-         |param text: .*
-         |param message: .*
+         |param text: ^.*$$
+         |param message: ^.*$$
          |
          |with file f
          | when { /.*\\.java$$/.test(f.name())}
@@ -312,8 +312,8 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |@description "I can get you a toe!"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when isJava

--- a/src/test/scala/com/atomist/rug/ConditionsTest.scala
+++ b/src/test/scala/com/atomist/rug/ConditionsTest.scala
@@ -205,7 +205,7 @@ class ConditionsTest extends FlatSpec with Matchers {
         |
         |reviewer NeverGripe
         |
-        |param whatever: .*
+        |param whatever: ^.*$
         |
         |with file f
         |when "a" = "b"

--- a/src/test/scala/com/atomist/rug/InterpreterRuntimeTest.scala
+++ b/src/test/scala/com/atomist/rug/InterpreterRuntimeTest.scala
@@ -18,8 +18,8 @@ class CompilerChainRuntimeTest extends AbstractRuntimeTest {
          |@description "That's over the line!"
          |editor Caspar
          |
-         |param text: .*
-         |param message: .*
+         |param text: ^.*$$
+         |param message: ^.*$$
          |
          |with file
          | #when { file.name().endsWith(".java") }
@@ -47,7 +47,7 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description 'A very short tempered editor'
         |editor Caspar
         |
-        |param message: .*
+        |param message: ^.*$
         |
         |let text = "// I'm talkin' about ethics"
         |
@@ -64,7 +64,7 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description 'A very short tempered editor'
         |editor Caspar
         |
-        |param message: .*
+        |param message: ^.*$
         |
         |let text = "// I'm talkin' about ethics"
         |
@@ -80,8 +80,8 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
       """
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |{
         |
@@ -103,8 +103,8 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description "I believe in the first amendment!"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when isJava
@@ -136,8 +136,8 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
          |@description "What is this, the high hat?"
          |editor Caspar
          |
-         |param text: .*
-         |param message: .*
+         |param text: ^.*$$
+         |param message: ^.*$$
          |
          |with file f
          | when {
@@ -159,8 +159,8 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description "I can get you a toe!"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when isJava
@@ -178,8 +178,8 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description "I can get you a toe!"
         |editor Caspar
         |
-        |param text: .*
-        |param message: .*
+        |param text: ^.*$
+        |param message: ^.*$
         |
         |with file f
         | when isJava
@@ -223,7 +223,7 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description "This is a second editor"
         |editor Other
         |
-        |param num: \d+
+        |param num: ^\d+$
         |
         |with project p
         |do
@@ -247,7 +247,7 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
         |@description "This is a second editor"
         |editor Other
         |
-        |param num: \d+
+        |param num: ^\d+$
         |
         |with project p
         |do

--- a/src/test/scala/com/atomist/rug/K8Test.scala
+++ b/src/test/scala/com/atomist/rug/K8Test.scala
@@ -116,8 +116,8 @@ class K8Test extends FlatSpec with Matchers {
         |@description "Update Kube spec to redeploy a service"
         |editor Redeploy
         |
-        |param service: [\w.\-_]+
-        |param new_sha: [a-f0-9]{7}
+        |param service: ^[\w.\-_]+$
+        |param new_sha: ^[a-f0-9]{7}$
         |
         |let regexp = ":[a-f0-9]{7}"
         |
@@ -135,8 +135,8 @@ class K8Test extends FlatSpec with Matchers {
         |@description "Update Kube spec to redeploy a service"
         |editor Redeploy
         |
-        |param service: [\w.\-_]+
-        |param new_sha: [a-f0-9]{7}
+        |param service: ^[\w.\-_]+$
+        |param new_sha: ^[a-f0-9]{7}$
         |
         |let regexp = ":[a-f0-9]{7}"
         |
@@ -155,8 +155,8 @@ class K8Test extends FlatSpec with Matchers {
         |@description "Update Kube spec to redeploy a service"
         |editor Redeploy
         |
-        |param service: [\w.\-_]+
-        |param new_sha: [a-f0-9]{7}
+        |param service: ^[\w.\-_]+$
+        |param new_sha: ^[a-f0-9]{7}$
         |
         |let regexp = ":[a-f0-9]{7}"
         |
@@ -174,8 +174,8 @@ class K8Test extends FlatSpec with Matchers {
         |@description "Update Kube spec to redeploy a service"
         |editor Redeploy
         |
-        |param service: [\w.\-_]+
-        |param new_sha: [a-f0-9]{7}
+        |param service: ^[\w.\-_]+$
+        |param new_sha: ^[a-f0-9]{7}$
         |
         |with file f
         | when { f.name().indexOf("80-" + service + "-deployment") >= 0 }
@@ -195,8 +195,8 @@ class K8Test extends FlatSpec with Matchers {
         |@description "Update Kube spec to redeploy a service"
         |editor Redeploy
         |
-        |param service: [\w.\-_]+
-        |param new_sha: [a-f0-9]{7}
+        |param service: ^[\w.\-_]+$
+        |param new_sha: ^[a-f0-9]{7}$
         |
         |with project p;
         |do
@@ -211,8 +211,8 @@ class K8Test extends FlatSpec with Matchers {
         |@description "Update Kube spec to redeploy a service"
         |editor Redeploy
         |
-        |param service: [\w.\-_]+
-        |param new_sha: [a-f0-9]{7}
+        |param service: ^[\w.\-_]+$
+        |param new_sha: ^[a-f0-9]{7}$
         |
         |with file f
         | when { f.name().indexOf("80-" + service + "-deployment") >= 0 }

--- a/src/test/scala/com/atomist/rug/UsesTest.scala
+++ b/src/test/scala/com/atomist/rug/UsesTest.scala
@@ -209,7 +209,7 @@ class UsesTest extends FlatSpec with Matchers {
         |
         |editor Foo
         |
-        |param foo: .*
+        |param foo: ^.*$
         |
         |with file f
         |do replace "some" "bar"
@@ -232,7 +232,7 @@ class UsesTest extends FlatSpec with Matchers {
       """
         |editor Redeploy
         |
-        |param foo: .*
+        |param foo: ^.*$
         |
         |with file f
         |do
@@ -241,8 +241,8 @@ class UsesTest extends FlatSpec with Matchers {
         |
         |editor Foo
         |
-        |param foo: .*
-        |param bar: .*
+        |param foo: ^.*$
+        |param bar: ^.*$
         |
         |with file f
         | do replace "some" "bar"
@@ -257,7 +257,7 @@ class UsesTest extends FlatSpec with Matchers {
       """
         |editor Redeploy
         |
-        |param foo: .*
+        |param foo: ^.*$
         |
         |with file f
         |do
@@ -267,16 +267,16 @@ class UsesTest extends FlatSpec with Matchers {
         |
         |editor Foo
         |
-        |param foo: .*
-        |param bar: .*
+        |param foo: ^.*$
+        |param bar: ^.*$
         |
         |with file f
         | do replace "some" "bar"
         |
         |editor Bar
         |
-        |param foo: .*
-        |param bar: .*
+        |param foo: ^.*$
+        |param bar: ^.*$
         |
         |with file f
         | do replace "some" "bar"
@@ -299,15 +299,15 @@ class UsesTest extends FlatSpec with Matchers {
         |
         |editor Foo
         |
-        |param foo: .*
-        |param bar: .*
+        |param foo: ^.*$
+        |param bar: ^.*$
         |
         |with file f
         | do replace "some" "bar"
         |
         |editor Bar
         |
-        |param baz: .*
+        |param baz: ^.*$
         |
         |with file f
         | do replace "some" "bar"
@@ -326,15 +326,15 @@ class UsesTest extends FlatSpec with Matchers {
         |
         |editor Foo
         |
-        |param foo: .*
-        |param bar: .*
+        |param foo: ^.*$
+        |param bar: ^.*$
         |
         |with file f
         | do replace "some" "bar"
         |
         |editor Bar
         |
-        |param baz: .*
+        |param baz: ^.*$
         |
         |with file f
         | do replace "some" "bar"
@@ -459,8 +459,8 @@ class UsesTest extends FlatSpec with Matchers {
         |
         |editor Foo
         |
-        |param foo: .*
-        |param bar: .*
+        |param foo: ^.*$
+        |param bar: ^.*$
         |
         |with file f
         | do replace "some" "bar"

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerTypeTestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerTypeTestRunnerTest.scala
@@ -12,7 +12,7 @@ class DockerTypeTestRunnerTest extends FlatSpec with Matchers with RugTestRunner
       """
         |editor UpdateServicePort
         |
-        |param servicePort: .*
+        |param servicePort: ^.*$
         |
         |with dockerfile d when path = "src/main/docker/Dockerfile"
         |  do addOrUpdateExpose servicePort

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmCaseManipulationTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmCaseManipulationTest.scala
@@ -38,8 +38,8 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
     """
       |editor AddClause
       |
-      |param expr: .*
-      |param rhs: .*
+      |param expr: ^.*$
+      |param rhs: ^.*$
       |
       |with elm.module when name = 'Main'
       |    with case cc when matchAsString = 'msg'

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmExtractModuleTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmExtractModuleTest.scala
@@ -12,7 +12,7 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
       """editor ExtractAllIntoModule
         |
         |@description "Name of the module to extract into"
-        |param new_module_name: [A-Z][\w]*
+        |param new_module_name: ^[A-Z][\w]*$
         |
         |let new_file_name={ new_module_name + ".elm" }
         |
@@ -29,8 +29,8 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
         |RemoveFunction module=new_module_name, function="main"
         |
         |editor RemoveFunction
-        |  param module: .*
-        |  param function: .*
+        |  param module: ^.*$
+        |  param function: ^.*$
         |
         |  with elm.module when name = module
         |    do removeFunction function
@@ -46,11 +46,10 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
     content.contains(expectedHeader) should be(true)
     content.contains("main") should be(false)
   }
-
   it should "replace the init function" in {
     val prog =
       """editor ReplaceInit
-        |param new_module_name: .*
+        |param new_module_name: ^[\s\S]*$
         |
         |let lower_new_module={ new_module_name.charAt(0).toLowerCase() + new_module_name.slice(1) }
         |let new_init={
@@ -68,8 +67,8 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
         |
         |editor ReplaceFunctionBody
         |
-        |param function: .*
-        |param new_body: .*
+        |param function: ^.*$
+        |param new_body: ^[\s\S]*$
         |# gut all the functions in Main and make them call the new module
         |  with elm.module when name = "Main"
         |    with function when name = function
@@ -91,7 +90,7 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
 
     val prog =
       """editor ReplaceModel
-        |param new_module_name: .*
+        |param new_module_name: ^.*$
         |
         |let lower_new_module={ new_module_name.charAt(0).toLowerCase() + new_module_name.slice(1) }
         |let new_body={
@@ -120,7 +119,7 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
 
     val prog =
       """editor ReplaceSubscriptions
-        |param new_module_name: .*
+        |param new_module_name: ^.*$
         |
         |let lower_new_module={ new_module_name.charAt(0).toLowerCase() + new_module_name.slice(1) }
         |let new_body={
@@ -140,7 +139,7 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
 
     val prog =
       """editor ReplaceMsg
-        |param new_module_name: .*
+        |param new_module_name: ^.*$
         |
         |let new_body={
         |return ("  Noop" + "\n" +

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTextInputTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTextInputTest.scala
@@ -84,7 +84,7 @@ class ElmTextInputTest extends FlatSpec with Matchers {
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source),
       ElmTextInputTest.AddToModel,
       Map("module" -> "Main",
-        "type_name" -> "Model",
+        "type_name" -> "model",
         "field_name" -> "topic",
         "field_type" -> "String",
         "initial_value" -> "cats"))
@@ -102,7 +102,7 @@ object ElmTextInputTest {
       |@displayName "Name"
       |@description "Name of the text input (the field to store in the model)"
       |@validInput "An elm identifier"
-      |param input_name: [a-z][\w]*
+      |param input_name: ^[a-z][\w]*$
       |
       |# capitalize
       |let type_name={ input_name.charAt(0).toUpperCase() + input_name.slice(1) }
@@ -124,7 +124,7 @@ object ElmTextInputTest {
       |  param module: [A-Z][\w]*
       |
       |  @description "The import to add, fully qualified"
-      |  param fqn: .*
+      |  param fqn: ^.*$
       |
       |  with elm.module when name = module
       |    do addImportStatement {"import " + fqn}
@@ -139,7 +139,7 @@ object ElmTextInputTest {
       |@displayName "Code"
       |@description "All the code to add"
       |@validInput "An Elm declaration"
-      |param code: .*
+      |param code: ^.*$
       |
       |with file
       |  with elm.module when name = module
@@ -149,9 +149,9 @@ object ElmTextInputTest {
   val AddToModel =
     """editor AddToModel
       |
-      |param field_name: [a-z][\w]*
-      |param field_type: .*
-      |param initial_value: .*
+      |param field_name: ^[a-z][\w]*$
+      |param field_type: ^.*$
+      |param initial_value: ^.*$
       |
       |
       |AddToRecordTypeAlias type_name="Model", module="Main"
@@ -160,10 +160,10 @@ object ElmTextInputTest {
       |
       |editor AddToRecordTypeAlias
       |
-      |  param module: .*
-      |  param type_name: [a-z][\w]*
-      |  param field_name: [a-z][\w]*
-      |  param field_type: .*
+      |  param module: ^.*$
+      |  param type_name: ^[a-z][\w]*$
+      |  param field_name: ^[a-z][\w]*$
+      |  param field_type: ^.*$
       |
       |with file
       |  with elm.module when name = module
@@ -174,10 +174,10 @@ object ElmTextInputTest {
       |
       |editor AddToModelInitialization
       |
-      |	 param module: .*
-      |  param function_name: [a-z][\w]*
-      |  param field_name: [a-z][\w]*
-      |  param field_value: .*
+      |	 param module: ^.*$
+      |  param function_name: ^[a-z][\w]*$
+      |  param field_name: ^[a-z][\w]*$
+      |  param field_value: ^.*$
       |
       |with file
       |  with elm.module when name = module
@@ -193,19 +193,19 @@ object ElmTextInputTest {
       |
       |@displayName "Message Constructor"
       |@description "Message constructor, its name and parameter types"
-      |param constructor: .*
+      |param constructor: ^.*$
       |
       |@displayName "Deconstructor"
       |@description "What this looks like in a pattern match; leave blank if there are no type parameters"
       |@optional
       |@default ""
-      |param deconstructor: .*
+      |param deconstructor: ^.*$
       |
       |@displayName "Case Clause Body"
       |@description "Value for model when the message is received"
       |@optional
       |@default "model"
-      |param update_model: .*
+      |param update_model: ^.*$
       |
       |AddToUnionType module="Main", type_name="Msg", constructor=constructor
       |AddCaseClause module="Main", function_name="update", match="msg", new_pattern=deconstructor, body=update_model
@@ -219,11 +219,11 @@ object ElmTextInputTest {
       |
       |  @description "The union type"
       |  @displayName "Type"
-      |  param type_name: [a-z][\w]*
+      |  param type_name: ^[a-z][\w]*$
       |
       |  @description "The constructor to add, with its type parameters"
       |  @displayName "Constructor"
-      |  param constructor: [a-z][\w]*
+      |  param constructor: ^[a-z][\w]*$
       |
       |with file
       |  with elm.module when name = module
@@ -236,25 +236,25 @@ object ElmTextInputTest {
       |
       |	@description "Elm module to modify"
       |	@displayName "Module Name"
-      |	param module: [A-Z][\w]*
+      |	param module: ^[A-Z][\w]*$
       |
       |  @description "Name of the function that has a case in it"
       |  @displayName "Function name"
-      |  param function_name: [a-z][\w]*
+      |  param function_name: ^[a-z][\w]*$
       |
       |  @displayName "Match Expression"
       |  @description "What the case statement is matching"
-      |  param match: .*
+      |  param match: ^.*$
       |
       |  @displayName "New Pattern"
       |  @description "new pattern the case can match"
       |  @validInput "A union type deconstructor"
-      |  param new_pattern: .*
+      |  param new_pattern: ^.*$
       |
       |  @displayName "Result"
       |  @description "body of the new case clause"
       |  @validInput "An Elm expression"
-      |  param body: .*
+      |  param body: ^.*$
       |
       |# TODO implement the selection by match expression
       |with file

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTypeUsageTest.scala
@@ -23,10 +23,10 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       |editor Renamer
       |
       |@description "Name of module we're renaming"
-      |param old_name: [A-Z][\w]+
+      |param old_name: ^[A-Z][\w]+$
       |
       |@description "New name for the module"
-      |param new_name: [A-Z][\w]+
+      |param new_name: ^[A-Z][\w]+$
       |
       |with elm.module when name = old_name
       | do rename new_name
@@ -40,7 +40,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     val imp1 = if (param)
       """
         |@parameter({description: "Name of module we're renaming",
-        |    pattern: "[A-Z][\w]+", maxLength: 100, required: true
+        |    pattern: "^[A-Z][\w]+$", maxLength: 100, required: true
         |  })
       """.stripMargin
     else ""
@@ -48,7 +48,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     val imp2 = if (param)
       """
         |@parameter({description: "New name for the module",
-        |    pattern: "[A-Z][\w]+", maxLength: 100
+        |    pattern: "^[A-Z][\w]+$", maxLength: 100
         |  })
       """.stripMargin
     else ""
@@ -125,10 +125,10 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       |editor Renamer
       |
       |@description "Name of module we're renaming"
-      |param old_name: [A-Z][\w]+
+      |param old_name: ^[A-Z][\w]+$
       |
       |@description "New name for the module"
-      |param new_name: [A-Z][\w]+
+      |param new_name: ^[A-Z][\w]+$
       |
       | # TODO note hard coding here
       |let em = $(/->elm.module[name='Todo'])
@@ -147,10 +147,10 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       |editor Renamer
       |
       |@description "Name of module we're renaming"
-      |param old_name: [A-Z][\w]+
+      |param old_name: ^[A-Z][\w]+$
       |
       |@description "New name for the module"
-      |param new_name: [A-Z][\w]+
+      |param new_name: ^[A-Z][\w]+$
       |
       |with file
       | with elm.module when name = old_name
@@ -167,10 +167,10 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       |editor Renamer
       |
       |@description "Name of module we're renaming"
-      |param old_name: [A-Z][\w]+
+      |param old_name: ^[A-Z][\w]+$
       |
       |@description "New name for the module"
-      |param new_name: [A-Z][\w]+
+      |param new_name: ^[A-Z][\w]+$
       |
       |with elm.module e
       |when { e.name() == old_name}
@@ -424,8 +424,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     val fieldType = "String"
     val prog =
       s"""editor AddToRecordValue
-          |param initial_value:.*
-          |param field_type:.*
+          |param initial_value:^.*$$
+          |param field_type:^.*$$
           |
          |let initial_value_careful = {
           |  var quoted = /^".*"$$/
@@ -653,7 +653,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
   it should "replace the body of this function" in {
     val prog =
       """editor UpgradeMainFunction
-        |  param module: .*
+        |  param module: ^.*$
         |
         |  with file f begin
         |    with elm.module when name = module
@@ -702,8 +702,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
   it should "let me switch on the type of a function" in {
     val prog =
       """editor AddCase
-        |param new_pattern: .*
-        |param body: .*
+        |param new_pattern: ^.*$
+        |param body: ^.*$
         |
         |with file
         |  with elm.module when name = "Main"

--- a/src/test/scala/com/atomist/rug/kind/exec/EditorandReviewerExecutionTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/exec/EditorandReviewerExecutionTest.scala
@@ -157,7 +157,7 @@ class EditorAndReviewerExecutionTest extends FlatSpec with Matchers {
         |   editWith Bar
         |
         |editor Bar
-        |param film: .*
+        |param film: ^.*$
         |with project p
         |  do addFile "film.txt" film
       """.stripMargin

--- a/src/test/scala/com/atomist/rug/kind/js/PackageJsonTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/js/PackageJsonTest.scala
@@ -92,7 +92,7 @@ class PackageJsonTest extends FlatSpec with Matchers {
         |@description "Update package JSON"
         |editor Rename
         |
-        |param new_name: [\w.\-_]+
+        |param new_name: ^[\w.\-_]+$
         |
         |with packageJSON f
         |do

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonTypeUsageTest.scala
@@ -87,7 +87,7 @@ class PythonTypeUsageTest extends FlatSpec with Matchers {
       """
         |editor AddFlaskRoute
         |
-        |param new_route: .*
+        |param new_route: ^[\s\S]*$
         |
         |with python when filename = "hello.py"
         | do append new_route

--- a/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
@@ -40,7 +40,7 @@ object CommonRugParserTest {
        |@description '100% JavaScript free'
        |editor Triplet
        |
-       |param what: .*
+       |param what: ^.*$$
        |
        |with file f
        | when name = "thing"
@@ -120,7 +120,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |
         |editor Other
         |
-        |param num: \d+
+        |param num: ^\d+$
         |
         |with file f when name = "foooo" do setPath "doesn't matter"
       """.stripMargin
@@ -140,7 +140,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |@description "This is a second editor"
         |editor Other
         |
-        |param num: \d+
+        |param num: ^\d+$
         |
         |with project p
         |do
@@ -185,7 +185,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |@description "I can get you a toe!"
         |editor Caspar
         |
-        |param num: \d+
+        |param num: ^\d+$
         |
         |{
         | print(project)
@@ -572,7 +572,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
          |@description '100% JavaScript free'
          |editor Triplet
          |
-         |param Bar: .*
+         |param Bar: ^.*$$
          |
          |with file f
          | when isJava;
@@ -667,7 +667,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
          |editor Triplet
          |
          |@generator
-         |param foo: .*
+         |param foo: ^.*$$
          |
          |with file f
          | when isJava

--- a/src/test/scala/com/atomist/rug/parser/RugEditorParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/RugEditorParserTest.scala
@@ -121,7 +121,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
   it should "parse single line script" in {
     val prog =
-      """editor AddFileAndContent param filename: ".*" param content: ".*" with project p do addFile filename content """.stripMargin
+      """editor AddFileAndContent param filename: "^.*$" param content: "^.*$" with project p do addFile filename content """.stripMargin
     ri.parse(prog)
   }
 
@@ -131,7 +131,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         |@description 'No JS'
         |editor RemoveEJB
         |
-        |param name: ...
+        |param name: ^...$
         |
         |with file f
         | when isJava;
@@ -144,7 +144,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     actions.parameters.size should be(1)
     val p = actions.parameters.head
     p.getName should be("name")
-    p.getPattern should be("...")
+    p.getPattern should be("^...$")
     p.isRequired should be(true)
     p.isDisplayable should be(true)
   }
@@ -164,7 +164,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
          |@validInput '$validInput'
          |@displayName '$displayName'
          |@hide
-         |param name: .*
+         |param name: ^.*$$
          |
          |with file f
          | when isJava;
@@ -177,7 +177,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     actions.parameters.size should be(1)
     val p = actions.parameters.head
     p.getName should be("name")
-    p.getPattern should be(".*")
+    p.getPattern should be("^.*$")
     p.getDescription should be(paramDesc)
     p.getDefaultValue should be(defaultVal)
     p.getValidInputDescription should be(validInput)
@@ -192,7 +192,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         |@description "Death to EJBs"
         |editor RemoveEJB
         |
-        |param name: .*
+        |param name: ^.*$
         |
         |with file f
         | when isJava;
@@ -205,7 +205,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     actions.parameters.size should be(1)
     val p = actions.parameters.head
     p.getName should be("name")
-    p.getPattern should be(".*")
+    p.getPattern should be("^.*$")
     p.isRequired should be(true)
   }
 
@@ -250,7 +250,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
          |@description "Something"
          |editor RemoveEJB
          |
-         |@optional param name: .*
+         |@optional param name: ^.*$$
          |
          |with file f
          | when isJava
@@ -265,7 +265,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     actions.parameters.size should be(1)
     val p = actions.parameters.head
     p.getName should be("name")
-    p.getPattern should be(".*")
+    p.getPattern should be("^.*$")
     p.isRequired should be(false)
     actions
   }
@@ -299,7 +299,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
          |@description 'Demonstrate computation'
          |editor RemoveEJB
          |
-         |@optional param name: .*
+         |@optional param name: ^.*$$
          |
          |let ${infers.mkString("\n")}
          |
@@ -414,10 +414,10 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         |editor Renamer
         |
         |@description "Name of module we're renaming"
-        |param old_name: [A-Z][\w]+
+        |param old_name: ^[A-Z][\w]+$
         |
         |@description "New name for the module"
-        |param new_name: [A-Z][\w]+
+        |param new_name: ^[A-Z][\w]+$
         |
         |with elmModule e
         |when { e.name() == old_name}

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperationTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperationTest.scala
@@ -1,6 +1,7 @@
 package com.atomist.rug.runtime.js
 
-import com.atomist.project.{SimpleProjectOperationArguments}
+import com.atomist.project.SimpleProjectOperationArguments
+import com.atomist.rug.InvalidRugParameterPatternException
 import com.atomist.source.{FileArtifact, SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -10,6 +11,44 @@ import org.scalatest.{FlatSpec, Matchers}
 
 
 object JavaScriptInvokingProjectOperationTest {
+
+    val SimpleEditorWithBrokenParameterPattern =
+        s"""
+           |import {Project} from 'user-model/model/Core'
+           |import {ParametersSupport} from 'user-model/operations/Parameters'
+           |import {ProjectEditor} from 'user-model/operations/ProjectEditor'
+           |import {Parameters} from 'user-model/operations/Parameters'
+           |import {File} from 'user-model/model/Core'
+           |import {Result,Status} from 'user-model/operations/Result'
+           |
+           |import {parameter} from 'user-model/support/Metadata'
+           |import {inject} from 'user-model/support/Metadata'
+           |import {parameters} from 'user-model/support/Metadata'
+           |import {tag} from 'user-model/support/Metadata'
+           |import {editor} from 'user-model/support/Metadata'
+           |
+           |abstract class ContentInfo extends ParametersSupport {
+           |
+           |  @parameter({description: "Content", displayName: "content", pattern: ".*", maxLength: 100})
+           |  content: string = null
+           |
+           |}
+           |
+           |@editor("A nice little editor")
+           |@tag("java")
+           |@tag("maven")
+           |class SimpleEditor implements ProjectEditor<ContentInfo> {
+           |
+           |    edit(project: Project, @parameters("ContentInfo") p: ContentInfo) {
+           |      p["otherParam"] = p.content
+           |      return new Result(Status.Success,
+           |        `Edited Project now containing $${project.fileCount()} files: \n`
+           |        );
+           |    }
+           |  }
+           |
+    """.stripMargin
+
     val SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters =
         s"""
            |import {Project} from 'user-model/model/Core'
@@ -54,7 +93,14 @@ class JavaScriptInvokingProjectOperationTest  extends FlatSpec with Matchers {
     it should "run simple editor compiled from TypeScript and validate the pattern correctly" in {
         invokeAndVerifySimple(StringFileArtifact(s".atomist/SimpleEditor.ts", SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters))
     }
-    private def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
+
+  it should "run simple editor and throw an exception for the bad pattern" in {
+    assertThrows[InvalidRugParameterPatternException]{
+      invokeAndVerifySimple(StringFileArtifact(s".atomist/SimpleEditor.ts", SimpleEditorWithBrokenParameterPattern))
+    }
+  }
+
+  private def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
         val as = SimpleFileBasedArtifactSource(tsf)
         val jsed = JavaScriptOperationFinder.fromTypeScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
         jsed.name should be("Simple")

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 object TypeScriptRugEditorTest {
 
-  val ContentPattern = "Anders .*"
+  val ContentPattern = "^Anders .*$"
 
   val SimpleEditorWithoutParameters =
     """
@@ -147,7 +147,7 @@ object TypeScriptRugEditorTest {
        |  @parameter({description: "Content", displayName: "content", pattern: "$ContentPattern", maxLength: 100})
        |  content: string = "Anders"
        |
-       |   @parameter({description: "some num", displayName: "num", pattern: "[\\d]+", maxLength: 100})
+       |   @parameter({description: "some num", displayName: "num", pattern: "^[\\d]+$$", maxLength: 100})
        |   num: number = 10
        |}
        |
@@ -184,7 +184,7 @@ object TypeScriptRugEditorTest {
       |
       |abstract class JavaInfo extends ParametersSupport {
       |
-      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: ".*", maxLength: 100})
+      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
       |  packageName: string = null
       |
       |}
@@ -243,7 +243,7 @@ object TypeScriptRugEditorTest {
       |
       |abstract class JavaInfo extends ParametersSupport {
       |
-      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: ".*", maxLength: 100})
+      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
       |  packageName: string = null
       |
       |}
@@ -299,7 +299,7 @@ object TypeScriptRugEditorTest {
       |
       |abstract class JavaInfo extends ParametersSupport {
       |
-      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: ".*", maxLength: 100})
+      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
       |  packageName: string = null
       |
       |}

--- a/src/test/scala/com/atomist/rug/runtime/lang/js/NashornConstructorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/lang/js/NashornConstructorTest.scala
@@ -165,7 +165,7 @@ object NashornConstructorTest {
       |        this.content = null;
       |    }
       |    __decorate([
-      |        Metadata_1.parameter({ description: "Content", displayName: "content", pattern: "Anders .*", maxLength: 100 })
+      |        Metadata_1.parameter({ description: "Content", displayName: "content", pattern: "^Anders .*$", maxLength: 100 })
       |    ], ContentInfo.prototype, "content", void 0);
       |    return ContentInfo;
       |}(Parameters_1.ParametersSupport));

--- a/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
@@ -411,10 +411,10 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """
         |editor UpdateReadme
         |
-        |param name: .*
+        |param name: ^.*$
         |
         |@default 'Boy Wizard'
-        |param description: .*
+        |param description: ^.*$
         |
         |with file f when { f.name().contains(".md") } begin
         |	do replace "{{name}}" name

--- a/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
@@ -411,10 +411,10 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """
         |editor UpdateReadme
         |
-        |param name: ^.*$
+        |param name: @all
         |
         |@default 'Boy Wizard'
-        |param description: ^.*$
+        |param description: @all
         |
         |with file f when { f.name().contains(".md") } begin
         |	do replace "{{name}}" name

--- a/src/test/scala/com/atomist/util/lang/TypeScriptArrayTest.scala
+++ b/src/test/scala/com/atomist/util/lang/TypeScriptArrayTest.scala
@@ -26,7 +26,7 @@ class TypeScriptArrayTest extends FlatSpec with Matchers {
       |import {editor} from 'user-model/support/Metadata'
       |
       |class JavaInfo extends ParametersSupport {
-      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: ".*", maxLength: 100})
+      |  @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
       |  packageName: string = null
       |}
       |


### PR DESCRIPTION
# **Beware!**

This will break editors at parse time that are not explicitly using ^ and $ to anchor their expressions. 

See #31 for more details.