### PR TITLE
Remove implicit project_name parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   **BREAKING** CustomizingProjectGenerator was removed from ProjectGenerator.ts 
     as it's no longer required, and it's thought that it's not being used at all yet.
 
+-   **BREAKING** signature of TypeScript ProjectGenerator.populate() changed: parameter
+    `projectName` got removed. Name of the generated project can be obtained via `project.name()`.
+
 ## [0.10.0]
 
 [0.10.0]: https://github.com/atomist/rug/compare/0.9.0...0.10.0

--- a/src/main/scala/com/atomist/project/generate/ProjectGenerator.scala
+++ b/src/main/scala/com/atomist/project/generate/ProjectGenerator.scala
@@ -12,5 +12,5 @@ import com.atomist.source.ArtifactSource
 trait ProjectGenerator extends ProjectDelta {
 
   @throws(classOf[InvalidParametersException])
-  def generate(poa: ProjectOperationArguments): ArtifactSource
+  def generate(projectName: String, poa: ProjectOperationArguments): ArtifactSource
 }

--- a/src/main/scala/com/atomist/rug/rugdoc/TypeDoc.scala
+++ b/src/main/scala/com/atomist/rug/rugdoc/TypeDoc.scala
@@ -44,7 +44,7 @@ class TypeDoc(
     setDefaultValue(DefaultDocName))
 
   @throws[InvalidParametersException](classOf[InvalidParametersException])
