### PR TITLE
Fail fast when typescript compile breaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
                         <phase>process-test-resources</phase>
                         <configuration>
                             <tasks>
-                                <exec executable="target/node_modules/typescript/bin/tsc">
+                                <exec executable="target/node_modules/typescript/bin/tsc" failonerror="true">
                                     <arg value="-p"/>
                                     <arg value="target/.atomist/node_modules/@atomist/rug/"/>
                                 </exec>


### PR DESCRIPTION
This phase of the build fails silently when node is not installed locally. Later, it means the tests fail in a way that's hard to explain.

This was surprising because the build is supposed to work without node installed. However, tsc doesn't see target/node/node as the node executable.

Christian and I found this today. We'd probably rather require a local node (and tsc?) install, rather than use the node-and-npm plugin because that one stops offline builds from working.

This PR is fine alone, it just makes the build fail with a better message.  Workaround is "install node."

@kipz what do you think about the larger problem?