### PR TITLE
Made Predicate hierarchy explicit in PathExpressionParser

### DIFF
--- a/src/main/scala/com/atomist/tree/pathexpression/LocationStep.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/LocationStep.scala
@@ -23,7 +23,7 @@ case class LocationStep(axis: AxisSpecifier,
       case Right(nodes) => Right(
         nodes
           .map(nodePreparer)
-          .filter(tn => predicateToEvaluate(tn, nodes))
+          .filter(tn => predicateToEvaluate.evaluate(tn, nodes))
       )
       case failure => failure
     }

--- a/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
@@ -30,7 +30,7 @@ abstract class PredicatedNodeTest(name: String, predicate: Predicate) extends No
   final override def follow(tn: TreeNode, axis: AxisSpecifier, typeRegistry: TypeRegistry): ExecutionResult =
     sourceNodes(tn, axis, typeRegistry) match {
     case Right(nodes) =>
-      ExecutionResult(nodes.filter(tn => predicate(tn, nodes)))
+      ExecutionResult(nodes.filter(tn => predicate.evaluate(tn, nodes)))
     case failure => failure
   }
 

--- a/src/main/scala/com/atomist/tree/pathexpression/PathExpressionParser.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/PathExpressionParser.scala
@@ -3,9 +3,8 @@ package com.atomist.tree.pathexpression
 import java.util.Objects
 
 import com.atomist.source.StringFileArtifact
-import com.atomist.tree.pathexpression.PathExpressionParsingConstants._
 import com.atomist.tree.content.text.TreeNodeOperations._
-import com.atomist.tree.{ContainerTreeNode, TreeNode}
+import com.atomist.tree.pathexpression.PathExpressionParsingConstants._
 import com.atomist.util.scalaparsing.CommonTypesParser
 
 /**
@@ -28,7 +27,7 @@ trait PathExpressionParser extends CommonTypesParser {
   private def nodeTypeTest: Parser[ObjectType] = objectType <~ "()" ^^ (p => ObjectType(p))
 
   private def propertyTest: Parser[Predicate] =
-    "@" ~> nodeName ~ EqualsToken ~ singleQuotedString ^^ {
+    "@" ~> nodeName ~ EqualsToken ~ (singleQuotedString | doubleQuotedString) ^^ {
       case prop ~ op ~ literal => prop match {
         case "name" =>
           NodeNameTest(literal)

--- a/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
@@ -1,74 +1,138 @@
 package com.atomist.tree.pathexpression
 
-import com.atomist.tree.TreeNode
-
-object Selector {
-
-  /**
-    * Function taking nodes returned by navigation
-    * to filter them. First argument is the node we're testing on;
-    * second argument is all nodes returned. The second argument is
-    * often ignored, but can be used to discern the index of the target node.
-    */
-  type Selector = (TreeNode, Seq[TreeNode]) => Boolean
-}
-
-import com.atomist.tree.TreeNode
-import com.atomist.tree.pathexpression.Selector.Selector
+import com.atomist.tree.{ContainerTreeNode, TreeNode}
 
 /**
   * Based on the XPath concept of a predicate. A predicate acts on a sequence of nodes
   * returned from navigation to filter them.
+  * Predicates can be evaluated against materialized objects, and most predicates expose enough information
+  * to generate queries against external systems to retrieve data.
   */
