### PR TITLE
In case someone tries to use invocations in the given

### DIFF
--- a/src/main/scala/com/atomist/rug/test/TestRunner.scala
+++ b/src/main/scala/com/atomist/rug/test/TestRunner.scala
@@ -91,6 +91,10 @@ class TestRunner(executionLog: ExecutionLog = ConsoleExecutionLog) {
       val poa: ProjectOperationArguments = test.args(testResources)
       eventLog.recordParameters(poa)
 
+      if (test.givenInvocations.nonEmpty) {
+        ??? // not implemented
+      }
+
       val applicability = ed.applicability(testResources)
 
       test.outcome.assertions.toList match {


### PR DESCRIPTION
Notify them that we haven't implemented it yet.
It will parse; that part is done, but they won't run. Failing is better than ignoring for now.