### PR TITLE
Fix generex regex anchor issue

### DIFF
--- a/src/test/scala/com/atomist/param/ParameterGenerator.scala
+++ b/src/test/scala/com/atomist/param/ParameterGenerator.scala
@@ -17,7 +17,9 @@ object ParameterGenerator {
   def validValueFor(p: Parameter, minLength: Int): ParameterValue = p.hasDefaultValue match {
     case true => SimpleParameterValue(p.getName, p.getDefaultValue)
     case false =>
-      val generex = new Generex(p.getPattern)
+      // Generex seems to assume anchors and treat explicit regex anchors (^,$) literally
+      // when generating strings, so strip them off before sending to Generex
+      val generex = new Generex(p.getPattern.stripPrefix("^").stripSuffix("$"))
       val generated = generex.random(minLength)
       SimpleParameterValue(p.getName, generated)
   }

--- a/src/test/scala/com/atomist/param/ParameterTest.scala
+++ b/src/test/scala/com/atomist/param/ParameterTest.scala
@@ -45,15 +45,15 @@ class ParameterTest extends FlatSpec with Matchers {
   }
 
   it should "reject a param that doesn't match anchored regexp" in {
-    shouldReject(Parameter("foo","""^[a-z][\w]*$"""), Seq("FavoriteColour"))
+    shouldReject(Parameter("foo","""^[a-z]\w*$"""), Seq("FavoriteColour"))
   }
 
   it should "don't reject parameter that matches a stricter pattern" in {
-    shouldAccept(InputParamStrict, Seq("eColour"))
+    shouldAccept(InputParam, Seq("eColour"))
   }
 
   it should "reject a parameter that doesn't match the pattern" in {
-    shouldReject(InputParamStrict, Seq("FavoriteColour"))
+    shouldReject(InputParam, Seq("FavoriteColour"))
   }
 
   private def shouldAccept(p: Parameter, values: Seq[String]): Unit = {

--- a/src/test/scala/com/atomist/param/ParametersToTest.scala
+++ b/src/test/scala/com/atomist/param/ParametersToTest.scala
@@ -4,13 +4,11 @@ object ParametersToTest {
 
   val StringParam = Parameter("name")
 
-  val AgeParam = Parameter("age", "[0-9]+")
+  val AgeParam = Parameter("age", "^\\d+$")
 
-  val InputParam = Parameter("input_param", """[a-z][\w]*""")
+  val InputParam = Parameter("input_param", """^[a-z]\w*$""")
 
-  val InputParamStrict = Parameter("input_param", """^[a-z][\w]*$""")
-
-  val ParamStartingWithX = Parameter("mystery", "x.*")
+  val ParamStartingWithX = Parameter("mystery", "^x.*$")
 
   val ParameterizedToTest = new ParameterizedSupport {
     addParameter(StringParam)


### PR DESCRIPTION
Generex generates strings matching the entire regular expression you
provide to it.  Unlike the Java regular expression parser, anchors (^,$)
are not ignored but treated literally.  Since we require these anchors,
remove them from the regular expression before sending it to generex.

Also move generex stuff under test.