-trait Predicate extends Selector {
+trait Predicate {
 
   def name: String
 
+  /**
+    * Function taking nodes returned by navigation
+    * to filter them. We test one node with knowledge of all returned nodes.
+    *
+    * @param nodeToTest    node we're testing on;
+    * @param returnedNodes all nodes returned. This argument is
+    *                      often ignored, but can be used to discern the index of the target node.
+    */
+  def evaluate(nodeToTest: TreeNode, returnedNodes: Seq[TreeNode]): Boolean
+
   def and(that: Predicate): Predicate =
-    SimplePredicate(s"${this.name} and ${that.name}", (n, among) => this (n, among) && that(n, among))
+    AndPredicate(this, that)
 
   def or(that: Predicate): Predicate =
-    SimplePredicate(s"${this.name} or ${that.name}", (n, among) => this (n, among) || that(n, among))
+    OrPredicate(this, that)
 
-  def not(predicate: Predicate): Predicate = ???
-
-}
-
-/**
-  * Convenient concrete predicate implementation
-  */
-case class SimplePredicate(name: String, f: Selector) extends Predicate {
-
-  override def apply(n: TreeNode, among: Seq[TreeNode]): Boolean = f(n, among)
+  def not: Predicate =
+    NegationOfPredicate(this)
 
 }
 
 
-/**
-  * Convenient support class for implementing predicates,
-  * considering Scala's prohibition on case-case inheritance.
-  */
-abstract class AbstractPredicate(val name: String, f: Selector) extends Predicate {
+case object TruePredicate extends Predicate {
 
-  def apply(tn: TreeNode, among: Seq[TreeNode]): Boolean = f(tn, among)
+  override def name: String = "true"
+
+  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean = true
 }
 
-case object TruePredicate extends AbstractPredicate("true", (_, _) => true)
 
-case object FalsePredicate extends AbstractPredicate("false", (_, _) => false)
+case object FalsePredicate extends Predicate {
 
-case class NegationOf(p: Predicate)
-  extends AbstractPredicate(s"!${p.name}", (tn,among) => !p(tn, among))
+  override def name: String = "false"
+
+  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean = false
+}
+
+
+case class NegationOfPredicate(p: Predicate) extends Predicate {
+
+  override def name: String = "!" + p.name
+
+  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean = !p.evaluate(root, returnedNodes)
+}
+
+case class AndPredicate(a: Predicate, b: Predicate) extends Predicate {
+
+  override def name: String = a.name + " and " + b.name
+
+  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+    a.evaluate(root, returnedNodes) && b.evaluate(root, returnedNodes)
+}
+
+case class OrPredicate(a: Predicate, b: Predicate) extends Predicate {
+
+  override def name: String = a.name + " or " + b.name
+
+  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+    a.evaluate(root, returnedNodes) || b.evaluate(root, returnedNodes)
+}
 
 /**
+  * Test for the index of the given node among all returned nodes.
   * XPath indexes from 1, and unfortunately we need to do that also.
   */
 case class IndexPredicate(name: String, i: Int) extends Predicate {
 
-  def apply(tn: TreeNode, among: Seq[TreeNode]): Boolean = {
+  def evaluate(tn: TreeNode, among: Seq[TreeNode]): Boolean = {
     val index = among.indexOf(tn)
     if (index == -1)
       throw new IllegalStateException(s"Internal error: Index [$i] not found in collection $among")
     i == index + 1
   }
+
+}
+
+case class PropertyValueTest(property: String, expectedValue: String) extends Predicate {
+
+  override def name: String = s"$property=[$expectedValue]"
+
+  override def evaluate(n: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+      n match {
+        case ctn: ContainerTreeNode =>
+          val extracted = ctn.childrenNamed(property)
+          if (extracted.size == 1) {
+            extracted.head.value.equals(expectedValue)
+          }
+          else
+            false
+        case _ => false
+      }
+}
+
+case class NodeNameTest(expectedName: String) extends Predicate {
+
+  override def name: String = s"name=[$expectedName]"
+
+  override def evaluate(n: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+    n.nodeName.equals(expectedName)
+}
+
+
+case class NodeTypeTest(expectedType: String) extends Predicate {
+
+  override def name: String = s"type=[$expectedType]"
+
+  override def evaluate(n: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+    n.nodeType.equals(expectedType)
+
+}
+
+
+/**
+  * Needs to run against JVM objects. Can't be used to
+  * generate queries, but needs to be executed against materialized tree
+  *
+  * @param name name of the predicate
+  * @param f    function to run against returned classes
+  */
+case class FunctionPredicate(name: String, f: (TreeNode, Seq[TreeNode]) => Boolean) extends Predicate {
+
+  def evaluate(tn: TreeNode, among: Seq[TreeNode]): Boolean = f(tn, among)
+
 }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
@@ -156,7 +156,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     rtn2.right.get should equal (Nil)
   }
 
-  it should "compare method value to int" in {
+  it should "compare method value to int with method" in {
     val rn = new ParsedMutableContainerTreeNode("root")
     val tn = new ParsedMutableContainerTreeNode("name") {
       def age = 25
@@ -168,6 +168,21 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     rtn.right.get should equal (Seq(tn))
 
     val expr2 = "/*[.age()=26]"
+    val rtn2 = ee.evaluate(rn, expr2, DefaultTypeRegistry)
+    rtn2.right.get should equal (Nil)
+  }
+
+  it should "compare method value to int with property" in {
+    val rn = new ParsedMutableContainerTreeNode("root")
+    val tn = new ParsedMutableContainerTreeNode("name")
+    tn.appendField(SimpleTerminalTreeNode("age", "25"))
+    rn.appendField(tn)
+
+    val expr = "/*[@age='25']"
+    val rtn = ee.evaluate(rn, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(tn))
+
+    val expr2 = "/*[@age='26']"
     val rtn2 = ee.evaluate(rn, expr2, DefaultTypeRegistry)
     rtn2.right.get should equal (Nil)
   }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
@@ -133,7 +133,9 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     val ls = parsed.locationSteps.head
     ls.axis should be(Child)
     ls.predicateToEvaluate match {
-      case p@SimplePredicate("size=large", _) =>
+      case np: PropertyValueTest =>
+        np.property should be ("size")
+        np.expectedValue should be ("large")
       case x => fail(s"predicate did not match expected type: $x")
     }
     ls.test match {
@@ -142,7 +144,7 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "parse a json jump" in {
+  it should "parse into json" in {
     val pe = "/*[@name='elm-package.json']/Json()/summary"
     val parsed = pep.parsePathExpression(pe)
     parsed.locationSteps.size should be (3)
@@ -155,6 +157,16 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     parsed.locationSteps.size should be (2)
     parsed.locationSteps(1).axis match {
       case NavigationAxis("belongsTo") =>
+    }
+  }
+
+  it should "parse predicate to understandable repo" in {
+    val pe = """/Issue()[@state='open']/belongsTo::Repo()[@name='rug-cli']"""
+    val parsed = pep.parsePathExpression(pe)
+    println(parsed)
+    parsed.locationSteps.size should be (2)
+    parsed.locationSteps(0).predicates.head match {
+      case PropertyValueTest("state", "open") =>
     }
   }
 

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
@@ -160,6 +160,16 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "parse a property name axis specifier using double quoted strings" in {
+    val pe = """/Issue()[@state="open"]/belongsTo::Repo()[@name="rug-cli"]"""
+    val parsed = pep.parsePathExpression(pe)
+    println(parsed)
+    parsed.locationSteps.size should be (2)
+    parsed.locationSteps(1).axis match {
+      case NavigationAxis("belongsTo") =>
+    }
+  }
+
   it should "parse predicate to understandable repo" in {
     val pe = """/Issue()[@state='open']/belongsTo::Repo()[@name='rug-cli']"""
     val parsed = pep.parsePathExpression(pe)


### PR DESCRIPTION
This exposes Predicate instances (except for functions) so that they can be used to generate queries to retrieve data, not just against objects in memory.