### PR TITLE
Look for children both by name and type

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/dynamic/DefaultViewFinder.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/DefaultViewFinder.scala
@@ -60,7 +60,11 @@ class DefaultViewFinder(typeRegistry: TypeRegistry)
     })
 
     val childOfCurrentContext: Option[Seq[MutableView[_]]] =
-      if (context.childNodeNames.contains(selected.kind))
+      if (context.childNodeTypes.contains(selected.kind))
+        Some(context.childrenNamed(selected.kind).collect {
+          case mv: MutableView[_] => mv
+        })
+      else if (context.childNodeNames.contains(selected.kind))
         Some(context.childrenNamed(selected.kind).collect {
           case mv: MutableView[_] => mv
         })


### PR DESCRIPTION
Children were being found only if the name matched, and stuff like

```
with Project p
   with File f
```
was resolving based on File as a globally available type rather than as a child of the project as intended.
(I saw this in the debugger.)

It seems we don't have a test for a child type that doesn't resolve locally. Adding one in another branch.