### PR TITLE
Implement 'not' in predicates

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/dynamic/ViewFinder.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/ViewFinder.scala
@@ -81,6 +81,8 @@ trait ViewFinder {
       case or: OrExpression =>
         invokePredicate(rugAs, poa, identifierMap, or.a, targetAlias, v) ||
           invokePredicate(rugAs, poa, identifierMap, or.b, targetAlias, v)
+      case not: NotExpression =>
+        !invokePredicate(rugAs, poa, identifierMap, not.inner, targetAlias, v)
       case eq: EqualsExpression =>
         val l = v.evaluator.evaluate[MutableView[_], Object](eq.a, null, null, v, targetAlias, identifierMap, poa)
         val r = v.evaluator.evaluate[MutableView[_], Object](eq.b, null, null, v, targetAlias, identifierMap, poa)

--- a/src/main/scala/com/atomist/rug/parser/CommonRugProductionsParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/CommonRugProductionsParser.scala
@@ -130,7 +130,7 @@ abstract class CommonRugProductionsParser extends PathExpressionParser with Comm
   }
 
   protected def predicateTerm: Parser[Predicate] =
-    (literalBoolean | comparison | functionCall | javaScriptBlock) ^^ {
+    (nottedTerm | literalBoolean | comparison | functionCall | javaScriptBlock) ^^ {
       case fn: Predicate => fn
       case js: JavaScriptBlock => ParsedJavaScriptFunction(js)
       case true => TruePredicate
@@ -143,6 +143,11 @@ abstract class CommonRugProductionsParser extends PathExpressionParser with Comm
       case "OR" => OrExpression(left, right)
     }
   }
+
+  protected def nottedTerm: Parser[Predicate] =
+    NotToken ~> predicateTerm ^^ {
+      case pt => NotExpression(pt)
+    }
 
   protected def andedTerm: Parser[Term] = AndToken ~> predicateExpression ^^ (right => Term(right, "AND"))
 

--- a/src/main/scala/com/atomist/rug/parser/CommonRugTokens.scala
+++ b/src/main/scala/com/atomist/rug/parser/CommonRugTokens.scala
@@ -7,6 +7,8 @@ trait CommonRugTokens {
 
   val AndToken = "and"
 
+  val NotToken = "not"
+
   val OrToken = "or"
 
   val TrueToken = "true"

--- a/src/main/scala/com/atomist/rug/parser/RugParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/RugParser.scala
@@ -214,6 +214,13 @@ case class AndExpression(a: Predicate, b: Predicate) extends ComparisonPredicate
 
 case class OrExpression(a: Predicate, b: Predicate) extends ComparisonPredicate
 
+case class NotExpression(inner: Predicate) extends Predicate {
+  override def accept(v: Visitor, depth: Int): Unit = {
+    v.visit(this, depth)
+    inner.accept(v, depth + 1)
+  }
+}
+
 sealed trait DoStep extends Action
 
 /**

--- a/src/test/scala/com/atomist/rug/kind/elm/PredicateTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/PredicateTest.scala
@@ -1,0 +1,98 @@
+package com.atomist.rug.kind.elm
+
+import com.atomist.rug.DefaultRugPipeline
+import com.atomist.rug.kind.elm.ElmTypeUsageTest.TestDidNotModifyException
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, Matchers}
+
+class PositivePredicateTest extends FlatSpec with Matchers {
+
+  import ElmTypeUsageTest.elmExecute
+
+  val editor =
+    """editor Baby
+      |
+      |precondition Yes
+      |
+      |with elm.module e
+      |  do updateImport from "Carrot" to "Kiwifruit"
+      |
+      |predicate Yes
+      |
+      |with project p
+      |  when fileExists "Banana.elm"
+    """.stripMargin
+
+  val original =
+    """module Banana exposing (..)
+      |
+      |import Carrot
+      | """.stripMargin
+
+  val expected =
+    """module Banana exposing (..)
+      |
+      |import Kiwifruit
+      |""".stripMargin
+
+  it should "run the editor when the predicate passes" in {
+    val source = StringFileArtifact("Banana.elm", original)
+
+    val elmProject = new SimpleFileBasedArtifactSource("", Seq(source))
+
+    val result = elmExecute(elmProject, editor, Map[String, String](),
+      runtime = new DefaultRugPipeline())
+
+    val carrotContent = result.findFile(s"Banana.elm").get.content
+    // TODO: remove the trims! this finds the newline problem
+    carrotContent.trim should equal(expected.trim)
+  }
+
+
+}
+
+
+class NegativePredicateTest extends FlatSpec with Matchers {
+
+  import ElmTypeUsageTest.elmExecute
+
+
+  val editor =
+    """editor Baby
+      |
+      |precondition No
+      |
+      |with elm.module e
+      |  do updateImport from "Carrot" to "Kiwifruit"
+      |
+      |predicate No
+      |
+      |with project p
+      |  when not fileExists "Banana.elm"
+    """.stripMargin
+
+  val original =
+    """module Banana exposing (..)
+      |
+      |import Carrot
+      | """.stripMargin
+
+  val expected =
+    """module Banana exposing (..)
+      |
+      |import Kiwifruit
+      |""".stripMargin
+
+  it should "does not modify when the predicate fails" in {
+    val source = StringFileArtifact("Banana.elm", original)
+
+    val elmProject = new SimpleFileBasedArtifactSource("", Seq(source))
+
+    an [TestDidNotModifyException] should be thrownBy {
+      elmExecute(elmProject, editor, Map[String, String](),
+        runtime = new DefaultRugPipeline())
+    }
+  }
+
+
+}


### PR DESCRIPTION
with @gotcha

Rug predicates have 'and' and 'or.' They should totally have 'not' !

now we can say when not fileContains "src/Main.elm" "Html.beginnerProgram"
which lets us make UpgradeToBeginnerProgram idempotent.