-  override def generate(poa: ProjectOperationArguments): ArtifactSource = {
+  override def generate(projectName: String, poa: ProjectOperationArguments): ArtifactSource = {
     val createdFile = createFile(poa)
     val output = StringFileArtifact(DefaultDocName, createdFile.content)
     new SimpleFileBasedArtifactSource("RugDocs", output)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectGenerator.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectGenerator.scala
@@ -26,11 +26,12 @@ class JavaScriptInvokingProjectGenerator(
   override val name: String = jsVar.getMember("name").asInstanceOf[String]
 
   @throws(classOf[InvalidParametersException])
-  override def generate(poa: ProjectOperationArguments): ArtifactSource = {
+  override def generate(projectName: String, poa: ProjectOperationArguments): ArtifactSource = {
     validateParameters(poa)
     val tr = time {
-      val pmv = new ProjectMutableView(rugAs, startProject, atomistConfig = DefaultAtomistConfig, context)
-      invokeMemberWithParameters("populate", wrapProject(pmv), poa.parameterValueMap("project_name").getValue, poa)
+      val project = new EmptyArtifactSource(projectName) + startProject
+      val pmv = new ProjectMutableView(rugAs, project, atomistConfig = DefaultAtomistConfig, context)
+      invokeMemberWithParameters("populate", wrapProject(pmv), poa)
       pmv.currentBackingObject
     }
     logger.debug(s"$name modifyInternal took ${tr._2}ms")

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -21,7 +21,7 @@ object TypeScriptInterfaceGenerator extends App {
   val target = if (args.length < 1) "target/classes/@atomist/rug/model/Core.ts" else args.head
   val generator = new TypeScriptInterfaceGenerator
 
-  val output = generator.generate(SimpleProjectOperationArguments("", Map(generator.OutputPathParam -> "Core.ts")))
+  val output = generator.generate("", SimpleProjectOperationArguments("", Map(generator.OutputPathParam -> "Core.ts")))
   Utils.withCloseable(new PrintWriter(target))(_.write(output.allFiles.head.content))
   println(s"Written to $target")
 }
@@ -100,7 +100,7 @@ class TypeScriptInterfaceGenerator(
     setDefaultValue(DefaultFilename))
 
   @throws[InvalidParametersException](classOf[InvalidParametersException])
-  override def generate(poa: ProjectOperationArguments): ArtifactSource = {
+  override def generate(projectName: String, poa: ProjectOperationArguments): ArtifactSource = {
     val createdFile = emitInterfaces(poa)
     // println(s"The content of ${createdFile.path} is\n${createdFile.content}")
     new SimpleFileBasedArtifactSource("Rug user model", createdFile)

--- a/src/main/typescript/node_modules/@atomist/rug/operations/ProjectGenerator.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/ProjectGenerator.ts
@@ -7,7 +7,7 @@ import {Parameter, RugOperation} from "./RugOperation"
  */
 interface ProjectGenerator extends RugOperation {
     
-    populate(emptyProject: Project, projectName: string, args: {})
+    populate(emptyProject: Project, args: {})
 }
 
 export {ProjectGenerator}

--- a/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
@@ -150,9 +150,10 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
     val ops = apc.findOperations(rugAs, None, Nil)
     ops.generators.size should be(1)
     ops.generators.head.parameters.size should be(0)
-    val result = ops.generators.head.generate(
-      SimpleProjectOperationArguments("", Map("project_name" -> "woot", "content" -> "woot")))
+    val result = ops.generators.head.generate("woot",
+      SimpleProjectOperationArguments("", Map("content" -> "woot")))
     // Should preserve content from the backing archive
+    result.id.name should be("woot")
     result.findFile(f1.path).get.content.equals(f1.content) should be(true)
     result.findFile(f2.path).get.content.equals(f2.content) should be(true)
 
@@ -213,8 +214,8 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
     val ops = apc.findOperations(rugAs, None, Nil)
     ops.generators.size should be(1)
     ops.generators.head.parameters.size should be(0)
-    val result = ops.generators.head.generate(
-      SimpleProjectOperationArguments("", Map("project_name" -> "woot", "content" -> "woot")))
+    val result = ops.generators.head.generate("woot",
+      SimpleProjectOperationArguments("", Map("content" -> "woot")))
     // Should preserve content from the backing archive
     result.findFile(f1.path).get.content.equals(f1.content) should be(true)
     result.findFile(f2.path).get.content.equals(f2.content) should be(true)

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmNewStaticPageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmNewStaticPageTest.scala
@@ -64,7 +64,7 @@ class ElmNewStaticPageTest extends FlatSpec with Matchers {
         rugArchive)
 
     val freshArtifactSource =
-      gen.generate(
+      gen.generate("",
         SimpleProjectOperationArguments(
           "wut",
           parameters))

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeDocTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeDocTest.scala
@@ -12,7 +12,7 @@ class TypeDocTest extends FlatSpec with Matchers {
 
   it should "generate type doc" in {
     val td = new TypeDoc()
-    val output = td.generate(SimpleProjectOperationArguments.Empty)
+    val output = td.generate("", SimpleProjectOperationArguments.Empty)
     output.allFiles.size should be(1)
     val d = output.allFiles.head
     d.contentLength should be > (100000)

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGen.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGen.scala
@@ -11,7 +11,7 @@ object TypeScriptInterfaceGen extends App {
 
   val td = new TypeScriptInterfaceGenerator()
   // Make it puts the generated files where our compiler will look for them
-  val output = td.generate(SimpleProjectOperationArguments("",
+  val output = td.generate("", SimpleProjectOperationArguments("",
     Map(td.OutputPathParam -> ".atomist/editors/Interfaces.ts")))
   val d = output.allFiles.head
   // println(d.content)

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
@@ -13,7 +13,7 @@ class TypeScriptInterfaceGeneratorTest extends FlatSpec with Matchers {
   it should "generate compilable typescript file" in {
     val td = new TypeScriptInterfaceGenerator()
     // Make it put the generated files where our compiler will look for them
-    val output = td.generate(SimpleProjectOperationArguments("",
+    val output = td.generate("", SimpleProjectOperationArguments("",
       Map(td.OutputPathParam -> ".atomist/editors/Interfaces.ts")))
     output.allFiles.size should be(1)
 

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
@@ -140,10 +140,10 @@ object TypeScriptRugEditorTest {
       |class SimpleGenerator implements ProjectGenerator{
       |     description: string = "My simple Generator"
       |     name: string = "SimpleGenerator"
-      |     populate(project: Project, project_name: string, {content} : {content: string}) {
+      |     populate(project: Project, {content} : {content: string}) {
       |        let len: number = content.length;
-      |        if(project_name != "woot"){
-      |           throw Error(`Project name should be woot, but was ${project_name}`)
+      |        if(project.name() != "woot"){
+      |           throw Error(`Project name should be woot, but was ${project.name()}`)
       |        }
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
       |    }
@@ -528,8 +528,8 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
     jsed.name should be("SimpleGenerator")
     jsed.setContext(others)
 
-    val prj = jsed.generate(SimpleProjectOperationArguments("", Map("project_name" -> "woot","content" -> "Anders Hjelsberg is God")))
-
+    val prj = jsed.generate("woot", SimpleProjectOperationArguments("", Map("content" -> "Anders Hjelsberg is God")))
+    prj.id.name should be("woot")
 
     jsed
   }


### PR DESCRIPTION
The name of the new project is now passed into the ProjectGenerator from the runtime and is accesssible from `ProjectMutableView` via `project.name()`.

This removes the obscure requirement to declare a `project_name` parameter.

refs #192