### PR TITLE
Allow annotations with properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
--   TypeScript/JavaScript should now "export" instances of Rugs inline with CommonJS standard.
-    Hopefully not a breaking change as there is limited support for automatically exporting legacy ones.
-    
+-   TypeScript/JavaScript should now "export" instances of Rugs inline
+    with CommonJS standard.  Hopefully not a breaking change as there
+    is limited support for automatically exporting legacy ones.
+
 ### Fixed
 
--   Comments are removed from JS files as they are 'required', and relative imports now work correctly
-    when 'export' is used from TS or vars are added to the global exports var
+-   Comments are removed from JS files as they are 'required', and
+    relative imports now work correctly when 'export' is used from TS
+    or vars are added to the global exports var
     https://github.com/atomist/rug/issues/156
 
 -   Generation of Rug types documentation
 
 -   minLength and maxLength now default to -1 as per Rug DSL
     https://github.com/atomist/rug/issues/169
+
+-   Allow Java annotations with properties,
+    https://github.com/atomist/rug/issues/164
 
 ## [0.9.0] - 2017-01-09
 

--- a/src/main/scala/com/atomist/rug/kind/java/BodyDeclarationView.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/BodyDeclarationView.scala
@@ -62,7 +62,10 @@ abstract class BodyDeclarationView[T <: BodyDeclaration](originalBackingObject: 
                       description = "The annotation to add")
                     annotation: String): Unit = {
     JavaTypeType.annotationAddedTo(currentBackingObject, annotation)
-    addImport(s"$pkg.$annotation")
+    val annotationName: String =
+      if (annotation.contains("(")) annotation.substring(0, annotation.indexOf('('))
+      else annotation
+    addImport(s"$pkg.$annotationName")
   }
 
   @ExportFunction(readOnly = false,

--- a/src/test/scala/com/atomist/rug/kind/java/JavaTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/JavaTypeUsageTest.scala
@@ -222,6 +222,26 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
     annotateClass(program)
   }
 
+  it should "add an annotation with properties to class" in {
+    val program =
+      """
+        |@description "I add ExtendWith() annotations"
+        |editor ClassAnnotated
+        |
+        |with JavaType c
+        |begin
+        | do addAnnotation "org.junit.jupiter.api.extension" "ExtendWith(value = SpringExtension.class)"
+        |end
+      """.stripMargin
+
+    val result = executeJava(program, "editors/ClassAnnotated.rug")
+    val f = result.findFile("src/main/java/Dog.java").get
+
+    f.content.lines.size should be > 0
+    f.content should include("import org.junit.jupiter.api.extension.ExtendWith;")
+    f.content should include("@ExtendWith(value = SpringExtension.class)")
+  }
+
   it should "remove annotation from class" in {
     val program =
       """


### PR DESCRIPTION
Allow adding annotations of the form `Annotations(prop = Value)`.

Addresses #164