### PR TITLE
Unescape backslashes in parsed double-quoted string

### DIFF
--- a/src/main/scala/com/atomist/util/scalaparsing/CommonTypesParser.scala
+++ b/src/main/scala/com/atomist/util/scalaparsing/CommonTypesParser.scala
@@ -31,7 +31,7 @@ abstract class CommonTypesParser extends JavaTokenParsers with LazyLogging {
   val CBlockCommentAndHashLineCommentWhitespace = ("""(\s|""" + HashLineComment + "|" + CComment + ")+").r
 
   // NB: This does not correctly preserve positions
-  def doubleQuotedString: Parser[String] = stringLiteral ^^ (s => s.substring(1).dropRight(1))
+  def doubleQuotedString: Parser[String] = stringLiteral ^^ (s => s.substring(1).dropRight(1).replace("""\\""", """\"""))
 
   // Taken from Scala superclass
   def doubleQuotedStringContent: Parser[String] = """([^"\p{Cntrl}\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*+""".r

--- a/src/test/scala/com/atomist/rug/InterpreterRuntimeTest.scala
+++ b/src/test/scala/com/atomist/rug/InterpreterRuntimeTest.scala
@@ -285,6 +285,18 @@ class InterpreterRuntimeTest extends AbstractRuntimeTest {
     }
   }
 
+  it should "run editor with complicated regular expression" in {
+    val complexRegexEditor =
+      """editor ComplexRegexpReplace
+        |
+        |with project p
+        |  do regexpReplace "^\\s*class\\s+Dog\\s*\\{\\s*\\}" "ssalc Dog {}"
+      """.stripMargin
+    val originalFile = JavaAndText.findFile("src/main/java/Dog.java").get
+    val expected = originalFile.content.replace("class", "ssalc")
+    simpleAppenderProgramExpectingParameters(complexRegexEditor, Some(expected))
+  }
+
   // PUT in a deliberate type error and expect to see a good message
   it should "handle type error in predicate and give good error message" is pending
 

--- a/src/test/scala/com/atomist/rug/runtime/rugdsl/RugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/rugdsl/RugEditorTest.scala
@@ -18,6 +18,19 @@ object RugEditorTest {
       |   do addFile "src/from/typescript" "Anders Hjelsberg is God"
     """.stripMargin
 
+  val TwoStepEditor =
+    """editor TwoStepEditor
+      |
+      |let dsf = "DoubleSecretFile"
+      |
+      |with project p
+      |  begin
+      |    do addFile dsf "Probation"
+      |    with file f when { !p.fileExists("README") }
+      |      do p.addFile "README" "A Pledge Pin!"
+      |  end
+    """.stripMargin
+
 }
 
 class RugEditorTest extends FlatSpec with Matchers {
@@ -63,5 +76,29 @@ class RugEditorTest extends FlatSpec with Matchers {
         }
     }
     red
+  }
+
+  it should "run TwoStepEditor and return that something changed" in {
+    invokeAndVerifySomethingChanged(StringFileArtifact(".atomist/editors/TwoStepEditor.rug", TwoStepEditor))
+  }
+
+  private def invokeAndVerifySomethingChanged(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil) = {
+    val as = SimpleFileBasedArtifactSource(tsf)
+    val ops = new DefaultRugPipeline(DefaultTypeRegistry).create(as, None)
+    val red = ops.head.asInstanceOf[RugDrivenProjectEditor]
+    red.name should be ("TwoStepEditor")
+    red.setContext(others)
+
+    val target = SimpleFileBasedArtifactSource(StringFileArtifact("README", "I dub thee... Flounder"))
+
+    val p = SimpleProjectOperationArguments("", Map[String,Object]())
+    red.modify(target, p) match {
+      case sm: SuccessfulModification =>
+        sm.result.totalFileCount should be (2)
+        sm.result.findFile("DoubleSecretFile").get.content.contains("Probation") should be(true)
+        sm.result.findFile("README").get.content.contains("Flounder") should be(true)
+        sm.result.findFile("README").get.content.contains("Pledge") should be(false)
+      case _ => fail("two identical modifications reported no modifications")
+    }
   }
 }


### PR DESCRIPTION
Regular expressions provided in double-quoted strings were failing to
match because values like `"\\s*"` were being passed to the regex parser
as `\\s*` instead of `\s*`.  This commit makes Rug double-quoted strings
behave like Java double-quoted strings.

Other tests were added as part of trying to track down this issue.