### PR TITLE
introduce a new type which handles every pom.xml file

### DIFF
--- a/src/main/resources/META-INF/services/com.atomist.rug.spi.Typed
+++ b/src/main/resources/META-INF/services/com.atomist.rug.spi.Typed
@@ -14,6 +14,7 @@ com.atomist.rug.kind.json.JsonType
 
 com.atomist.rug.kind.java.SpringBootProjectType
 com.atomist.rug.kind.pom.PomType
+com.atomist.rug.kind.pom.EveryPomType
 
 com.atomist.rug.kind.dynamic.MutableContainerTypeProvider
 com.atomist.rug.kind.python3.PythonFileType

--- a/src/main/scala/com/atomist/rug/kind/pom/EveryPomType.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/EveryPomType.scala
@@ -1,0 +1,41 @@
+package com.atomist.rug.kind.pom
+
+import com.atomist.project.ProjectOperationArguments
+import com.atomist.rug.kind.core.ProjectMutableView
+import com.atomist.rug.parser.Selected
+import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
+import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
+import com.atomist.source.ArtifactSource
+
+/**
+  * Maven POM type
+  *
+  * @param evaluator used to evaluate expressions
+  */
+class EveryPomType(
+               evaluator: Evaluator
+             )
+  extends Type(evaluator)
+    with ReflectivelyTypedType {
+
+  def this() = this(DefaultEvaluator)
+
+  override def description = "POM XML file"
+
+  override def viewManifest: Manifest[PomMutableView] = manifest[PomMutableView]
+
+  override protected def findAllIn(rugAs: ArtifactSource,
+                                   selected: Selected,
+                                   context: MutableView[_],
+                                   poa: ProjectOperationArguments,
+                                   identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
+    context match {
+      case pmv: ProjectMutableView =>
+        Some(pmv.currentBackingObject.allFiles
+          .filter(f => f.name.equals("pom.xml"))
+          .map(f => new PomMutableView(f, pmv))
+        )
+      case _ => None
+    }
+  }
+}

--- a/src/test/scala/com/atomist/rug/kind/pom/EveryPomUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/EveryPomUsageTest.scala
@@ -1,0 +1,64 @@
+package com.atomist.rug.kind.pom
+
+import com.atomist.project.SimpleProjectOperationArguments
+import com.atomist.project.edit.SuccessfulModification
+import com.atomist.rug.DefaultRugPipeline
+import com.atomist.rug.InterpreterRugPipeline.DefaultRugArchive
+import com.atomist.rug.kind.java.JavaTypeUsageTest
+import com.atomist.source.{ArtifactSource, EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, Matchers}
+
+class EveryPomUsageTest extends FlatSpec with Matchers {
+
+  import com.atomist.rug.TestUtils._
+
+  private def runProgAndCheck(as: ArtifactSource, mods: Int): ArtifactSource = {
+    val prog =
+      """
+        |editor EveryPomEdit
+        |with Project p
+        |  with EveryPom o
+        |    do setGroupId "mygroup"
+      """.stripMargin
+
+    val progArtifact: ArtifactSource = new SimpleFileBasedArtifactSource(DefaultRugArchive,
+      StringFileArtifact(new DefaultRugPipeline().defaultFilenameFor(prog), prog)
+    )
+
+    val result = doModification(progArtifact, as, EmptyArtifactSource(""),
+      SimpleProjectOperationArguments("", Map.empty[String,Object]))
+
+    result.cachedDeltas.size should be(mods)
+
+    result
+  }
+
+  private val pomFileArtifact = JavaTypeUsageTest.NewSpringBootProject.findFile("pom.xml").get
+
+  it should "edit a single pom" in {
+    val singlePom: ArtifactSource = new SimpleFileBasedArtifactSource("simple", pomFileArtifact)
+    runProgAndCheck(singlePom, 1)
+  }
+
+  it should "edit three poms" in {
+    val triplePom: ArtifactSource = new SimpleFileBasedArtifactSource("simple",
+      Seq(pomFileArtifact,
+        StringFileArtifact("module1/pom.xml", pomFileArtifact.content),
+        StringFileArtifact("module2/but/further/nested/pom.xml", pomFileArtifact.content)
+      )
+    )
+    runProgAndCheck(triplePom, 3)
+  }
+
+  it should "edit three poms and ignore other files" in {
+    val triplePomPlus: ArtifactSource = new SimpleFileBasedArtifactSource("simple",
+      Seq(pomFileArtifact,
+        StringFileArtifact("README.md", "This is a README\n"),
+        StringFileArtifact("module1/pom.xml", pomFileArtifact.content),
+        StringFileArtifact("src/main/Some.java", "class Some {}\n"),
+        StringFileArtifact("module2/but/further/nested/pom.xml", pomFileArtifact.content)
+      )
+    )
+    runProgAndCheck(triplePomPlus, 3)
+  }
+}

--- a/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
@@ -227,7 +227,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   it should "update existing parent artifactId" in {
 
-    val (originalParentGroupId: String, originalParentArtifactId: String, originalParentVersion: String) = assertParentBlockInitialState
+    val (originalParentGroupId: String, _, originalParentVersion: String) = assertParentBlockInitialState
 
     val newParentArtifactId = "bowling-ball"
     validPomUut.setParentArtifactId(newParentArtifactId)

--- a/src/test/scala/com/atomist/rug/kind/pom/PomUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/PomUsageTest.scala
@@ -57,8 +57,6 @@ class PomUsageTest extends FlatSpec with Matchers with LazyLogging {
 
   // Return new content
   private def updateWith(prog: String, project: ArtifactSource): ModificationAttempt = {
-    val filename = "thing.yml"
-
     val newName = "Foo"
     val pas = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(new DefaultRugPipeline().defaultFilenameFor(prog), prog))
 


### PR DESCRIPTION
The current `Pom` type only returns the `pom.xml` file from the root of the project. In a multi-module Maven project, it would be useful to be able to iterate through all of the `pom.xml` files. While this can be done with the existing `Xml` type, that loses some of the Maven-specifics of the `Pom` type.

While a different approach could be to simply modify the existing `Pom` type, I think it is more natural to define this as a separate type named `EveryPom`.