### PR TITLE
Rename RugTestParser so I can find it

### DIFF
--- a/src/main/scala/com/atomist/rug/test/RugTestParser.scala
+++ b/src/main/scala/com/atomist/rug/test/RugTestParser.scala
@@ -6,10 +6,10 @@ import com.atomist.source.FileArtifact
 /**
   * Use Scala ParserCombinators to parse test scenario scripts
   */
-object ParserCombinatorTestScriptParser
-  extends CommonRugProductionsParser with TestScriptParser {
+object RugTestParser
+  extends CommonRugProductionsParser {
 
-  import TestScriptParser._
+  import RugTestTokens._
 
   override def identifierRef: Parser[IdentifierRef] =
     identifierRef(KeywordsToAvoidInBody, camelCaseIdentifier)
@@ -78,7 +78,7 @@ object ParserCombinatorTestScriptParser
 
   private def testPrograms: Parser[Seq[TestScenario]] = phrase(rep1(testProgram))
 
-  override def parse(f: FileArtifact): Seq[TestScenario] =
+  def parse(f: FileArtifact): Seq[TestScenario] =
     parseTo(f, testPrograms)
 
 }

--- a/src/main/scala/com/atomist/rug/test/RugTestTokens.scala
+++ b/src/main/scala/com/atomist/rug/test/RugTestTokens.scala
@@ -3,13 +3,8 @@ package com.atomist.rug.test
 import com.atomist.rug.parser.CommonRugTokens
 import com.atomist.source.FileArtifact
 
-trait TestScriptParser {
 
-  @throws[IllegalArgumentException]
-  def parse(f: FileArtifact): Seq[TestScenario]
-}
-
-object TestScriptParser extends CommonRugTokens {
+object RugTestTokens extends CommonRugTokens {
 
   val ScenarioToken = "scenario"
 

--- a/src/main/scala/com/atomist/rug/test/TestLoader.scala
+++ b/src/main/scala/com/atomist/rug/test/TestLoader.scala
@@ -17,7 +17,7 @@ class TestLoader(val atomistConfig: AtomistConfig = DefaultAtomistConfig) {
   def loadTestScenarios(archive: ArtifactSource): Seq[TestScenario] = {
     archive.allFiles
       .filter(atomistConfig.isRugTest)
-      .flatMap(f => ParserCombinatorTestScriptParser.parse(f))
+      .flatMap(f => RugTestParser.parse(f))
   }
 
 }

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerTypeTestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerTypeTestRunnerTest.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.kind.docker
 
 import com.atomist.rug.DefaultRugPipeline
-import com.atomist.rug.test.{ParserCombinatorTestScriptParser, RugTestRunnerTestSupport}
+import com.atomist.rug.test.{RugTestParser, RugTestRunnerTestSupport}
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -50,7 +50,7 @@ class DockerTypeTestRunnerTest extends FlatSpec with Matchers with RugTestRunner
         |
       """.stripMargin)
 
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", scenario))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, new SimpleFileBasedArtifactSource("", dockerfile), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {

--- a/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
@@ -26,7 +26,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |  # fileCount 1
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), Nil)
     executedTests.tests.size should be(1)
     executedTests.tests.head.passed should be(false)
@@ -192,7 +192,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
         |do rename "Cat"
       """.stripMargin
     val eds = new DefaultRugPipeline().createFromString(edProg, namespace)
-    val testProg = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.rt", prog))
+    val testProg = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(testProg, rugAs, eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -228,7 +228,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |  and dumpAll
          |  and fileContains "src/main/java/Cat.java" "class Cat"
       """.stripMargin
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -260,7 +260,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |  fileCount = 1
          |  and fileContains "src/main/java/Cat.java" "class Cat"
       """.stripMargin
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -292,7 +292,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |  NoChange
       """.stripMargin
 
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -324,7 +324,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |then
          |  ShouldFail
       """.stripMargin
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head.eventLog.input.shouldBe(defined)
@@ -358,7 +358,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |then
          |  MissingParameters
       """.stripMargin
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -391,7 +391,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |then
          |  InvalidParameters
       """.stripMargin
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", prog))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -444,7 +444,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
         |
         |## {{description}}
       """.stripMargin)
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", scenario))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, new SimpleFileBasedArtifactSource("", readme), eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -480,7 +480,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
     val readme = StringFileArtifact("test.txt", "Some pearls of wisdom")
     val editorBackingArchive = new SimpleFileBasedArtifactSource("", Seq(readme, StringFileArtifact("editors/AddDocumentation.rug", prog)))
     val eds = new DefaultRugPipeline().create(editorBackingArchive, None, Nil)
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", scenario))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, editorBackingArchive, eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -521,7 +521,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
     val readme = StringFileArtifact("test.txt", "Some pearls of wisdom")
     val editorBackingArchive = new SimpleFileBasedArtifactSource("", Seq(readme, StringFileArtifact("editors/DoSomething.rug", prog)))
     val eds = new DefaultRugPipeline().create(editorBackingArchive, None, Nil)
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", scenario))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, editorBackingArchive, eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {
@@ -566,7 +566,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
     val readme = StringFileArtifact("test.txt", "Some pearls of wisdom")
     val editorBackingArchive = new SimpleFileBasedArtifactSource("", Seq(readme, StringFileArtifact("editors/DoSomething.rug", prog)))
     val eds = new DefaultRugPipeline().create(editorBackingArchive, None, Nil)
-    val test = ParserCombinatorTestScriptParser.parse(StringFileArtifact("x.ts", scenario))
+    val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, editorBackingArchive, eds)
     executedTests.tests.size should be(1)
     executedTests.tests.head match {

--- a/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
@@ -5,9 +5,9 @@ import com.atomist.rug.parser.{ParsedRegisteredFunctionPredicate, WrappedFunctio
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
 
-class TestScriptParserTest extends FlatSpec with Matchers {
+class TestScriptParserRugTest extends FlatSpec with Matchers {
 
-  val parser: TestScriptParser = ParserCombinatorTestScriptParser
+  val parser = RugTestParser
 
   it should "parse computations" in {
     val f = InlineFileSpec("src/main/java/Dog.java", "class Dog {}")
@@ -27,7 +27,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.name should be(scenarioName)
@@ -77,7 +77,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "${filepath.replace("Dog", "Cat")}" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.name should be(scenarioName)
@@ -113,7 +113,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.name should be(scenarioName)
@@ -140,7 +140,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.name should be(scenarioName)
@@ -172,7 +172,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.given.fileSpecs should equal(Seq(EmptyArchiveFileSpec))
@@ -194,7 +194,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.given.fileSpecs should equal(Seq(ArchiveRootFileSpec))
@@ -216,7 +216,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.name should be(scenarioName)
@@ -244,7 +244,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  and contentEquals "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.given.fileSpecs should equal(Seq(f, f))
@@ -279,7 +279,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
          |  # and fileHasContent "src/main/java/Cat.java" "class Cat {}"
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.size should be(1)
     val test = tp.head
     test.given.fileSpecs should equal(Seq(f, f))
@@ -309,7 +309,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
         |  NoChange
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.head.outcome.assertions should equal(Seq(NoChangeAssertion))
   }
 
@@ -328,7 +328,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
         |  NotApplicable
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.head.outcome.assertions should equal(Seq(NotApplicableAssertion))
   }
 
@@ -347,7 +347,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
         |  ShouldFail
       """.stripMargin
 
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.head.outcome.assertions should equal(Seq(ShouldFailAssertion))
   }
 
@@ -383,7 +383,7 @@ class TestScriptParserTest extends FlatSpec with Matchers {
         |  and fileContains pomPath v
         |  and fileContains readmePath project_name
       """.stripMargin
-    val tp = parser.parse(StringFileArtifact("x.ts", prog))
+    val tp = parser.parse(StringFileArtifact("x.rt", prog))
     tp.head.outcome.assertions.size should be(6)
   }
 }


### PR DESCRIPTION
A few class renames, and a single-impl trait rolled in.

r? @johnsonr 