### PR TITLE
Added Break support to microgrammar support

### DIFF
--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -65,4 +65,7 @@ class MatcherMicrogrammar(val matcher: Matcher) extends Microgrammar {
     }
     nodes
   }
+
+  override def toString: String = s"MatcherMicrogrammar wrapping [$matcher]"
+
 }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParser.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParser.scala
@@ -30,7 +30,7 @@ class MatcherDefinitionParser extends CommonTypesParser {
     * @return
     */
   private def break(implicit matcherName: String, registry: MatcherRegistry): Parser[Break] =
-    "¡" ~> matcherExpression() <~ "¡" ^^ (m => Break(m))
+    "¡" ~> matcherExpression <~ "¡" ^^ (m => Break(m))
 
   private def predicateValue: Parser[String] = "true" | "false" | "\\d+".r
 
@@ -86,12 +86,10 @@ class MatcherDefinitionParser extends CommonTypesParser {
       case newName ~ _ ~ regex => regex.copy(name = newName)
     }
 
-  private def matcherExpression()(implicit matcherName: String, registry: MatcherRegistry): Parser[Matcher] =
+  private def matcherExpression(implicit matcherName: String, registry: MatcherRegistry): Parser[Matcher] =
     descendantClause |
       concatenation |
       matcherTerm
-
-  private def matcher(implicit matcherName: String, registry: MatcherRegistry): Parser[Matcher] = matcherExpression
 
   /**
     * Parse the given microgrammar definition given a registry of known matchers.
@@ -109,7 +107,7 @@ class MatcherDefinitionParser extends CommonTypesParser {
     case _ =>
       implicit val matcherName: String = name
       implicit val registry: MatcherRegistry = mRegistry
-      val m = parseTo(StringFileArtifact("<input>", matcherDef), phrase(matcher))
+      val m = parseTo(StringFileArtifact("<input>", matcherDef), phrase(matcherExpression))
       m
   }
 

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParser.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParser.scala
@@ -27,6 +27,7 @@ class MatcherDefinitionParser extends CommonTypesParser {
 
   /**
     * Skip till this clause
+    *
     * @return
     */
   private def break(implicit matcherName: String, registry: MatcherRegistry): Parser[Break] =
@@ -37,7 +38,7 @@ class MatcherDefinitionParser extends CommonTypesParser {
   // Applies to a boxed clause
   // [curlyDepth=1]
   private def predicate(implicit matcherName: String, registry: MatcherRegistry): Parser[StatePredicateTest] =
-    "[" ~> ident ~ "=" ~ predicateValue <~ "]" ^^ {
+  "[" ~> ident ~ "=" ~ predicateValue <~ "]" ^^ {
     case predicateName ~ "=" ~ predicateVal => StatePredicateTest(predicateName, predicateVal)
   }
 
@@ -52,6 +53,7 @@ class MatcherDefinitionParser extends CommonTypesParser {
 
   private def matcherTerm(implicit matcherName: String, registry: MatcherRegistry): Parser[Matcher] =
     rex |
+      break |
       literal |
       variableReference() |
       inlineReference()

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/matchers/Break.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/matchers/Break.scala
@@ -4,7 +4,7 @@ import com.atomist.tree.content.text.microgrammar.{Matcher, PatternMatch}
 import com.atomist.tree.content.text.{MutableTerminalTreeNode, OffsetInputPosition}
 
 /**
-  * Similar to a SNOBOL "break". If we don't eventually find the literal,
+  * Similar to a SNOBOL "break". If we don't eventually find the terminating pattern in breakToMatcher,
   * we don't match. Matches the content up to and including the final matcher.
   *
   * @param breakToMatcher matcher that might match

--- a/src/main/scala/com/atomist/tree/pathexpression/PathExpressionParser.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/PathExpressionParser.scala
@@ -80,9 +80,13 @@ trait PathExpressionParser extends CommonTypesParser {
 
   private def falsePredicate: Parser[Predicate] = "false" ^^ (_ => FalsePredicate)
 
-  private def predicateTerm: Parser[Predicate] = methodInvocationTest | propertyTest | booleanMethodInvocation |
-    truePredicate | falsePredicate |
-    index
+  private def predicateTerm: Parser[Predicate] =
+    methodInvocationTest |
+      propertyTest |
+      booleanMethodInvocation |
+      truePredicate |
+      falsePredicate |
+      index
 
   private def negatedPredicate: Parser[Predicate] = "not" ~> "(" ~> predicateExpression <~ ")" ^^ {
     pred => NegationOf(pred)

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -8,6 +8,8 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
 
   val mgp = new MatcherDefinitionParser
 
+  import MatcherDefinitionParser._
+
   it should "reject null string" in {
     val bogusInputs = Seq(null, "", "$", "[", "▶")
     for (bad <- bogusInputs)
@@ -24,7 +26,10 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
   }
 
   it should "accept valid regex" in {
-    val validLiterals = Seq("§a§", "§[.*]§", "§[.]§")
+    val validLiterals = Seq(
+      s"${RegexpOpenToken}a$RegexpCloseToken",
+      s"$RegexpOpenToken[.*]$RegexpCloseToken",
+      s"$RegexpOpenToken[.]$RegexpCloseToken")
     for (v <- validLiterals) mgp.parseMatcher("y", v) match {
       case Regex("y", rex, _) =>
     }
@@ -41,7 +46,10 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
 //  }
 
   it should "accept valid inline regex" in {
-    val validLiterals = Seq("$foo:§a§", "$foo:§.*§", "$foo:§.§")
+    val validLiterals = Seq(
+      s"${VariableDeclarationToken}foo:${RegexpOpenToken}a$RegexpCloseToken",
+      s"${VariableDeclarationToken}foo:${RegexpOpenToken}.*$RegexpCloseToken",
+      s"${VariableDeclarationToken}foo:${RegexpOpenToken}.$RegexpCloseToken")
     for (v <- validLiterals) mgp.parseMatcher("x", v) match {
       case Regex("foo", rex, _) =>
         withClue(s"String [$v] should contain regex [$rex]") {
@@ -115,14 +123,14 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
   }
 
   it should "accept valid break alone" in {
-    val f = """¡<span data-original="¡"""
+    val f = s"""$BreakOpenToken<span data-original="$BreakCloseToken"""
     mgp.parseMatcher("f", f) match {
       case x =>
     }
   }
 
   it should "accept valid break in string" in {
-    val f = """<tr class="emoji_row">¡<span data-original="¡and now for something completely different"""
+    val f = s"""<tr class="emoji_row">$BreakOpenToken<span data-original="${BreakCloseToken}and now for something completely different"""
     mgp.parseMatcher("f", f) match {
       case x =>
     }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -122,7 +122,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
   }
 
   it should "accept valid break in string" in {
-    val f = """<tr class="emoji_row">¡<span data-original="¡$emojiUrl"""
+    val f = """<tr class="emoji_row">¡<span data-original="¡and now for something completely different"""
     mgp.parseMatcher("f", f) match {
       case x =>
     }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -114,7 +114,14 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "accept valid break" in {
+  it should "accept valid break alone" in {
+    val f = """¡<span data-original="¡"""
+    mgp.parseMatcher("f", f) match {
+      case x =>
+    }
+  }
+
+  it should "accept valid break in string" in {
     val f = """<tr class="emoji_row">¡<span data-original="¡$emojiUrl"""
     mgp.parseMatcher("f", f) match {
       case x =>

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -132,7 +132,9 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
   it should "accept valid break in string" in {
     val f = s"""<tr class="emoji_row">$BreakOpenToken<span data-original="${BreakCloseToken}and now for something completely different"""
     mgp.parseMatcher("f", f) match {
-      case x =>
+      case x : Matcher =>
+        val matchThisYouMicrogrammar = x.matchPrefix(0, """<tr class="emoji_row">THIS OTHER STUFF<span data-original="and now for something completely different blah blah more things here""")
+        matchThisYouMicrogrammar.isDefined should be(true)
     }
   }
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -114,4 +114,10 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "accept valid break" in {
+    val f = """<tr class="emoji_row">¡<span data-original="¡$emojiUrl"""
+    mgp.parseMatcher("f", f) match {
+      case x =>
+    }
+  }
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -67,20 +67,21 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("emoji",
-        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§"""
+        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[^\"]+§" class="$name:§[a-zA-Z0-9_\-]*§"""
         //"""<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§" class="$name:§[a-zA-Z0-9_\-]*§"""
       ))
-    println(mg)
+    //println(mg)
 
     val matches = mg.findMatches(html)
     matches.size should be(1)
 
-    for (elem <- matches;
-         field <- elem.fieldValues
-    ) {
-      println(field.nodeName + " = " + field.value)
-    }
-
+//    for (elem <- matches;
+//         field <- elem.fieldValues
+//    ) {
+//      println(field.nodeName + " = " + field.value)
+//    }
+    matches.head.fieldValues.head.value should be ("https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
+    matches.head.fieldValues(1).value should be ("lazyemoji-wrapper")
   }
 
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -47,7 +47,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
     matches.size should be(1)
   }
 
-  it should "parse Slack emoji html" in pendingUntilFixed {
+  it should "parse Slack emoji html" in {
     val html =
       """<tr class="emoji_row">
         |													<td class="align_middle"><span data-original="https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg" class="lazy emoji-wrapper"></span></td>
@@ -67,7 +67,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("emoji",
-        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.-_]+§" class="$name:§[a-z\S0-9_-]*§"""))
+        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§" class="$name:§[a-zA-Z\S0-9_\-]*§"""))
     println(mg)
 
     val matches = mg.findMatches(html)

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -50,7 +50,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
   it should "parse Slack emoji html" in {
     val html =
       """<tr class="emoji_row">
-        |													<td class="align_middle"><span data-original="https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg" class="lazy emoji-wrapper"></span></td>
+        |													<td class="align_middle"><span data-original="https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg" class="lazyemoji-wrapper"></span></td>
         |												<td class="align_middle" style="white-space: normal; word-break: break-all; word-wrap: break-word; height: 100%; vertical-align:middle;">:666:
         |												</td>
         |													<td class="align_middle">Image</td>
@@ -67,7 +67,9 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("emoji",
-        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§" class="$name:§[a-zA-Z\S0-9_\-]*§"""))
+        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§"""
+        //"""<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§" class="$name:§[a-zA-Z0-9_\-]*§"""
+      ))
     println(mg)
 
     val matches = mg.findMatches(html)

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -19,15 +19,12 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
   // if there's nothing dynamic in the content? No nodes are created
   it should "match literal using microgrammar" in pendingUntilFixed {
     val matcher = mgp.parseMatcher("lit", "def foo")
-    //println(matcher)
-    // Problem is that this is discarded as nothing is bound
     val mg = new MatcherMicrogrammar(matcher)
     mg.findMatches("def foo bar").size should be(1)
   }
 
   it should "match regex using microgrammar" in {
     val matcher = mgp.parseMatcher("l", "def $foo:§f.o§")
-    //println(matcher)
     val mg = new MatcherMicrogrammar(matcher)
     val input = "def foo bar"
     matcher.matchPrefix(0, input) match {
@@ -40,10 +37,8 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
     val proj = ParsingTargets.NewStartSpringIoProject
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("m", "<modelVersion>$modelVersion:§[a-zA-Z0-9_\\.]+§</modelVersion>"))
-    println(mg.matcher)
     val pom = proj.findFile("pom.xml").get.content
     val matches = mg.findMatches(pom)
-    println(matches)
     matches.size should be(1)
   }
 
@@ -68,18 +63,11 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("emoji",
         """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[^\"]+§" class="$name:§[\sa-zA-Z0-9_\-]*§"""
-        //"""<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§" class="$name:§[a-zA-Z0-9_\-]*§"""
       ))
-    //println(mg)
 
     val matches = mg.findMatches(html)
     matches.size should be(1)
 
-//    for (elem <- matches;
-//         field <- elem.fieldValues
-//    ) {
-//      println(field.nodeName + " = " + field.value)
-//    }
     matches.head.fieldValues.head.value should be ("https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
     matches.head.fieldValues(1).value should be ("lazy emoji-wrapper")
   }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -50,7 +50,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
   it should "parse Slack emoji html" in {
     val html =
       """<tr class="emoji_row">
-        |													<td class="align_middle"><span data-original="https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg" class="lazyemoji-wrapper"></span></td>
+        |													<td class="align_middle"><span data-original="https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg" class="lazy emoji-wrapper"></span></td>
         |												<td class="align_middle" style="white-space: normal; word-break: break-all; word-wrap: break-word; height: 100%; vertical-align:middle;">:666:
         |												</td>
         |													<td class="align_middle">Image</td>
@@ -67,7 +67,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("emoji",
-        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[^\"]+§" class="$name:§[a-zA-Z0-9_\-]*§"""
+        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[^\"]+§" class="$name:§[\sa-zA-Z0-9_\-]*§"""
         //"""<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.\-_0-9]+§" class="$name:§[a-zA-Z0-9_\-]*§"""
       ))
     //println(mg)
@@ -81,7 +81,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 //      println(field.nodeName + " = " + field.value)
 //    }
     matches.head.fieldValues.head.value should be ("https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
-    matches.head.fieldValues(1).value should be ("lazyemoji-wrapper")
+    matches.head.fieldValues(1).value should be ("lazy emoji-wrapper")
   }
 
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -67,7 +67,8 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 
     val mg = new MatcherMicrogrammar(
       mgp.parseMatcher("emoji",
-        """<tr class="emoji_row">.*<span data-original="$emojiUrl:§https://.*§".*:$name:§[a-z0-9_-]*§:.*</tr"""))
+        """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[a-zA_Z\.-_]+§" class="$name:§[a-z\S0-9_-]*§"""))
+    println(mg)
 
     val matches = mg.findMatches(html)
     matches.size should be(1)


### PR DESCRIPTION
A break in a microgrammar says "find this terminator; capture it and everything before." It lets you capture the inside of a block, say, or of an XML element.
You could say "If you find a { then grab everything up to and including the }" or "find a `<tr>` and then skip to after the `</tr>`"

(description written by Jess)

