### PR TITLE
Handler JS/TS programming model as per atomist/rug#105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.10.0...HEAD
 
+### Added
+
+-   Support for a new TS (JS) Handler programming model as per
+    https://github.com/atomist/rug/issues/105
+
 ### Fixed
 
 -   TS generators are now passed project name as second argument as per TS contract
@@ -27,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   **BREAKING** signature of TypeScript ProjectGenerator.populate() changed: parameter
     `projectName` got removed. Name of the generated project can be obtained via `project.name()`.
 
+-   Core.ts is generated and compiled on-the-fly during unit-testing so that
+    the build is not dependent on network or later maven phases until deployment
+        
 ## [0.10.0]
 
 [0.10.0]: https://github.com/atomist/rug/compare/0.9.0...0.10.0

--- a/src/main/scala/com/atomist/event/archive/HandlerArchiveReader.scala
+++ b/src/main/scala/com/atomist/event/archive/HandlerArchiveReader.scala
@@ -9,7 +9,7 @@ import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.dynamic.{DefaultViewFinder, ViewFinder}
 import com.atomist.rug.kind.service.MessageBuilder
 import com.atomist.rug.runtime.js.JavaScriptHandlerFinder
-import com.atomist.rug.runtime.js.interop.ModelBackedAtomistFacade
+import com.atomist.rug.runtime.js.interop.{JavaScriptHandlerContext, ModelBackedAtomistFacade}
 import com.atomist.rug.runtime.rugdsl.DefaultEvaluator
 import com.atomist.rug.spi.TypeRegistry
 import com.atomist.source.ArtifactSource
@@ -38,7 +38,12 @@ class HandlerArchiveReader(
                 messageBuilder: MessageBuilder): Seq[SystemEventHandler] = {
     val atomist = new ModelBackedAtomistFacade(teamId, messageBuilder, treeMaterializer)
     JavaScriptHandlerFinder.registerHandlers(rugArchive, atomist)
-    atomist.handlers
+    val handlers = atomist.handlers
+    if(handlers.nonEmpty){
+      handlers
+    }else{
+      JavaScriptHandlerFinder.fromJavaScriptArchive(rugArchive, new JavaScriptHandlerContext(teamId,treeMaterializer, messageBuilder), None)
+    }
   }
 }
 

--- a/src/main/scala/com/atomist/rug/kind/service/SimpleMessageBuilder.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/SimpleMessageBuilder.scala
@@ -1,5 +1,6 @@
 package com.atomist.rug.kind.service
 
+import java.util
 import java.util.Collections
 
 import com.atomist.tree.TreeNode
