### PR TITLE
Add @version_range to TypeScript

### DIFF
--- a/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
@@ -26,6 +26,7 @@ abstract class Pattern {
   public static ruby_class: string ="@ruby_class"
   public static ruby_identifier: string ="@ruby_identifier"
   public static semantic_version: string ="@semantic_version"
+  public static version_range: string ="@version_range"
   public static uuid: string ="@uuid"
 }
 


### PR DESCRIPTION
@kipz I found this and concluded this change also needed to be done when adding the `@version_range` parameter validation regex. Is there anywhere else it needs to be added for TypeScript?