### PR TITLE
Added NestedPathExpressionPredicate

### DIFF
--- a/src/main/scala/com/atomist/tree/pathexpression/LocationStep.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/LocationStep.scala
@@ -18,12 +18,12 @@ case class LocationStep(axis: AxisSpecifier,
 
   import ExpressionEngine.NodePreparer
 
-  def follow(tn: TreeNode, typeRegistry: TypeRegistry, nodePreparer: NodePreparer): ExecutionResult =
-    test.follow(tn, axis, typeRegistry) match {
+  def follow(tn: TreeNode, ee: ExpressionEngine, typeRegistry: TypeRegistry, nodePreparer: NodePreparer): ExecutionResult =
+    test.follow(tn, axis, ee, typeRegistry) match {
       case Right(nodes) => Right(
         nodes
           .map(nodePreparer)
-          .filter(tn => predicateToEvaluate.evaluate(tn, nodes))
+          .filter(tn => predicateToEvaluate.evaluate(tn, nodes, ee, typeRegistry, Some(nodePreparer)))
       )
       case failure => failure
     }

--- a/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
@@ -20,7 +20,7 @@ trait NodeTest {
     * @param axis AxisSpecifier indicating the kind of navigation
     * @return Resulting nodes
     */
-  def follow(tn: TreeNode, axis: AxisSpecifier, typeRegistry: TypeRegistry): ExecutionResult
+  def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult
 
 }
 
@@ -31,10 +31,10 @@ trait NodeTest {
   */
 abstract class PredicatedNodeTest(name: String, predicate: Predicate) extends NodeTest {
 
-  final override def follow(tn: TreeNode, axis: AxisSpecifier, typeRegistry: TypeRegistry): ExecutionResult =
+  final override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult =
     sourceNodes(tn, axis, typeRegistry) match {
       case Right(nodes) =>
-        ExecutionResult(nodes.filter(tn => predicate.evaluate(tn, nodes)))
+        ExecutionResult(nodes.filter(tn => predicate.evaluate(tn, nodes, ee, typeRegistry, None)))
       case failure => failure
     }
 
@@ -71,7 +71,7 @@ object All extends PredicatedNodeTest("All", TruePredicate)
 case class NamedNodeTest(name: String)
   extends NodeTest {
 
-  override def follow(tn: TreeNode, axis: AxisSpecifier, typeRegistry: TypeRegistry): ExecutionResult = axis match {
+  override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult = axis match {
     case Child =>
       tn match {
         case ctn: ContainerTreeNode =>

--- a/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
@@ -48,7 +48,7 @@ case class ObjectType(typeName: String)
     //println(s"Returning ${kids.size} ${kids.mkString("\n")} for type $typeName under $tn")
   }
 
-  override def follow(tn: TreeNode, axis: AxisSpecifier, typeRegistry: TypeRegistry): ExecutionResult = {
+  override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult = {
     axis match {
       case NavigationAxis(propertyName) =>
         val nodes = tn match {

--- a/src/main/scala/com/atomist/tree/pathexpression/PathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/PathExpressionEngine.scala
@@ -11,21 +11,22 @@ class PathExpressionEngine extends ExpressionEngine {
 
   import ExpressionEngine.NodePreparer
 
-  override def evaluate(node: TreeNode, parsed: PathExpression,
+  override def evaluate(node: TreeNode,
+                        parsed: PathExpression,
                         typeRegistry: TypeRegistry,
                         nodePreparer: Option[NodePreparer]): ExecutionResult = {
     var nodesToApplyNextStepTo: ExecutionResult = ExecutionResult(List(node))
     for (locationStep <- parsed.locationSteps) {
       val nextNodes = nodesToApplyNextStepTo match {
         case Right(n :: Nil) =>
-          val next: ExecutionResult = locationStep.follow(n, typeRegistry, nodePreparer.getOrElse(n => n))
+          val next: ExecutionResult = locationStep.follow(n, this, typeRegistry, nodePreparer.getOrElse(n => n))
           next
         case Right(Nil) =>
           ExecutionResult(Nil)
         case Right(seq) =>
           val kids: List[TreeNode] = seq
             .flatMap(kid =>
-              locationStep.follow(kid, typeRegistry, nodePreparer.getOrElse(n => n))
+              locationStep.follow(kid, this, typeRegistry, nodePreparer.getOrElse(n => n))
                 .right.toOption)
             .flatten
           ExecutionResult(kids)

--- a/src/main/scala/com/atomist/tree/pathexpression/PathExpressionParser.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/PathExpressionParser.scala
@@ -69,13 +69,17 @@ trait PathExpressionParser extends CommonTypesParser {
 
   private def falsePredicate: Parser[Predicate] = "false" ^^ (_ => FalsePredicate)
 
+  private def nestedPathExpressionPredicate: Parser[Predicate] =
+    pathExpression ^^ (pe => NestedPathExpressionPredicate(pe))
+
   private def predicateTerm: Parser[Predicate] =
     methodInvocationTest |
       propertyTest |
       booleanMethodInvocation |
       truePredicate |
       falsePredicate |
-      index
+      index |
+      nestedPathExpressionPredicate
 
   private def negatedPredicate: Parser[Predicate] = "not" ~> "(" ~> predicateExpression <~ ")" ^^ {
     pred => NegationOfPredicate(pred)

--- a/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
@@ -1,5 +1,7 @@
 package com.atomist.tree.pathexpression
 
+import com.atomist.rug.spi.TypeRegistry
+import com.atomist.tree.pathexpression.ExpressionEngine.NodePreparer
 import com.atomist.tree.{ContainerTreeNode, TreeNode}
 import com.fasterxml.jackson.annotation.JsonProperty
 
@@ -22,7 +24,11 @@ trait Predicate {
     * @param returnedNodes all nodes returned. This argument is
     *                      often ignored, but can be used to discern the index of the target node.
     */
-  def evaluate(nodeToTest: TreeNode, returnedNodes: Seq[TreeNode]): Boolean
+  def evaluate(nodeToTest: TreeNode,
+               returnedNodes: Seq[TreeNode],
+               ee: ExpressionEngine,
+               typeRegistry: TypeRegistry,
+               nodePreparer: Option[NodePreparer]): Boolean
 
   def and(that: Predicate): Predicate =
     AndPredicate(this, that)
@@ -40,7 +46,11 @@ case object TruePredicate extends Predicate {
 
   override def toString: String = "true"
 
-  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean = true
+  override def evaluate(root: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean = true
 }
 
 
@@ -48,7 +58,11 @@ case object FalsePredicate extends Predicate {
 
   override def toString: String = "false"
 
-  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean = false
+  override def evaluate(root: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean = false
 }
 
 
@@ -56,23 +70,37 @@ case class NegationOfPredicate(p: Predicate) extends Predicate {
 
   override def toString: String = "!" + p.name
 
-  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean = !p.evaluate(root, returnedNodes)
+  override def evaluate(root: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean = !p.evaluate(root, returnedNodes, ee, typeRegistry, nodePreparer)
 }
 
 case class AndPredicate(a: Predicate, b: Predicate) extends Predicate {
 
   override def toString: String = a.name + " and " + b.name
 
-  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
-    a.evaluate(root, returnedNodes) && b.evaluate(root, returnedNodes)
+  override def evaluate(root: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean =
+    a.evaluate(root, returnedNodes, ee, typeRegistry, nodePreparer) &&
+      b.evaluate(root, returnedNodes, ee, typeRegistry, nodePreparer)
 }
 
 case class OrPredicate(a: Predicate, b: Predicate) extends Predicate {
 
   override def toString: String = a.name + " or " + b.name
 
-  override def evaluate(root: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
-    a.evaluate(root, returnedNodes) || b.evaluate(root, returnedNodes)
+  override def evaluate(root: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean =
+    a.evaluate(root, returnedNodes, ee, typeRegistry, nodePreparer) ||
+      b.evaluate(root, returnedNodes, ee, typeRegistry, nodePreparer)
 }
 
 /**
@@ -81,7 +109,11 @@ case class OrPredicate(a: Predicate, b: Predicate) extends Predicate {
   */
 case class IndexPredicate(i: Int) extends Predicate {
 
-  def evaluate(tn: TreeNode, among: Seq[TreeNode]): Boolean = {
+  def evaluate(tn: TreeNode,
+               among: Seq[TreeNode],
+               ee: ExpressionEngine,
+               typeRegistry: TypeRegistry,
+               nodePreparer: Option[NodePreparer]): Boolean = {
     val index = among.indexOf(tn)
     if (index == -1)
       throw new IllegalStateException(s"Internal error: Index [$i] not found in collection $among")
@@ -94,7 +126,11 @@ case class PropertyValuePredicate(property: String, expectedValue: String) exten
 
   override def toString: String = s"$property=[$expectedValue]"
 
-  override def evaluate(n: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+  override def evaluate(n: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean =
       n match {
         case ctn: ContainerTreeNode =>
           val extracted = ctn.childrenNamed(property)
@@ -113,7 +149,11 @@ case class NodeNamePredicate(expectedName: String) extends Predicate {
 
   override def toString: String = s"name=[$expectedName]"
 
-  override def evaluate(n: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+  override def evaluate(n: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean =
     n.nodeName.equals(expectedName)
 }
 
@@ -122,7 +162,11 @@ case class NodeTypePredicate(expectedType: String) extends Predicate {
 
   override def toString: String = s"type=[$expectedType]"
 
-  override def evaluate(n: TreeNode, returnedNodes: Seq[TreeNode]): Boolean =
+  override def evaluate(n: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean =
     n.nodeType.contains(expectedType)
 
 }
@@ -138,6 +182,26 @@ case class NodeTypePredicate(expectedType: String) extends Predicate {
 case class FunctionPredicate(override val name: String, f: (TreeNode, Seq[TreeNode]) => Boolean)
   extends Predicate {
 
-  def evaluate(tn: TreeNode, among: Seq[TreeNode]): Boolean = f(tn, among)
+  def evaluate(tn: TreeNode,
+               among: Seq[TreeNode],
+               ee: ExpressionEngine,
+               typeRegistry: TypeRegistry,
+               nodePreparer: Option[NodePreparer]): Boolean = f(tn, among)
+
+}
+
+
+case class NestedPathExpressionPredicate(pe: PathExpression) extends Predicate {
+
+  override def evaluate(nodeToTest: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean = {
+    ee.evaluate(nodeToTest, pe, typeRegistry, nodePreparer) match {
+      case Left(_) => false
+      case Right(nodes) => nodes.nonEmpty
+    }
+  }
 
 }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
@@ -241,4 +241,18 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 //    rtn.right.get should equal (Seq(fooNode))
 //  }
 
+  it should "handle a property name axis specifier nested predicate with Object type" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
+    repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
+    issue.addField(repo)
+    // TODO should we be able to handle a property called "name"?
+    val expr = """/Issue()[@state='open'][/belongsTo::Repo()[@name2='rug-cli']]"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
+
 }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
@@ -178,4 +178,14 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "parse nested predicate" in {
+    val pe = """/Issue()[@state='open'][/belongsTo::Repo()[@name='rug-cli']]"""
+    val parsed = pep.parsePathExpression(pe)
+    //println(parsed)
+    parsed.locationSteps.size should be (1)
+    parsed.locationSteps.head.predicates(1) match {
+      case np: NestedPathExpressionPredicate =>
+    }
+  }
+
 }


### PR DESCRIPTION
Note that this changes various signatures, as it's necessary to pass down everything the `ExpressionEngine` needs to evaluate a nested expression in a `Predicate`.