### PR TITLE
Support rug-tests for generators

### DIFF
--- a/src/main/scala/com/atomist/rug/InterpreterRugPipeline.scala
+++ b/src/main/scala/com/atomist/rug/InterpreterRugPipeline.scala
@@ -12,6 +12,9 @@ import com.atomist.source.{ArtifactSource, FileArtifact}
   * Build executable ProjectOperations from Rug archives
   * Rug scripts must be in .atomist/editors directory
   *
+  * If you're looking for "how do I parse these rugs" you probably want ProjectOperationArchiveReader,
+  * which calls into this and does other important stuff too
+  *
   * @param parser parser to use
   * @param compiler compiler to use
   */

--- a/src/main/scala/com/atomist/rug/parser/ParserCombinatorRugParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/ParserCombinatorRugParser.scala
@@ -80,6 +80,7 @@ class ParserCombinatorRugParser(
     rep(annotation) ~ operationToken ~ capitalizedIdentifier ~ rep(uses) ^^ {
       case annotations ~ op ~ name ~ imports =>
         val o: Op = op match {
+          case GeneratorToken => Editor
           case EditorToken => Editor
           case PredicateToken => Predicate
           case ReviewerToken => Reviewer
@@ -90,7 +91,8 @@ class ParserCombinatorRugParser(
         for (annotation <- annotations) annotation match {
           case Annotation(DescriptionAnnotationAttribute, Some(desc: String)) => ed = ed.copy(description = desc)
           case Annotation(TagAnnotation, Some(tag: String)) => ed = ed.copy(tags = ed.tags :+ tag)
-          case Annotation(GeneratorAnnotation, pubName: Option[String @unchecked]) =>
+          case Annotation(GeneratorToken, pubName: Option[String@unchecked]) =>
+            System.err.println(s"Generator [$name] uses old style @generator annotation. Use 'generator', rather than 'editor', keyword")
             ed = ed.copy(publishedName = Some(pubName.getOrElse(ed.name)))
           // TODO Do what we did for parameters
           // and do the resolution later, because someone thought this makes it worse, but it doesn't, printing the $op helps
@@ -119,7 +121,7 @@ class ParserCombinatorRugParser(
   private def doSteps(simpleAction: Parser[DoStep]): Parser[Seq[DoStep]] =
     (simpleAction | compoundDoStep) ^^ {
       case d: DoStep => Seq(d)
-      case dos: Seq[DoStep @unchecked] => dos
+      case dos: Seq[DoStep@unchecked] => dos
     }
 
   private def simpleWithDoStep: Parser[DoStep] = (doDoStep | withBlock(simpleWithDoStep)) ^^ {
@@ -163,9 +165,7 @@ class ParserCombinatorRugParser(
 
   protected def scriptActionBlock: Parser[ScriptBlock] = javaScriptBlock
 
-  private def opActions: Parser[Seq[Action]] =  rep1(action(simpleWithDoStep)) ^^ {
-    case actions => actions
-  }
+  private def opActions: Parser[Seq[Action]] = rep1(action(simpleWithDoStep))
 
   private def rugEditor: Parser[RugEditor] =
     operationSpec(EditorToken) ~
@@ -181,14 +181,12 @@ class ParserCombinatorRugParser(
 
   private def rugGenerator: Parser[RugEditor] =
     operationSpec(GeneratorToken) ~
-      rep(precondition) ~ opt(postcondition) ~
+      opt(postcondition) ~
       rep(parameter) ~ rep(letStatement) ~
       opActions ^^ {
-      case opSpec ~ preconditions ~ postcondition ~ params ~ compBlock ~ actions =>
-        RugEditor(opSpec.name,
-          opSpec.publishedName.orElse(Some(opSpec.name)),   // the secret "i am a generator" clue
-          opSpec.tags, opSpec.description, opSpec.imports,
-          preconditions, postcondition,
+      case opSpec ~ postcondition ~ params ~ compBlock ~ actions =>
+        RugEditor(opSpec.name, Some(opSpec.name), opSpec.tags, opSpec.description, opSpec.imports,
+          Nil, postcondition,
           paramDefsToParameters(opSpec.name, params),
           compBlock, actions)
     }
@@ -251,7 +249,7 @@ class ParserCombinatorRugParser(
 
   protected def executorActions: Parser[Seq[Action]] = (scriptActionBlock | rep1(action(simpleExecutionDoStep))) ^^ {
     case sab: ScriptBlock => Seq(ScriptBlockAction(sab))
-    case actions: Seq[Action @unchecked] => actions
+    case actions: Seq[Action@unchecked] => actions
   }
 
   private def rugExecutor: Parser[RugExecutor] =
@@ -264,7 +262,12 @@ class ParserCombinatorRugParser(
           compBlock, actions)
     }
 
-  protected def rugProgram: Parser[RugProgram] = rugPredicate | rugEditor | rugReviewer | rugExecutor | rugGenerator
+  protected def rugProgram: Parser[RugProgram] =
+    rugPredicate |
+      rugGenerator |
+      rugEditor |
+      rugReviewer |
+      rugExecutor
 
   private def rugPrograms: Parser[Seq[RugProgram]] = phrase(rep1(rugProgram))
 

--- a/src/main/scala/com/atomist/rug/parser/ParserCombinatorRugParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/ParserCombinatorRugParser.scala
@@ -185,7 +185,9 @@ class ParserCombinatorRugParser(
       rep(parameter) ~ rep(letStatement) ~
       opActions ^^ {
       case opSpec ~ preconditions ~ postcondition ~ params ~ compBlock ~ actions =>
-        RugEditor(opSpec.name, opSpec.publishedName, opSpec.tags, opSpec.description, opSpec.imports,
+        RugEditor(opSpec.name,
+          opSpec.publishedName.orElse(Some(opSpec.name)),   // the secret "i am a generator" clue
+          opSpec.tags, opSpec.description, opSpec.imports,
           preconditions, postcondition,
           paramDefsToParameters(opSpec.name, params),
           compBlock, actions)
@@ -262,10 +264,7 @@ class ParserCombinatorRugParser(
           compBlock, actions)
     }
 
-  protected def rugProgram: Parser[RugProgram] = (rugPredicate | rugEditor | rugReviewer | rugExecutor | rugGenerator | "\\w+".r) ^^ {
-    case s: String => throw new BadRugException(s"Expected one of: ${Seq(PredicateToken, EditorToken, ReviewerToken, ExecutorToken, GeneratorToken).mkString(", ")}, but found [$s]") {}
-    case p: RugProgram => p
-  }
+  protected def rugProgram: Parser[RugProgram] = rugPredicate | rugEditor | rugReviewer | rugExecutor | rugGenerator
 
   private def rugPrograms: Parser[Seq[RugProgram]] = phrase(rep1(rugProgram))
 

--- a/src/main/scala/com/atomist/rug/parser/RugParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/RugParser.scala
@@ -79,12 +79,6 @@ object RugParser extends CommonRugTokens {
 
   val OnNoChangeToken = "onNoChange"
 
-  /**
-    * Used to indicate to indicate that an editor or reviewer should be exposed
-    * directly to users
-    */
-  val GeneratorAnnotation = "generator"
-
   val TagAnnotation = "tag"
 
   val OptionalAnnotationAttribute = "optional"

--- a/src/main/scala/com/atomist/rug/parser/RugParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/RugParser.scala
@@ -42,6 +42,8 @@ object RugParser extends CommonRugTokens {
 
   val EditorToken = "editor"
 
+  val GeneratorToken = "generator"
+
   val ReviewerToken = "reviewer"
 
   val PredicateToken = "predicate"

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/FunctionInvocationContext.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/FunctionInvocationContext.scala
@@ -16,10 +16,6 @@ trait FunctionInvocationContext[T] {
 
   def functionInvocation: FunctionInvocation
 
-  /**
-    * Target artifact source.
-    */
-  def artifactSource: ArtifactSource
 
   def args: ProjectOperationArguments
 
@@ -70,7 +66,7 @@ case class SimpleFunctionInvocationContext[T <: Object](
                                                          targetAlias: String,
                                                          functionInvocation: FunctionInvocation,
                                                          target: T,
-                                                         artifactSource: ArtifactSource,
+                                                         deprecated: ArtifactSource,
                                                          reviewContext: ReviewContext,
                                                          identifierMap: Map[String, Object],
                                                          args: ProjectOperationArguments = SimpleProjectOperationArguments.Empty,

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenExecutor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenExecutor.scala
@@ -27,7 +27,7 @@ class RugDrivenExecutor(
     val context = new ServicesMutableView(rugAs, services)
 
     val reviewContext = new ReviewContext
-    val identifierMap = buildIdentifierMap(rugAs, context, null, poa)
+    val identifierMap = buildIdentifierMap(context, poa)
 
     program.actions match {
       case Seq(sba: ScriptBlockAction) =>
@@ -35,7 +35,7 @@ class RugDrivenExecutor(
       case actions =>
         actions.foreach {
           case wb: With =>
-            val idm = buildIdentifierMap(rugAs, context, null, poa)
+            val idm = buildIdentifierMap(context, poa)
             executedSelectedBlock(
               rugAs, wb, null, reviewContext, context, poa, identifierMap = idm)
         }

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectEditor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectEditor.scala
@@ -56,11 +56,11 @@ class RugDrivenProjectEditor(
       try {
         program.actions.foreach {
           case wb: With =>
-            val identifierMap = buildIdentifierMap(rugAs, currentProjectState, currentProjectState.currentBackingObject, poa)
+            val identifierMap = buildIdentifierMap(currentProjectState, poa)
             currentProjectState = executedSelectedBlock(rugAs, wb, currentProjectState.currentBackingObject,
               reviewContext, currentProjectState, poa, identifierMap).asInstanceOf[ProjectMutableView]
           case sba: ScriptBlockAction =>
-            val identifierMap = buildIdentifierMap(rugAs, currentProjectState, currentProjectState.currentBackingObject, poa)
+            val identifierMap = buildIdentifierMap(currentProjectState, poa)
             scriptBlockActionExecutor.execute(sba, currentProjectState, ScriptBlockActionExecutor.DEFAULT_PROJECT_ALIAS, identifierMap)
           case roo: RunOtherOperation =>
             runEditor(roo, rugAs, currentProjectState.currentBackingObject, poa) match {

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectPredicate.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectPredicate.scala
@@ -38,7 +38,7 @@ class RugDrivenProjectPredicate(
 
     program.actions.foreach {
       case wb: With =>
-        val idm = buildIdentifierMap(rugAs, project, as, poa)
+        val idm = buildIdentifierMap(project, poa)
         executedSelectedBlock(
           rugAs, wb, as, reviewContext, project, poa, identifierMap = idm)
       //      case sba: ScriptBlockAction =>

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectReviewer.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectReviewer.scala
@@ -34,11 +34,11 @@ class RugDrivenProjectReviewer(
 
     program.actions.foreach {
       case wb: With =>
-        val idm = buildIdentifierMap(rugAs, project, as, poa)
+        val idm = buildIdentifierMap(project, poa)
         executedSelectedBlock(
           rugAs, wb, as, reviewContext, project, poa, identifierMap = idm)
       case sba: ScriptBlockAction =>
-        val identifierMap = buildIdentifierMap(rugAs, project, project.currentBackingObject, poa)
+        val identifierMap = buildIdentifierMap( project, poa)
         scriptBlockActionExecutor.execute(sba, project, ScriptBlockActionExecutor.DEFAULT_SERVICES_ALIAS, identifierMap)
       case run: RunOtherOperation =>
         val rr = runReviewer(run, rugAs, as, poa)

--- a/src/main/scala/com/atomist/rug/test/RugTestParser.scala
+++ b/src/main/scala/com/atomist/rug/test/RugTestParser.scala
@@ -41,7 +41,7 @@ object RugTestParser
 
   private def fileSpec: Parser[FileSpec] = inlineFile | loadedFile | filesUnder | archiveRoot | emptyArchive
 
-  private def givenFiles: Parser[GivenFiles] = GivenToken.r ~> rep1(fileSpec) ^^ (f => GivenFiles(f))
+  private def givenFiles: Parser[GivenFiles] = GivenToken.r ~> rep(fileSpec) ^^ (f => GivenFiles(f))
 
   private def givenOperations: Parser[Seq[RunOtherOperation]] = rep(runOtherOperation)
 

--- a/src/main/scala/com/atomist/rug/test/TestRunner.scala
+++ b/src/main/scala/com/atomist/rug/test/TestRunner.scala
@@ -55,7 +55,7 @@ class TestRunner(executionLog: ExecutionLog = ConsoleExecutionLog) {
     * Run the given test programs
     *
     * @param testPrograms test programs
-    * @param testResources backing archive for thetests
+    * @param testResources backing archive for the tests
     * @param context known project operations. What we're testing
     * @param namespace current namespace for use in name resolution
     * @return a test report

--- a/src/main/scala/com/atomist/rug/test/TestRunner.scala
+++ b/src/main/scala/com/atomist/rug/test/TestRunner.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.test
 
 import com.atomist.project.common.{InvalidParametersException, MissingParametersException}
 import com.atomist.project.edit.{FailedModificationAttempt, NoModificationNeeded, ProjectEditor, SuccessfulModification}
+import com.atomist.project.generate.ProjectGenerator
 import com.atomist.project.{ProjectOperation, ProjectOperationArguments}
 import com.atomist.source.{ArtifactSource, ArtifactSourceUtils}
 
@@ -54,10 +55,10 @@ class TestRunner(executionLog: ExecutionLog = ConsoleExecutionLog) {
   /**
     * Run the given test programs
     *
-    * @param testPrograms test programs
+    * @param testPrograms  test programs
     * @param testResources backing archive for the tests
-    * @param context known project operations. What we're testing
-    * @param namespace current namespace for use in name resolution
+    * @param context       known project operations. What we're testing
+    * @param namespace     current namespace for use in name resolution
     * @return a test report
     */
   def run(
@@ -73,10 +74,13 @@ class TestRunner(executionLog: ExecutionLog = ConsoleExecutionLog) {
               s"Known operations are [${context.map(op => op.name).mkString(",")}]", EmptyTestEventLog)
         case Some(ed: ProjectEditor) =>
           executeAgainst(test, ed, testResources)
+        case Some(gen: ProjectGenerator) =>
+          executeGenerator(test, gen)
       }
     })
     TestReport(executedTests)
   }
+
 
   private def executeAgainst(test: TestScenario, ed: ProjectEditor, testResources: ArtifactSource): ExecutedTest = {
     val eventLog = new TestEventLog
@@ -88,7 +92,7 @@ class TestRunner(executionLog: ExecutionLog = ConsoleExecutionLog) {
         eventLog.recordInput(input)
       }
 
-      val poa: ProjectOperationArguments = test.args(testResources)
+      val poa: ProjectOperationArguments = test.args
       eventLog.recordParameters(poa)
 
       if (test.givenInvocations.nonEmpty) {
@@ -126,6 +130,44 @@ class TestRunner(executionLog: ExecutionLog = ConsoleExecutionLog) {
               }
           }
       }
+    }
+    catch {
+      case mp: MissingParametersException =>
+        test.outcome.assertions match {
+          case Seq(ShouldBeMissingParametersAssertion) =>
+            ExecutedTest(test.name,
+              Seq(TestedAssertion(result = true, s"Editor was missing parameters: ${mp.getMessage}")), eventLog)
+          case _ =>
+            ExecutedTest.failure(test.name, s"Editor failed due to missing parameters: ${mp.getMessage}", eventLog)
+        }
+      case ivp: InvalidParametersException =>
+        test.outcome.assertions match {
+          case Seq(ShouldBeInvalidParametersAssertion) =>
+            ExecutedTest(test.name, Seq(TestedAssertion(result = true, s"Editor had invalid parameters: ${ivp.getMessage}")), eventLog)
+          case _ =>
+            ExecutedTest.failure(test.name, s"Editor failed due to invalid parameters: ${ivp.getMessage}", eventLog)
+        }
+    }
+  }
+
+
+  private def executeGenerator(test: TestScenario, gen: ProjectGenerator): ExecutedTest = {
+    val eventLog = new TestEventLog
+    try {
+      // TODO should publish events rather than sysout
+      executionLog.log(s"Executing scenario ${test.name}...")
+
+
+      val poa: ProjectOperationArguments = test.args
+      eventLog.recordParameters(poa)
+
+      if (test.givenInvocations.nonEmpty) {
+        ??? // not implemented
+      }
+
+          println("I see a generator!")
+          val result = gen.generate(test.name, poa)
+          verifyOutput(test, null, result, eventLog) // That null thing is probably used
     }
     catch {
       case mp: MissingParametersException =>
@@ -184,6 +226,7 @@ case class TestReport(
       test.name + "diagnostics\n" +
         "\tInput: " + test.eventLog.input.map(i => ArtifactSourceUtils.prettyListFiles(i)).getOrElse("") +
         "\tOutput: " + test.eventLog.output.map(o => ArtifactSourceUtils.prettyListFiles(o)).getOrElse("")
+
     failures.map(f => testDebugOutput(f)).mkString("\n")
   }
 

--- a/src/main/scala/com/atomist/rug/test/TestScenario.scala
+++ b/src/main/scala/com/atomist/rug/test/TestScenario.scala
@@ -51,7 +51,7 @@ case class TestScenario(
   def identifierMap(backingArchive: ArtifactSource): Map[String, Object] = {
     val context = null
     val project = input(backingArchive)
-    buildIdentifierMap(backingArchive, context, project, args(backingArchive))
+    buildIdentifierMap(backingArchive, args)
   }
 
   /**
@@ -68,9 +68,8 @@ case class TestScenario(
     *
     * @return ProjectOperationArguments created from editor invocation
     */
-  def args(backingArchive: ArtifactSource): ProjectOperationArguments = {
-    val project = input(backingArchive)
-    parametersForOtherOperation(backingArchive, editorInvocation, SimpleProjectOperationArguments.Empty, project)
+  def args: ProjectOperationArguments = {
+    parametersForOtherOperation(editorInvocation, SimpleProjectOperationArguments.Empty)
   }
 }
 
@@ -193,7 +192,7 @@ case class PredicateAssertion(
 
   override def test(test: TestScenario, testBacking: ArtifactSource, output: ArtifactSource): TestedAssertion = {
     val pa = DefaultViewFinder
-    val result = pa.invokePredicate(EmptyArtifactSource(""), test.args(testBacking),
+    val result = pa.invokePredicate(EmptyArtifactSource(""), test.args,
       test.identifierMap(testBacking), predicate, PredicateAssertion.ProjectResultName, new ProjectAssertions(output))
     new TestedAssertion(result, this)
   }

--- a/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
@@ -31,8 +31,7 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
 
   val Generator = StringFileArtifact(atomistConfig.editorsRoot + "/Published.rug",
     """
-      |@generator
-      |editor Published
+      |generator Published
       |
       |First
     """.stripMargin

--- a/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
@@ -463,8 +463,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
 
   it should "reject bogus regex in parameter" in {
     val prog =
-      s"""
-         |editor Triplet
+      s"""editor Triplet
          |
          |param nonsense: @this_is_bollocks
          |

--- a/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
@@ -645,6 +645,24 @@ class CommonRugParserTest extends FlatSpec with Matchers {
     parsed.publishedName should be(Some(publishedName))
   }
 
+  it should "parse generator on operation with name override" in {
+    val publishedName = "FooBar666"
+    val prog =
+      s"""
+         |@description '100% JavaScript free'
+         |generator $publishedName
+         |
+         |with File f
+         | when isJava = "thing"
+         |
+         |do
+         | append "foobar"
+      """.stripMargin
+
+    val parsed = ri.parse(prog).head
+    parsed.publishedName should be(Some(publishedName))
+  }
+
   it should "pick up multiple @tags annotations on operation with name override" in {
     val publishedName = "FooBar666"
     val prog =

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
@@ -126,7 +126,7 @@ object TypeScriptRugEditorTest {
       |import {Project} from '@atomist/rug/model/Core'
       |import {Status,Result} from '@atomist/rug/operations/RugOperation'
       |
-      |class SimpleGenerator implements ProjectGenerator{
+      |class SimpleGenerator implements ProjectGenerator {
       |     description: string = "My simple Generator"
       |     name: string = "SimpleGenerator"
       |     populate(project: Project, {content} : {content: string}) {

--- a/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
@@ -1,6 +1,7 @@
 package com.atomist.rug.test
 
 import com.atomist.project.ProjectOperation
+import com.atomist.project.archive.ProjectOperationArchiveReader
 import com.atomist.rug.DefaultRugPipeline
 import com.atomist.rug.parser.ParserCombinatorRugParser
 import com.atomist.source.{ArtifactSource, EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
@@ -45,7 +46,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
     """.stripMargin)
     val theOneFile = StringFileArtifact("happy.txt", "Joy Joy")
     val rugArchive = SimpleFileBasedArtifactSource(theOneFile, generator)
-    val parsedGenerator: Seq[ProjectOperation] = new DefaultRugPipeline().create(rugArchive, None)
+    val parsedGenerator: Seq[ProjectOperation] = new ProjectOperationArchiveReader().findOperations(rugArchive, None, Nil).generators
 
     val generatorTest = StringFileArtifact(".atomist/tests/OneFileGenerator.rt",
       """scenario SomethingIsGenerated

--- a/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
@@ -145,7 +145,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
     val test = tp.head
     test.name should be(scenarioName)
     test.givenFiles.fileSpecs should equal(Seq(f))
-    val poa = test.args(new SimpleFileBasedArtifactSource("", StringFileArtifact("resources/something", "a file")))
+    val poa = test.args
     poa.parameterValues.size should be >= 2
     poa.paramValue("old_class") should equal("Dog")
     poa.paramValue("new_class") should equal("Cat")


### PR DESCRIPTION
This adds functionality: 

* `generator NewHappyProject` (deprecating @generator editor NewHappyProject)

* You can now test a generator in a rug test.