@@ -27,7 +28,7 @@ case class ImmutableMessage(
                              node: TreeNode = null,
                              message: String = null,
                              address: String = null,
-                             actions: java.util.List[Action] = Collections.emptyList())
+                             actions: java.util.List[Action] = new util.ArrayList[Action]())
   extends Message {
 
   // We use null for interop and JSON

--- a/src/main/scala/com/atomist/rug/kind/service/message.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/message.scala
@@ -1,8 +1,6 @@
 package com.atomist.rug.kind.service
 
-import java.util
-
-import com.atomist.param.{ParameterValue, SimpleParameterValue}
+import com.atomist.param.{ParameterValue}
 import com.atomist.tree.TreeNode
 
 /**

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptContext.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptContext.scala
@@ -130,16 +130,16 @@ class JavaScriptContext(allowedClasses: Set[String] = Set.empty[String], atomist
     def getFile(s: String): String = {
       val file = artifacts.findFile(getPath + s)
       if (file.isEmpty) return null
+      //remove these source-map comments because they seem to be breaking nashorn :/
+      val withoutComments = commentPattern.matcher(file.get.content).replaceAll("")
       if(atomistConfig.isAtomistSource(file.get)){
-        //remove these source-map comments because they seem to be breaking nashorn :/
-        val withoutComments = commentPattern.matcher(file.get.content).replaceAll("")
         //add export for those vars without them. TODO should be removed at some point once all have moved over!
         val js = new StringBuilder(withoutComments)
         append(varPattern, withoutComments, js)
         append(letPattern, withoutComments, js)
         js.toString()
       }else{
-        file.get.content
+        withoutComments
       }
     }
 

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
@@ -9,7 +9,7 @@ import com.atomist.rug.kind.service.{ServiceSource, ServicesMutableView}
 import com.atomist.rug.runtime.js.interop.{ContextMatch, jsPathExpressionEngine}
 import com.atomist.source.ArtifactSource
 import com.atomist.tree.content.text.SimpleMutableContainerTreeNode
-import com.atomist.tree.pathexpression.{NamedNodeTest, PathExpressionParser}
+import com.atomist.tree.pathexpression.{NamedNodeTest, PathExpression, PathExpressionParser}
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 class JavaScriptEventHandler(
@@ -27,7 +27,7 @@ class JavaScriptEventHandler(
 
   override def description: String = name
 
-  val pathExpression = PathExpressionParser.parsePathExpression(pathExpressionStr)
+  val pathExpression: PathExpression = PathExpressionParser.parsePathExpression(pathExpressionStr)
 
   override val rootNodeName: String = pathExpression.locationSteps.head.test match {
     case nnt: NamedNodeTest => nnt.name
@@ -36,7 +36,7 @@ class JavaScriptEventHandler(
 
   import com.atomist.tree.pathexpression.ExpressionEngine.NodePreparer
 
-  private def nodePreparer(hc: HandlerContext): NodePreparer = {
+  protected def nodePreparer(hc: HandlerContext): NodePreparer = {
     case mca: ModelContextAware =>
       mca.setContext(hc)
       mca
@@ -53,29 +53,20 @@ class JavaScriptEventHandler(
     val root = new SimpleMutableContainerTreeNode("root", Seq(targetNode), null, null)
     pexe.ee.evaluate(root, pathExpression, DefaultTypeRegistry, Some(np)) match {
       case Right(Nil) =>
-        println("Nothing to do: No nodes found")
       case Right(matches) =>
         val cm = ContextMatch(
           targetNode,
-          //matches.map(m => m.asInstanceOf[Object]).asJava,
           pexe.wrap(matches),
           s2,
           teamId = e.teamId)
         invokeHandlerFunction(e, cm)
-      //as.persist()
       case Left(failure) =>
         throw new RugRuntimeException(pathExpressionStr,
           s"Error evaluating path expression $pathExpression: [$failure]")
     }
   }
 
-  protected def invokeHandlerFunction(e: SystemEvent, cm: ContextMatch): Unit = {
-    //val context = new ResultsMutableView(rugAs, hc.servicesMutableView, as)
-    val args = Seq(cm)
-
-    // Signature is
-    // on<R,N>(pathExpression: string, handler: (m: ContextMatch<R,N>) => void): void
-
-      handlerFunction.call("apply", args:_*)
+  protected def invokeHandlerFunction(e: SystemEvent, cm: ContextMatch): Object = {
+    handlerFunction.call("apply", cm)
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptHandlerFinder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptHandlerFinder.scala
@@ -1,8 +1,15 @@
 package com.atomist.rug.runtime.js
 
+import com.atomist.event.SystemEventHandler
+import com.atomist.param.Tag
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
-import com.atomist.rug.runtime.js.interop.AtomistFacade
+import com.atomist.rug.runtime.js.interop._
 import com.atomist.source.ArtifactSource
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
 
 /**
   * Finds and evaluates handlers in a Rug archive.
@@ -15,7 +22,7 @@ object JavaScriptHandlerFinder {
     * @param rugAs   archive to look into
     * @param atomist facade to Atomist
     * @return a sequence of instantiated operations backed by JavaScript
-
+    *
     */
   def registerHandlers(rugAs: ArtifactSource,
                        atomist: AtomistFacade,
@@ -26,4 +33,52 @@ object JavaScriptHandlerFinder {
     jsc.engine.put("atomist", atomist)
     jsc.load(rugAs)
   }
+
+  def fromJavaScriptArchive(rugAs: ArtifactSource,
+                            ctx: JavaScriptHandlerContext,
+                            context: Option[JavaScriptContext]): Seq[SystemEventHandler] = {
+
+    val jsc: JavaScriptContext =
+      if (context.isEmpty)
+        new JavaScriptContext()
+      else
+        context.get
+
+    jsc.load(rugAs)
+    handlersFromVars(rugAs, jsc, ctx)
+  }
+
+  private def handlersFromVars(rugAs: ArtifactSource, jsc: JavaScriptContext, ctx: JavaScriptHandlerContext): Seq[SystemEventHandler] = {
+    jsc.vars.foldLeft(Seq[SystemEventHandler]())((acc: Seq[SystemEventHandler], jsVar) => {
+      val obj = jsVar.scriptObjectMirror
+      if (obj.hasMember("name") && obj.hasMember("description") && obj.hasMember("handle") && obj.hasMember("expression")) {
+        val name = obj.getMember("name").asInstanceOf[String]
+        val description = obj.getMember("description").asInstanceOf[String]
+        val handle = obj.getMember("handle").asInstanceOf[ScriptObjectMirror]
+        val expression: String = obj.getMember("expression") match {
+          case x: String => x
+          case o: ScriptObjectMirror => o.getMember("expression").asInstanceOf[String]
+          case _ => null
+        }
+        val tags = readTagsFromMetadata(obj)
+        acc :+ new NamedJavaScriptEventHandler(expression, handle, obj, rugAs, ctx, name, description, tags)
+      } else {
+        acc
+      }
+    })
+  }
+
+  protected def readTagsFromMetadata(someVar: ScriptObjectMirror): Seq[Tag] = {
+    Try {
+      someVar.getMember("tags") match {
+        case som: ScriptObjectMirror =>
+          val stringValues = som.values().asScala collect {
+            case s: String => s
+          }
+          stringValues.map(s => Tag(s, s)).toSeq
+        case _ => Nil
+      }
+    }.getOrElse(Nil)
+  }
 }
+

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinder.scala
@@ -35,7 +35,6 @@ object JavaScriptOperationFinder {
     */
   def fromJavaScriptArchive(rugAs: ArtifactSource,
                             context: JavaScriptContext = null): Seq[ProjectOperation] = {
-
     val jsc: JavaScriptContext =
       if (context == null)
         new JavaScriptContext()
@@ -43,8 +42,7 @@ object JavaScriptOperationFinder {
         context
 
     jsc.load(rugAs)
-    val operations = operationsFromVars(rugAs, jsc)
-    operations
+    operationsFromVars(rugAs, jsc)
   }
 
 

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/JavaScriptHandlerContext.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/JavaScriptHandlerContext.scala
@@ -1,0 +1,22 @@
+package com.atomist.rug.runtime.js.interop
+
+import com.atomist.plan.TreeMaterializer
+import com.atomist.rug.kind.service.{MessageBuilder, TeamContext}
+import com.atomist.tree.pathexpression.PathExpressionEngine
+
+class JavaScriptHandlerContext(val teamId: String,
+                               _treeMaterializer: TreeMaterializer,
+                               _messageBuilder: MessageBuilder)
+
+  extends UserModelContext with TeamContext {
+
+  val pathExpressionEngine = new jsPathExpressionEngine(teamContext = this, ee = new PathExpressionEngine)
+
+  val messageBuilder: MessageBuilder = _messageBuilder
+
+  override val treeMaterializer: TreeMaterializer = _treeMaterializer
+
+  override def registry: Map[String, Object] =  Map(
+    "PathExpressionEngine" -> pathExpressionEngine
+  )
+}

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandler.scala
@@ -1,0 +1,141 @@
+package com.atomist.rug.runtime.js.interop
+
+import com.atomist.event.{HandlerContext, SystemEvent}
+import com.atomist.param.Tag
+import com.atomist.rug.RugRuntimeException
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.kind.service._
+import com.atomist.rug.runtime.js.JavaScriptEventHandler
+import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
+import com.atomist.tree.content.text.SimpleMutableContainerTreeNode
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+
+import scala.collection.JavaConverters._
+
+/**
+  * Like super, except that we require a proper name, description, tags etc.
+  * and we wrap the match in an Event
+  */
+class NamedJavaScriptEventHandler(pathExpressionStr: String,
+                                  handlerFunction: ScriptObjectMirror,
+                                  thiz: ScriptObjectMirror,
+                                  rugAs: ArtifactSource,
+                                  ctx: JavaScriptHandlerContext,
+                                  _name: String,
+                                  _description: String,
+                                  _tags: Seq[Tag] = Nil)
+  extends JavaScriptEventHandler(pathExpressionStr, handlerFunction, rugAs, ctx.treeMaterializer, ctx.pathExpressionEngine) {
+
+  override def name: String = _name
+
+  override def tags: Seq[Tag] = _tags
+
+  override def description: String = _description
+
+  override def handle(e: SystemEvent, s2: ServiceSource): Unit = {
+    val smv = new ServicesMutableView(rugAs, s2)
+    val handlerContext = HandlerContext(smv)
+    val np = nodePreparer(handlerContext)
+
+    val targetNode = ctx.treeMaterializer.rootNodeFor(e, pathExpression)
+    // Put a new artificial root above to make expression work
+    val root = new SimpleMutableContainerTreeNode("root", Seq(targetNode), null, null)
+    ctx.pathExpressionEngine.ee.evaluate(root, pathExpression, DefaultTypeRegistry, Some(np)) match {
+      case Right(Nil) =>
+      case Right(matches) =>
+        val cm = ContextMatch(
+          targetNode,
+          ctx.pathExpressionEngine.wrap(matches),
+          s2,
+          teamId = e.teamId)
+        dispatch(invokeHandlerFunction(e, cm))
+
+      case Left(failure) =>
+        throw new RugRuntimeException(pathExpressionStr,
+          s"Error evaluating path expression $pathExpression: [$failure]")
+    }
+  }
+
+  override protected def invokeHandlerFunction(e: SystemEvent, cm: ContextMatch): Object = {
+    handlerFunction.call(thiz, Event(cm))
+  }
+
+  /**
+    * Extract all messages and use messageBuilder/actionRegistry to find and dispatch actions
+    * @param plan
+    */
+  def dispatch(plan: Object): Unit = {
+    plan match {
+      case o: ScriptObjectMirror => {
+        o.get("messages") match {
+          case messages: ScriptObjectMirror if messages.isArray => {
+            messages.values().asScala.foreach {
+              case m: ScriptObjectMirror => {
+                var responseMessage = ctx.messageBuilder.regarding(m.get("regarding").asInstanceOf[TreeNode])
+                responseMessage =m.get("text") match {
+                  case text: String => responseMessage.say(text)
+                  case _ => responseMessage
+                }
+                responseMessage = m.get("channelId") match {
+                  case c: String => responseMessage.on(c)
+                  case _ => responseMessage
+                }
+                responseMessage = m.get("rugs") match {
+                  case rugs: ScriptObjectMirror if rugs.isArray => {
+                    addActions(responseMessage, rugs)
+                  }
+                  case _ => responseMessage
+                }
+                responseMessage.send()
+              }
+              case _ =>
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+    * Extract action from JS and bind to Message
+    *
+    * Beware use of var!
+    *
+    * @param msg current message
+    * @param rugs array of Rugs
+    * @return new message
+    */
+  def addActions(msg: Message, rugs: ScriptObjectMirror) : Message = {
+    var responseMessage = msg
+    for (rug <- rugs.values().asScala) {
+      val r = rug.asInstanceOf[ScriptObjectMirror]
+      //TODO - this is a reimplementation of the @cd's label hack - but at least it's not in TS
+      val actionName = r.get("label") match {
+        case label: String => s"${r.get("name").asInstanceOf[String]}|$label"
+        case _ => r.get("name").asInstanceOf[String]
+      }
+      var action = responseMessage.actionRegistry.findByName(actionName)
+      r.get("params") match {
+        case params: ScriptObjectMirror => {
+          for (param <- params.entrySet().asScala) {
+            action = responseMessage.actionRegistry.bindParameter(action, param.getKey, param.getValue)
+          }
+        }
+        case _ =>
+      }
+      responseMessage = msg.withAction(action)
+    }
+    responseMessage
+  }
+}
+
+
+/**
+  * Represents an event that drives a handler
+  *
+  * @param cm the root node in the tree
+  */
+case class Event(cm: ContextMatch) {
+  def child: TreeNode = cm.root.asInstanceOf[TreeNode]
+}

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/RugOperationSupport.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/RugOperationSupport.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 
 object RugOperationSupport {
 
-  val YmlFormat = DateTimeFormatter.ofPattern("MMM d yyyy")
+  val YmlFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM d yyyy")
 
   // May have been passed in via the infrastructure but couldn't be declared in Rug: Suppress
   // so it doesn't upset binding into JavaScript

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -118,24 +118,6 @@ class TypeScriptInterfaceGenerator(
 
   val typeSort: (Typed, Typed) => Boolean = (a, b) => a.name <= b.name
 
-//  DO NOT DELETE
-//  private def allInterfaceTypes(allTypes: Seq[Typed]): Seq[InterfaceType] = {
-//    val methods = allTypes.map(t => t.name -> allMethods(t)).toMap
-//    val duplicateMethods = methods.values.flatten.groupBy(identity).filter(_ match {
-//      case (_, lst) => lst.size > 1
-//    }).keys.toSeq.sortWith(_.name <= _.name)
-//
-//    val parent = if (duplicateMethods.isEmpty) None else Some(
-//      InterfaceType(ParentInterface, "TypeScript superinterface", duplicateMethods))
-//
-//    parent.toList ::: allTypes.map(t => {
-//      val allMethods = methods.getOrElse(t.name, Nil)
-//      val uniqueMethods = allMethods diff duplicateMethods
-//      if (allMethods.size == uniqueMethods.size) InterfaceType(t.name, t.description, allMethods)
-//      else InterfaceType(t.name, t.description, uniqueMethods, ParentInterface)
-//    }).toList
-//  }
-
   private def allInterfaceTypes(allTypes: Seq[Typed]): Seq[InterfaceType] =
     allTypes.map(t => InterfaceType(t.name, t.description, allMethods(t)))
 
@@ -203,15 +185,6 @@ class TypeScriptInterfaceGenerator(
     val publishedTypeNames = publishedTypes.map(_.name).toSet
     (types -- publishedTypeNames).toSeq.sorted
   }
-
-//  private def findUnpublishedTypes1(publishedTypes: Seq[Typed]): Seq[Typed] = {
-//    val allOperations = publishedTypes.map(_.typeInformation).collect {
-//      case st: StaticTypeInformation => st.operations
-//    }.flatten
-//    val types = allOperations.map(op => op.definedOn).toSet
-//    val publishedTypeNames = publishedTypes.map(_.name).toSet
-//    (types -- publishedTypes).toSeq.sorted
-//  }
 
   override def modify(as: ArtifactSource, poa: ProjectOperationArguments): ModificationAttempt = {
     val createdFile = emitInterfaces(poa)

--- a/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
+++ b/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
@@ -7,7 +7,7 @@ import org.springframework.util.ReflectionUtils
 import scala.collection.mutable.ListBuffer
 
 /**
-  * Pperations on TreeNodes such as tree pruning.
+  * Operations on TreeNodes such as tree pruning.
   */
 object TreeNodeOperations {
 

--- a/src/main/scala/com/atomist/tree/pathexpression/PathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/PathExpressionEngine.scala
@@ -38,5 +38,4 @@ class PathExpressionEngine extends ExpressionEngine {
     //println(s"Returning $nodesToApplyNextStepTo when evaluating [$parsed] against $node")
     nodesToApplyNextStepTo
   }
-
 }

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -1,0 +1,94 @@
+import {TreeNode} from "../tree/PathExpression"
+
+interface RugCoordinate {
+  group: string
+  artifact: string
+  version?: string
+  name: string
+}
+
+interface Rug {
+  readonly name: string | RugCoordinate
+  readonly params: {}
+  readonly kind: "executor" | "generator" | "editor"
+}
+
+abstract class Executor implements Rug {
+  abstract name: string
+  abstract params: {}
+  kind: "executor"
+}
+
+abstract class Generator implements Rug {
+  abstract name: string
+  abstract params: {}
+  kind: "generator"
+}
+
+abstract class Editor implements Rug {
+  abstract name: string
+  abstract params: Object
+  kind: "editor"
+}
+
+interface Event<R extends TreeNode> {
+  child(): R
+}
+
+abstract class PathExpression<T extends TreeNode> {
+  readonly expression: string
+  readonly kind: T
+}
+
+interface Handler<T extends TreeNode> {
+  readonly name: string
+  readonly description: string
+  readonly expression: PathExpression<T>
+  readonly tags?: string[]
+  handle(root: Event<T>): HandlerResult
+}
+
+class HandlerResult {
+   private messages: Message[] = [];
+
+   public addMessage(message: Message) : this{
+     this.messages.push(message)
+     return this;
+   }
+
+  //TODO - we should add this back in when we want to invoke rugs directly without the bot
+  //  private rugs: Rug[]
+  //  public addExecutor(rug: Executor) {
+  //    this.rugs.push(rug)
+  //    return this;
+  //  }
+}
+
+class Message {
+  text: string;
+  channelId: string;
+  regarding: TreeNode;
+
+  private rugs: Rug[] = []
+
+  constructor(node: TreeNode){
+    this.regarding = node
+  }
+
+  public addExecutor(rug: Executor): this {
+    this.rugs.push(rug)
+    return this;
+  }
+
+  public addEditor(rug: Editor): this {
+    this.rugs.push(rug)
+    return this;
+  }
+
+  public addGenerator(rug: Generator) : this {
+    this.rugs.push(rug)
+    return this;
+  }
+}
+
+export {Handler, Event, HandlerResult, Message, Executor, Generator, Editor, PathExpression}

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -4,7 +4,7 @@
 */
 interface Match<R,N> {
 
-  root(): R 
+  root(): R
 
   matches(): N[]
 }

--- a/src/test/scala/com/atomist/event/archive/HandlerArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/event/archive/HandlerArchiveReaderTest.scala
@@ -5,6 +5,7 @@ import com.atomist.plan.TreeMaterializer
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
 import com.atomist.rug.TestUtils
 import com.atomist.rug.kind.service.ConsoleMessageBuilder
+import com.atomist.rug.runtime.js.interop.NamedJavaScriptEventHandlerTest
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.TreeNode
 import com.atomist.tree.pathexpression.PathExpression
@@ -54,6 +55,14 @@ class HandlerArchiveReaderTest extends FlatSpec with Matchers {
     handlers.size should be(2)
     handlers.exists(h => h.rootNodeName == "issue") should be(true)
     handlers.exists(h => h.rootNodeName == "commit") should be(true)
+  }
+
+  it should "parse single new-style handler" in {
+    val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
+    val handlers = har.handlers("XX", TestUtils.compileWithModel(SimpleFileBasedArtifactSource(NamedJavaScriptEventHandlerTest.reOpenCloseIssueProgram,NamedJavaScriptEventHandlerTest.issuesStuff)), None, Nil,
+      new ConsoleMessageBuilder("XX", null))
+    handlers.size should be(1)
+    handlers.head.rootNodeName should be("issue")
   }
 
   object TestTreeMaterializer extends TreeMaterializer {

--- a/src/test/scala/com/atomist/rug/TestUtils.scala
+++ b/src/test/scala/com/atomist/rug/TestUtils.scala
@@ -2,13 +2,14 @@ package com.atomist.rug
 
 import java.io.File
 
-import com.atomist.project.ProjectOperationArguments
+import com.atomist.project.{ProjectOperationArguments, SimpleProjectOperationArguments}
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
 import com.atomist.project.edit.{ModificationAttempt, ProjectEditor, SuccessfulModification}
 import com.atomist.rug.compiler.typescript.TypeScriptCompiler
 import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.ts.TypeScriptInterfaceGenerator
 import com.atomist.source.file.{FileSystemArtifactSource, FileSystemArtifactSourceIdentifier}
-import com.atomist.source.ArtifactSource
+import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource}
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 import org.scalatest.Matchers
 
@@ -24,7 +25,6 @@ object TestUtils extends Matchers {
 
     attemptModification(program, as, backingAs, poa, pipeline) match {
       case sm: SuccessfulModification =>
-        // show(sm.result)
         sm.result
     }
   }
@@ -41,18 +41,21 @@ object TestUtils extends Matchers {
     pe.modify(as, poa)
   }
 
-  // This brings in a node_modules directory that was copied there by a maven goal called copy-ts, which takes it from src/main/typescript
-  val user_model = new FileSystemArtifactSource(FileSystemArtifactSourceIdentifier(new File("target/.atomist"))).withPathAbove(".atomist")
 
   val compiler = new TypeScriptCompiler()
 
-  def compileWithModel(tsAs: ArtifactSource) : ArtifactSource = {
-    compiler.compile(addUserModel(tsAs))
+  // This brings in a node_modules directory that was copied there by a maven goal called copy-ts, which takes it from src/main/typescript
+  val user_model: ArtifactSource = {
+
+    val generator = new TypeScriptInterfaceGenerator
+    val output = generator.generate("stuff", SimpleProjectOperationArguments("", Map(generator.OutputPathParam -> "Core.ts")))
+    val src = new FileSystemArtifactSource(FileSystemArtifactSourceIdentifier(new File("src/main/typescript")))
+
+    val compiled = compiler.compile(src.underPath("node_modules/@atomist").withPathAbove(".atomist") + output.withPathAbove(".atomist/rug/model"))
+    compiled.underPath(".atomist").withPathAbove(".atomist/node_modules/@atomist")
   }
-  //work around for atomist/artifact-source#16
-  def addUserModel(as: ArtifactSource) : ArtifactSource = {
-    user_model.allFiles.foldLeft(as)((acc: ArtifactSource, fa) => {
-      acc + fa
-    })
+
+  def compileWithModel(tsAs: ArtifactSource) : ArtifactSource = {
+    compiler.compile(user_model + tsAs)
   }
 }

--- a/src/test/scala/com/atomist/rug/runtime/HandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/HandlerTest.scala
@@ -5,7 +5,7 @@ import java.util.Collections
 import com.atomist.rug.TestUtils
 import com.atomist.rug.kind.service.{ConsoleMessageBuilder, EmptyActionRegistry}
 import com.atomist.rug.runtime.js.JavaScriptContext
-import com.atomist.rug.runtime.js.interop.{AtomistFacade, Match, jsPathExpressionEngine}
+import com.atomist.rug.runtime.js.interop.{AtomistFacade, Match, NamedJavaScriptEventHandlerTest, jsPathExpressionEngine}
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.SimpleTerminalTreeNode
 import jdk.nashorn.api.scripting.ScriptObjectMirror
@@ -46,6 +46,14 @@ class HandlerTest extends FlatSpec with Matchers {
     }
 
   }
+
+  it should "find and invoke other style of handler" in {
+
+      val r = TestUtils.compileWithModel(SimpleFileBasedArtifactSource(NamedJavaScriptEventHandlerTest.reOpenCloseIssueProgram, NamedJavaScriptEventHandlerTest.issuesStuff))
+      val jsc = new JavaScriptContext()
+
+      jsc.load(r)
+    }
 }
 
 

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandlerTest.scala
@@ -1,0 +1,173 @@
+package com.atomist.rug.runtime.js.interop
+
+import java.util
+
+import com.atomist.event.SystemEvent
+import com.atomist.event.archive.HandlerArchiveReader
+import com.atomist.param.{ParameterValue, SimpleParameterValue}
+import com.atomist.plan.TreeMaterializer
+import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
+import com.atomist.rug.TestUtils
+import com.atomist.rug.kind.service.{Action, ActionRegistry, Callback, ConsoleMessageBuilder, Rug}
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
+import com.atomist.tree.TreeNode
+import com.atomist.tree.pathexpression.PathExpression
+import com.atomist.util.Visitor
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+object NamedJavaScriptEventHandlerTest {
+  val atomistConfig: AtomistConfig = DefaultAtomistConfig
+  val treeMaterializer: TreeMaterializer = TestTreeMaterializer
+
+  val issuesStuff = StringFileArtifact(atomistConfig.handlersRoot + "/Issues.ts",
+  """import {Executor, PathExpression} from '@atomist/rug/operations/Handlers'
+    |import {TreeNode} from '@atomist/rug/tree/PathExpression'
+    |
+    |abstract class IssueRug extends Executor {
+    |  abstract name: string
+    |  abstract label?: string
+    |  params: {} = {}
+    |  constructor(){
+    |    super();
+    |  }
+    |  withNumber(num: number): this {
+    |    this.params["number"] = num
+    |    return this
+    |  }
+    |
+    |  withOwner(owner: string) : this {
+    |    this.params["owner"] = owner;
+    |    return this;
+    |  }
+    |  withRepo(repo: string) : this {
+    |    this.params["repo"] = repo;
+    |    return this;
+    |  }
+    |}
+    |
+    |export class ReopenIssue extends IssueRug {
+    |  name = "ReopenIssue"
+    |  constructor(readonly label: string){
+    |    super()
+    |  }
+    |}
+    |
+    |export class AssignIssue extends IssueRug {
+    |  name = "AssignIssue"
+    |  constructor(readonly label: string){
+    |    super()
+    |  }
+    |}
+    |
+    |export interface Issue extends TreeNode{
+    |  number(): number
+    |  repo(): string
+    |  owner(): string
+    |}
+    |
+    |class OpenIssuesExpression implements PathExpression<Issue> {
+    |  expression: string = "/issue[.state()='open']"
+    |  kind: Issue
+    |}
+    |
+    |class ClosedIssuesExpression implements PathExpression<Issue> {
+    |  expression: "/issue[.state()='closed']"
+    |  kind: Issue
+    |}
+    |
+    |export let ClosedIssues = new ClosedIssuesExpression()
+    |export let OpenIssues = new OpenIssuesExpression()
+    |""".stripMargin)
+
+  val reOpenCloseIssueProgram =  StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
+    s"""
+       |import {Handler, HandlerResult, Message, Event} from '@atomist/rug/operations/Handlers'
+       |import {OpenIssues, Issue, ReopenIssue} from './Issues'
+       |
+       |export let simpleHandler: Handler<Issue> = {
+       |  name: "ClosedIssueReopener",
+       |  description: "Reopens closed issues",
+       |  tags: ["github", "issues"],
+       |  expression: OpenIssues,
+       |  handle(event: Event<Issue>){
+       |    let issue = event.child()
+       |    return new HandlerResult()
+       |      .addMessage(new Message(issue)
+       |        .addExecutor(new ReopenIssue("Reopen")
+       |          .withNumber(issue.number())
+       |          .withRepo(issue.repo())
+       |          .withOwner(issue.owner())))
+       |  }
+       |}
+      """.stripMargin)
+}
+
+class NamedJavaScriptEventHandlerTest extends FlatSpec with Matchers{
+
+  import NamedJavaScriptEventHandlerTest._
+
+
+  it should "extract and run a handler based on new style" in {
+    val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
+    val handlers = har.handlers("XX", TestUtils.compileWithModel(SimpleFileBasedArtifactSource(reOpenCloseIssueProgram,issuesStuff)), None, Nil,
+      new ConsoleMessageBuilder("XX", SimpleActionRegistry))
+    handlers.size should be(1)
+    val handler = handlers.head
+    handler.rootNodeName should be("issue")
+    handler.handle(SysEvent,null)
+  }
+}
+
+object SimpleActionRegistry extends ActionRegistry {
+
+  val rug = Rug("executor", "group", "artifact", "version", "ReopenIssue")
+
+  override def findByName(name: String): Action = Action(name, Callback(rug), new util.ArrayList[ParameterValue]())
+
+
+  override def bindParameter(action: Action, name: String, value: Object) = {
+    val params = new util.ArrayList[ParameterValue](action.parameters)
+    params.add(SimpleParameterValue(name,value))
+    Action(action.title,action.callback,params)
+  }
+}
+
+object SysEvent extends SystemEvent ("blah", "issue", 0l)
+
+class IssueTreeNode extends TreeNode {
+  /**
+    * Name of the node. This may vary with individual nodes: For example,
+    * with files. However, node names do not always need to be unique.
+    *
+    * @return name of the individual node
+    */
+  override def nodeName: String = "issue"
+
+  /**
+    * All nodes have values: Either a terminal value or the
+    * values built up from subnodes.
+    */
+  override def value: String = "blah"
+
+
+  def state(): String = "closed"
+
+  val number: Int = 10
+
+  val repo: String = "rug"
+
+  val owner: String = "atomist"
+
+  override def accept(v: Visitor, depth: Int): Unit = ???
+}
+
+object TestTreeMaterializer extends TreeMaterializer {
+
+  override def rootNodeFor(e: SystemEvent, pe: PathExpression): TreeNode = new IssueTreeNode()
+
+  override def hydrate(teamId: String, rawRootNode: TreeNode, pe: PathExpression): TreeNode = rawRootNode
+}
+
+


### PR DESCRIPTION
- Current Rug internal APIs remain unchanged (i.e. should have no impact on runtime or CLI)
- Handler archives must have new-style (as per #105) or old 'on' style, but _not_ both
  - this is due to how the global var is not injected for the new style, and old handlers would fail to even parse without it.
- Core.ts generation and compilation is now done on-the-fly during tests so we don't need the maven tasks to have run or be online (we still would need to move npm/tsc installation outside of the pom for Travis build to benefit from this).