### PR TITLE
Restore FileArtifactMutableView for rug-cli compatibility

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/core/ArtifactContainerMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/ArtifactContainerMutableView.scala
@@ -28,14 +28,14 @@ abstract class ArtifactContainerMutableView[T <: ArtifactContainer](
 
   protected def kids(fieldName: String, parent: ProjectMutableView): Seq[MutableView[_]] = fieldName match {
     case FileAlias =>
-      currentBackingObject.allFiles.view.map(f => new FileMutableView(f, parent))
+      currentBackingObject.allFiles.view.map(f => new FileArtifactMutableView(f, parent))
     case DirectoryAlias =>
       currentBackingObject.allDirectories.view.map(d => new DirectoryArtifactMutableView(d, parent))
     case maybeContainedArtifactName =>
       val arts = currentBackingObject.artifacts.filter(_.name.equals(maybeContainedArtifactName))
       arts.map {
         case d : DirectoryArtifact => new DirectoryArtifactMutableView(d, parent)
-        case f : FileArtifact => new FileMutableView(f, parent)
+        case f : FileArtifact => new FileArtifactMutableView(f, parent)
       }
   }
 
@@ -45,14 +45,14 @@ abstract class ArtifactContainerMutableView[T <: ArtifactContainer](
   @ExportFunction(readOnly = true, description = "Find file with the given path. Return null if not found.")
   def findFile(@ExportFunctionParameterDescription(name = "path",
     description = "Path of the file we want")
-                 path: String): FileMutableView = {
+                 path: String): FileArtifactMutableView = {
     val parent: ProjectMutableView = this match {
       case pmv: ProjectMutableView => pmv
       case dmv: DirectoryArtifactMutableView => dmv.parent
     }
     currentBackingObject.findFile(path) match {
       case None => null
-      case Some(f) => new FileMutableView(f, parent)
+      case Some(f) => new FileArtifactMutableView(f, parent)
     }
   }
 

--- a/src/main/scala/com/atomist/rug/kind/core/FileArtifactMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileArtifactMutableView.scala
@@ -8,11 +8,13 @@ import scala.collection.JavaConverters._
 /**
   * Mutable view for working directly with files.
   */
-class FileMutableView(
+class FileArtifactMutableView(
                                originalBackingObject: FileArtifact,
                                override val parent: ProjectMutableView)
   extends FileArtifactBackedMutableView(originalBackingObject, parent)
     with TerminalView[FileArtifact] {
+
+  override def nodeType: String = "File"
 
   @ExportFunction(readOnly = false, description = "If the file already contains the specified text, does nothing. Otherwise appends it to the file")
   def mustContain(@ExportFunctionParameterDescription(name = "content", description = "The content that the file will contain")

--- a/src/main/scala/com/atomist/rug/kind/core/FileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileType.scala
@@ -21,13 +21,13 @@ class FileType(
       |Type for a file within a project. Supports generic options such as find and replace.
     """.stripMargin
 
-  override def viewManifest: Manifest[FileMutableView] = manifest[FileMutableView]
+  override def viewManifest: Manifest[FileArtifactMutableView] = manifest[FileArtifactMutableView]
 
   override protected def findAllIn(rugAs: ArtifactSource, selected: Selected, context: MutableView[_],
                                    poa: ProjectOperationArguments, identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     (selected.kind, context) match {
       case (`name`, pmv: ProjectMutableView) =>
-        Some(pmv.currentBackingObject.allFiles.map(f => new FileMutableView(f, pmv)))
+        Some(pmv.currentBackingObject.allFiles.map(f => new FileArtifactMutableView(f, pmv)))
       case _ => None
     }
   }
@@ -38,7 +38,7 @@ class FileType(
 
   override def findAllIn(context: MutableView[_]): Option[Seq[MutableView[_]]] = context match {
     case pmv: ProjectMutableView =>
-      Some(pmv.currentBackingObject.allFiles.map(f => new FileMutableView(f, pmv)))
+      Some(pmv.currentBackingObject.allFiles.map(f => new FileArtifactMutableView(f, pmv)))
     case x => None
   }
 }

--- a/src/main/scala/com/atomist/rug/kind/core/LineType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/LineType.scala
@@ -31,7 +31,7 @@ class LineType(
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {
-      case fa: FileMutableView =>
+      case fa: FileArtifactMutableView =>
         Some(fa.originalBackingObject.content.lines
           .zipWithIndex
           .map(tup => new LineMutableView(tup._1, tup._2, fa))
@@ -46,7 +46,7 @@ class LineType(
 class LineMutableView(
                        originalBackingObject: String,
                        linenum: Int,
-                       override val parent: FileMutableView)
+                       override val parent: FileArtifactMutableView)
   extends ViewSupport[String](originalBackingObject, parent)
     with TerminalView[String] {
 
@@ -73,7 +73,7 @@ class LineMutableView(
     applied(parent)
   }
 
-  private def applied(f: FileMutableView) = {
+  private def applied(f: FileArtifactMutableView) = {
     var i = 0
     val newLines =
       for {

--- a/src/main/scala/com/atomist/rug/kind/core/ProjectMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/ProjectMutableView.scala
@@ -379,7 +379,7 @@ class ProjectMutableView(
     description = "Files in this archive")
   def files: java.util.List[FileArtifactBackedMutableView] = {
     import scala.collection.JavaConverters._
-    val files = currentBackingObject.allFiles.map(f => new FileMutableView(f, this)).asJava
+    val files = currentBackingObject.allFiles.map(f => new FileArtifactMutableView(f, this)).asJava
     files.asInstanceOf[java.util.List[FileArtifactBackedMutableView]]
   }
 

--- a/src/main/scala/com/atomist/rug/kind/js/PackageJsonMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/js/PackageJsonMutableView.scala
@@ -1,6 +1,6 @@
 package com.atomist.rug.kind.js
 
-import com.atomist.rug.kind.core.{FileMutableView, ProjectMutableView}
+import com.atomist.rug.kind.core.{FileArtifactMutableView, ProjectMutableView}
 import com.atomist.rug.runtime.lang.js.NashornExpressionEngine
 import com.atomist.rug.runtime.rugdsl.FunctionInvocationContext
 import com.atomist.rug.spi.{ExportFunction, ExportFunctionParameterDescription}
@@ -15,7 +15,7 @@ import com.atomist.source.FileArtifact
 class PackageJsonMutableView(
                               originalBackingObject: FileArtifact,
                               parent: ProjectMutableView)
-  extends FileMutableView(originalBackingObject, parent) {
+  extends FileArtifactMutableView(originalBackingObject, parent) {
 
   // TODO we could probably make this more efficient by not using JavaScript
 

--- a/src/main/scala/com/atomist/rug/kind/properties/PropertiesType.scala
+++ b/src/main/scala/com/atomist/rug/kind/properties/PropertiesType.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.kind.properties
 
 import com.atomist.project.ProjectOperationArguments
-import com.atomist.rug.kind.core.{FileMutableView, ProjectMutableView}
+import com.atomist.rug.kind.core.{FileArtifactMutableView, ProjectMutableView}
 import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
@@ -24,7 +24,7 @@ class PropertiesType(
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {
-      case fmv: FileMutableView =>
+      case fmv: FileArtifactMutableView =>
         Some(Seq(fmv.originalBackingObject)
           .filter(f => f.name.endsWith(".properties"))
           .map(f => new PropertiesMutableView(f, fmv.parent)))

--- a/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
@@ -31,14 +31,13 @@ class TypeScriptGenerationHelper(indent: String = "    ")
       case "java.util.List<com.atomist.rug.kind.core.ProjectMutableView>" => "Project[]"
       case "class com.atomist.rug.kind.core.ProjectMutableView" => "Project"
       case "java.util.List<java.lang.Object>" => "any[]"
-      case "class com.atomist.rug.kind.core.FileMutableView" => "File"
+      case "class com.atomist.rug.kind.core.FileArtifactMutableView" => "File"
       case "class com.atomist.rug.kind.core.ProjectContext" => "ProjectContext"
       case "scala.collection.immutable.List<java.lang.Object>" => "any[]"
       case "java.util.List<com.atomist.rug.kind.core.FileArtifactBackedMutableView>" => "File[]"
       case "java.util.List<com.atomist.rug.kind.java.support.PackageInfo>" => "any[]"//TODO
       case "java.util.List<com.atomist.rug.kind.service.ServiceMutableView>" => "any[]"
       case "List" => "any[]" // TODO improve this
-      case "FileArtifactMutableView" => "File"   // TODO this is nasty
       case x => throw new UnsupportedOperationException(s"Unsupported type [$jt]")
     }
   }

--- a/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
+++ b/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
@@ -2,7 +2,7 @@ package com.atomist.rug
 
 import com.atomist.project.SimpleProjectOperationArguments
 import com.atomist.project.edit.{ProjectEditor, SuccessfulModification}
-import com.atomist.rug.kind.core.FileMutableView
+import com.atomist.rug.kind.core.FileArtifactMutableView
 import com.atomist.source.file.SimpleFileSystemArtifactSourceIdentifier
 import com.atomist.source.{ArtifactSource, EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
@@ -288,7 +288,7 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
 
     val fr = FixedRugFunctionRegistry(
       Map(
-        "isJava" -> new LambdaPredicate[FileMutableView]("isJava", f => f.currentBackingObject.name.endsWith(".java"))
+        "isJava" -> new LambdaPredicate[FileArtifactMutableView]("isJava", f => f.currentBackingObject.name.endsWith(".java"))
       )
     )
     val eds = pipeline.createFromString(program)

--- a/src/test/scala/com/atomist/rug/RugCompilerTest.scala
+++ b/src/test/scala/com/atomist/rug/RugCompilerTest.scala
@@ -5,7 +5,7 @@ import com.atomist.util.scalaparsing.SimpleLiteral
 import com.atomist.project.SimpleProjectOperationArguments
 import com.atomist.project.edit.{ProjectEditor, SuccessfulModification}
 import com.atomist.rug.kind.DefaultTypeRegistry
-import com.atomist.rug.kind.core.FileMutableView
+import com.atomist.rug.kind.core.FileArtifactMutableView
 import com.atomist.rug.parser._
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, LambdaPredicate, RugDrivenProjectEditor}
 import com.atomist.source._
@@ -91,7 +91,7 @@ class RugCompilerTest extends FlatSpec with Matchers {
   it should "insist on identifiers being declared" in {
     val fr = FixedRugFunctionRegistry(
       Map(
-        "absquatulate" -> new LambdaPredicate[FileMutableView]("absquatulate", f => true)
+        "absquatulate" -> new LambdaPredicate[FileArtifactMutableView]("absquatulate", f => true)
       )
     )
     //val interpreter = new DefaultRugCompiler(compiler, DefaultTypeRegistry)

--- a/src/test/scala/com/atomist/rug/kind/core/FileArtifactMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/core/FileArtifactMutableViewTest.scala
@@ -7,7 +7,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "handle nameContains" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.nameContains(".*") should be (false)
     fmv.nameContains("am") should be (true)
     fmv.nameContains("....") should be (false)
@@ -16,7 +16,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "return linecount in single line file" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.lineCount should be (1)
   }
 
@@ -31,13 +31,13 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
         |and
         |on
       """.stripMargin)
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.lineCount should be (9)
   }
 
   it should "handle contains" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.contains(".*") should be (false)
     fmv.contains("brown") should be (true)
     fmv.contains("....") should be (false)
@@ -46,7 +46,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "handle containsMatch" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.containsMatch(".*") should be (true)
     fmv.containsMatch("[1-9]") should be (false)
     fmv.containsMatch("....") should be (true)
@@ -54,7 +54,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "setPath" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.path should equal (f.path)
     fmv.dirty should be (false)
     val path2 = "foobar/name"
@@ -67,7 +67,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "setName in root" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.name should equal("name")
     fmv.dirty should be (false)
     val name2 = "foobar"
@@ -80,7 +80,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "setName under path" in {
     val f = StringFileArtifact("foo/name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.name should equal("name")
     fmv.dirty should be (false)
     val name2 = "foobar"
@@ -98,7 +98,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "setContent" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.content should equal (f.content)
     fmv.dirty should be (false)
     val content2 = "To be or not to be"
@@ -110,7 +110,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "handle prepend" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.content should equal (f.content)
     fmv.dirty should be (false)
     val prepended = "To be or not to be"
@@ -122,7 +122,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "handle append" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.content should equal (f.content)
     fmv.dirty should be (false)
     val appended = "To be or not to be"
@@ -134,14 +134,14 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "return name" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.filename should equal (f.name)
   }
 
   it should "not add a string if the text already contains it" in {
     val initialContent: String = "The quick brown jumped"
     val f = StringFileArtifact("name",  initialContent)
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
 
     val newString: String = " over the lazy dog"
     fmv.mustContain(newString)
@@ -151,7 +151,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
   it should "add a string if it isn't already present" in {
     val initialContent: String = "The quick brown jumped over the lazy dog"
     val f = StringFileArtifact("name",  initialContent)
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
 
     fmv.mustContain("over the lazy dog")
     fmv.content should equal(initialContent)
@@ -160,7 +160,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
   it should "not add a required string twice" in {
     val initialContent: String = "The quick brown jumped over the lazy dog"
     val f = StringFileArtifact("name",  initialContent)
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
 
     fmv.mustContain("over the lazy dog")
     fmv.mustContain("over the lazy dog")
@@ -169,7 +169,7 @@ class FileArtifactMutableViewTest extends FlatSpec with Matchers {
 
   it should "make file executable" in {
     val f = StringFileArtifact("name.sh", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     fmv.name should equal("name.sh")
     fmv.dirty should be (false)
     fmv.makeExecutable()

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/SafeCommittingProxyTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/SafeCommittingProxyTest.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.runtime.js.interop
 
 import com.atomist.rug.RugRuntimeException
-import com.atomist.rug.kind.core.{FileMutableView, FileType}
+import com.atomist.rug.kind.core.{FileArtifactMutableView, FileType}
 import com.atomist.rug.spi.{Command, CommandRegistry}
 import com.atomist.source.StringFileArtifact
 import com.atomist.tree.TreeNode
@@ -13,7 +13,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
   it should "not allow invocation of non export function" in {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
 
     val sc = new SafeCommittingProxy(typed, fmv)
     intercept[RugRuntimeException] {
@@ -24,7 +24,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
   it should "not allow invocation of export function" in {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     val sc = new SafeCommittingProxy(typed, fmv)
      sc.getMember("setContent")
   }
@@ -32,7 +32,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
   it should "not allow invocation of registred command function" in {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     val fc = new FakeCommand
     val sc = new SafeCommittingProxy(typed, fmv, new FakeCommandRegistry(fc))
     val ajs: AbstractJSObject = sc.getMember("execute").asInstanceOf[AbstractJSObject]
@@ -43,7 +43,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
   it should "fail for unregistered command function" in {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
-    val fmv = new FileMutableView(f, null)
+    val fmv = new FileArtifactMutableView(f, null)
     val sc = new SafeCommittingProxy(typed, fmv, new FakeCommandRegistry)
     intercept[RugRuntimeException] {
       sc.getMember("delete")
@@ -62,14 +62,14 @@ class FakeCommandRegistry(fakeCommand: FakeCommand = new FakeCommand) extends Co
   }
 }
 
-class FakeCommand extends Command[FileMutableView] {
+class FakeCommand extends Command[FileArtifactMutableView] {
   override def `type`: String = "file"
 
   override def name: String = "execute"
 
-  var fmv: FileMutableView = _
+  var fmv: FileArtifactMutableView = _
 
-  override def invokeOn(treeNode: FileMutableView): Unit = {
+  override def invokeOn(treeNode: FileArtifactMutableView): Unit = {
     fmv = treeNode
   }
 }


### PR DESCRIPTION
The cli depends on this class, so renaming it breaks the cli. Change it back for now, so we can find an upgrade path later.