### PR TITLE
Treenode simplification

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/dynamic/ContainerTreeNodeView.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/ContainerTreeNodeView.scala
@@ -24,7 +24,7 @@ class ContainerTreeNodeView[O <: ContainerTreeNode](
   @ExportFunction(readOnly = true, description = "Value")
   override def value: String = currentBackingObject.value
 
-  override def dirty: Boolean = originalBackingObject.dirty
+  override def dirty: Boolean = false
 
   @ExportFunction(readOnly = true, description = "Return the value of the given key")
   def valueOf(@ExportFunctionParameterDescription(name = "name",

--- a/src/main/scala/com/atomist/rug/kind/rug/dsl/EditorMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/rug/dsl/EditorMutableView.scala
@@ -9,7 +9,8 @@ import com.atomist.tree.TerminalTreeNode
 
 class EditorMutableView(originalBackingObject: FileArtifact,
                         parent: ProjectMutableView)
-  extends LazyFileArtifactBackedMutableView(originalBackingObject, parent) with TerminalTreeNode {
+  extends LazyFileArtifactBackedMutableView(originalBackingObject, parent)
+    with TerminalTreeNode {
 
   @ExportFunction(readOnly = false, description = "Change a .rug to a .ts editor")
   def convertToTypeScript(): Unit = {

--- a/src/main/scala/com/atomist/rug/spi/TerminalView.scala
+++ b/src/main/scala/com/atomist/rug/spi/TerminalView.scala
@@ -1,11 +1,10 @@
 package com.atomist.rug.spi
 
-import scala.collection.Seq
+import com.atomist.tree.TreeNode
 
 trait TerminalView[T] extends MutableView[T] {
 
   override def childNodeTypes: Set[String] = Set()
 
-  override def childrenNamed(fieldName: String): Seq[MutableView[_]] =
-    throw new UnsupportedOperationException(s"View of class ${getClass.getSimpleName} has no children. children() should not be called")
+  override def childrenNamed(key: String): Seq[TreeNode] = Nil
 }

--- a/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
@@ -18,4 +18,10 @@ trait MutableContainerTreeNode
   def appendFields(newFields: Seq[TreeNode]): Unit = {
     newFields.foreach(appendField)
   }
+
+  override def dirty: Boolean =
+    (childNodes collect {
+      case u: MutableTreeNode if u.dirty => u
+    }).nonEmpty
+
 }

--- a/src/main/scala/com/atomist/tree/content/text/MutableTerminalTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/MutableTerminalTreeNode.scala
@@ -39,9 +39,9 @@ class MutableTerminalTreeNode(
   override def endPosition: InputPosition = startPosition + currentValue.length
 
   @ExportFunction(readOnly = true, description = "Return the value")
-  override def value = currentValue
+  override def value: String = currentValue
 
-  override def dirty = currentValue != initialValue
+  override def dirty: Boolean = currentValue != initialValue
 
   def longString =
     s"scalar:${getClass.getSimpleName}: $nodeName=[$currentValue], position=$startPosition"

--- a/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
+++ b/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
@@ -43,20 +43,15 @@ object TreeNodeOperations {
     * that's typically necessary to provide a context for the name of the terminal.
     */
   val Flatten: TreeOperation = treeOperation {
-    case ofv: ContainerTreeNode if ofv.childNodes.size == 1 =>
-        val ret = ofv.childNodes.head match {
-          case ctn: ContainerTreeNode => Some(ctn)
-          case x => Some(x)
-        }
-      ret
-    case ofv: ContainerTreeNode =>
-      Some(ofv)
+    case ofv: TreeNode if ofv.childNodes.size == 1 =>
+      ofv.childNodes.headOption
     case x =>
       Some(x)
   }
 
   /**
     * Get rid of this level, pulling up its children
+    *
     * @param name name of node level to get rid of
     */
   def collapse(name: String): TreeOperation =
@@ -64,6 +59,7 @@ object TreeNodeOperations {
 
   /**
     * Get rid of this level, pulling up its children
+    *
     * @param f test for which nodes should be removed
     * @return new tree
     */
@@ -81,6 +77,7 @@ object TreeNodeOperations {
       case x =>
         Some(x)
     }
+
     filter
   }
 
@@ -90,8 +87,6 @@ object TreeNodeOperations {
   val Prune: TreeOperation = treeOperation {
     case ofv: ContainerTreeNode if ofv.childNodes.isEmpty =>
       None
-    case ectn: EmptyContainerTreeNode =>
-      None
     case x =>
       Some(x)
   }
@@ -100,7 +95,7 @@ object TreeNodeOperations {
     * TreeOperation that removes padding nodes
     */
   val RemovePadding: TreeOperation = treeOperation {
-    case pn: PaddingTreeNode =>
+    case _: PaddingTreeNode =>
       None
     case x =>
       Some(x)

--- a/src/main/scala/com/atomist/tree/content/text/grammar/MatchListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/MatchListener.scala
@@ -1,9 +1,7 @@
 package com.atomist.tree.content.text.grammar
 
-import com.atomist.tree.ContainerTreeNode
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.InputPosition
-import com.atomist.util.ConsoleVisitor
-import com.typesafe.scalalogging.LazyLogging
 
 /**
   * Decorates a string with its position in input
@@ -24,7 +22,7 @@ trait MatchListener {
 
   def onSkip(junk: PositionalString): Unit
 
-  def onMatch(m: ContainerTreeNode): Unit
+  def onMatch(m: TreeNode): Unit
 
   /**
     * Return the number of matches found.
@@ -41,12 +39,12 @@ abstract class AbstractMatchListener(val name: String) extends MatchListener {
 
   override def onSkip(junk: PositionalString): Unit = {}
 
-  final override def onMatch(m: ContainerTreeNode): Unit = {
+  final override def onMatch(m: TreeNode): Unit = {
     _matches += 1
     onMatchInternal(m)
   }
 
-  protected def onMatchInternal(m: ContainerTreeNode): Unit
+  protected def onMatchInternal(m: TreeNode): Unit
 
   final override def matches: Int = _matches
 }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Concat.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Concat.scala
@@ -1,8 +1,7 @@
 package com.atomist.tree.content.text.microgrammar
 
 import com.atomist.tree.ContainerTreeNode
-import com.atomist.tree.content.text.SimpleMutableContainerTreeNode
-import com.atomist.tree.content.text.microgrammar.PatternMatch.MatchedNode
+import com.atomist.tree.content.text.{PositionedTreeNode, SimpleMutableContainerTreeNode}
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
@@ -40,7 +39,7 @@ case class Concat(left: Matcher, right: Matcher, name: String = Concat.DefaultCo
             None
           case Some(rightMatch) =>
             // Both match.
-            val mergedTree: Option[MatchedNode] = (leftMatch.node, rightMatch.node) match {
+            val mergedTree: Option[PositionedTreeNode] = (leftMatch.node, rightMatch.node) match {
               case (None, None) => None
               case (Some(l), None) => Some(l)
               case (None, Some(r)) => Some(r)

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Matcher.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Matcher.scala
@@ -2,7 +2,6 @@ package com.atomist.tree.content.text.microgrammar
 
 import com.atomist.tree.MutableTreeNode
 import com.atomist.tree.content.text._
-import com.atomist.tree.content.text.microgrammar.PatternMatch.MatchedNode
 
 case class MatcherConfig(
                           greedy: Boolean = true
@@ -28,9 +27,10 @@ trait Matcher {
   final def matchPrefix(is: InputState) = {
     val matchedOption = matchPrefixInternal(is)
 
-    for {matched <- matchedOption
-         node <- matched.node} {
-        node.addType(name)
+    for {
+      matched <- matchedOption
+      node <- matched.node} {
+      node.asInstanceOf[MutableTreeNode].addType(name)
     }
     matchedOption
   }
@@ -76,20 +76,15 @@ trait ConfigurableMatcher extends Matcher {
   def config: MatcherConfig
 }
 
-object PatternMatch {
-
-  type MatchedNode = PositionedTreeNode with MutableTreeNode
-}
-
 /**
   * Returned for a pattern match.
   *
-  * @param node    matched node. If None, the match is discarded.
-  * @param matched the string that was matched
-  * @param resultingInputState   resulting InputState
+  * @param node                matched node. If None, the match is discarded.
+  * @param matched             the string that was matched
+  * @param resultingInputState resulting InputState
   */
 case class PatternMatch(
-                         node: Option[MatchedNode],
+                         node: Option[PositionedTreeNode],
                          matched: String,
                          resultingInputState: InputState,
                          matcherId: String)

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -52,9 +52,7 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
         case None =>
           is = is.advance
         case Some(matchFound) =>
-          listeners.foreach(l => matchFound.node collect {
-            case ctn: ContainerTreeNode => l.onMatch(ctn)
-          })
+          listeners.foreach(l => matchFound.node.map(l.onMatch(_)))
           val thisStartedAt = OffsetInputPosition(is.offset)
           matches.append(matchFound -> thisStartedAt)
           is = matchFound.resultingInputState

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -1,10 +1,9 @@
 package com.atomist.tree.content.text.microgrammar
 
 import com.atomist.tree.content.text.TreeNodeOperations._
-import com.atomist.tree.content.text.grammar.MatchListener
 import com.atomist.tree.content.text._
-import com.atomist.tree.content.text.microgrammar.PatternMatch.MatchedNode
-import com.atomist.tree.{ContainerTreeNode, TerminalTreeNode, TreeNode}
+import com.atomist.tree.content.text.grammar.MatchListener
+import com.atomist.tree.{ContainerTreeNode, TreeNode}
 
 import scala.collection.mutable.ListBuffer
 

--- a/src/main/scala/com/atomist/tree/pathexpression/AxisSpecifier.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/AxisSpecifier.scala
@@ -39,13 +39,11 @@ object Descendant extends AxisSpecifier {
 
   // TODO this is very inefficient and needs to be optimized.
   // Subclasses can help, or knowing a plan
-  def allDescendants(tn: TreeNode): Seq[TreeNode] = tn match {
-    case ctn: ContainerTreeNode =>
-      val v = new SaveAllDescendantsVisitor
-      ctn.accept(v, 0)
-      // Remove this node
-      v.nodes.diff(Seq(tn))
-    case x => Nil
+  def allDescendants(tn: TreeNode): Seq[TreeNode] = {
+    val v = new SaveAllDescendantsVisitor
+    tn.accept(v, 0)
+    // Remove this node
+    v.nodes.diff(Seq(tn))
   }
 
   private class SaveAllDescendantsVisitor extends Visitor {
@@ -53,8 +51,6 @@ object Descendant extends AxisSpecifier {
     private val _nodes = ListBuffer.empty[TreeNode]
 
     override def visit(v: Visitable, depth: Int): Boolean = v match {
-      //    case ctn: ContainerTreeNode =>
-      //      true
       case tn: TreeNode =>
         _nodes.append(tn)
         true

--- a/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
@@ -44,21 +44,15 @@ abstract class PredicatedNodeTest(name: String, predicate: Predicate) extends No
     */
   protected def sourceNodes(tn: TreeNode, axis: AxisSpecifier, typeRegistry: TypeRegistry): ExecutionResult = axis match {
     case Self => ExecutionResult(List(tn))
-    case Child => tn match {
-      case ctn: ContainerTreeNode =>
-        val kids = ctn.childNodes.toList
-        ExecutionResult(kids)
-      case x => ExecutionResult.empty
-    }
+    case Child =>
+      val kids = tn.childNodes.toList
+      ExecutionResult(kids)
+
     case Descendant =>
       val kids = Descendant.allDescendants(tn).toList
       ExecutionResult(kids)
     case NavigationAxis(propertyName) =>
-      val nodes = tn match {
-        case ctn: ContainerTreeNode =>
-          ctn.childrenNamed(propertyName)
-        case _ => Nil
-      }
+      val nodes = tn.childrenNamed(propertyName)
       ExecutionResult(nodes)
   }
 }

--- a/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
@@ -127,19 +127,16 @@ case class PropertyValuePredicate(property: String, expectedValue: String) exten
                         returnedNodes: Seq[TreeNode],
                         ee: ExpressionEngine,
                         typeRegistry: TypeRegistry,
-                        nodePreparer: Option[NodePreparer]): Boolean =
-      n match {
-        case ctn: ContainerTreeNode =>
-          val extracted = ctn.childrenNamed(property)
-          if (extracted.size == 1) {
-            val result = extracted.head.value.equals(expectedValue)
-            //println(s"Comparing property [$property] of [${extracted.head.value}] against expected [$expectedValue] gave $result")
-            result
-          }
-          else
-            false
-        case _ => false
-      }
+                        nodePreparer: Option[NodePreparer]): Boolean = {
+    val extracted = n.childrenNamed(property)
+    if (extracted.size == 1) {
+      val result = extracted.head.value.equals(expectedValue)
+      //println(s"Comparing property [$property] of [${extracted.head.value}] against expected [$expectedValue] gave $result")
+      result
+    }
+    else
+      false
+  }
 }
 
 case class NodeNamePredicate(expectedName: String) extends Predicate {

--- a/src/main/scala/com/atomist/tree/treeNode.scala
+++ b/src/main/scala/com/atomist/tree/treeNode.scala
@@ -42,13 +42,6 @@ trait TreeNode extends Visitable {
   @ExportFunction(readOnly = true, description = "Node content")
   def value: String
 
-}
-
-/**
-  * TreeNode that can contain other TreeNodes.
-  */
-trait ContainerTreeNode extends TreeNode {
-
   /**
     * Return all children of this node
     *
@@ -90,9 +83,21 @@ trait ContainerTreeNode extends TreeNode {
 }
 
 /**
-  * Terminal TreeNode. Contains a simple string value.
+  * Tag interface for TreeNodes that are intended to contain other TreeNodes.
+  */
+trait ContainerTreeNode extends TreeNode
+
+/**
+  * Convenient supertrait for terminal TreeNodes. Contains a simple string value.
   */
 trait TerminalTreeNode extends TreeNode {
 
-  override def accept(v: Visitor, depth: Int): Unit = v.visit(this, depth)
+  final override def accept(v: Visitor, depth: Int): Unit = v.visit(this, depth)
+
+  final override def childNodeNames: Set[String] = Set()
+
+  final override def childNodeTypes: Set[String] = Set()
+
+  final override def childrenNamed(key: String): Seq[TreeNode] = Nil
+
 }

--- a/src/main/scala/com/atomist/tree/treeNode.scala
+++ b/src/main/scala/com/atomist/tree/treeNode.scala
@@ -66,11 +66,6 @@ trait TreeNode extends Visitable {
       childNodes.foreach(_.accept(v, depth + 1))
   }
 
-  def dirty: Boolean =
-    (childNodes collect {
-      case u: MutableTreeNode if u.dirty => u
-    }).nonEmpty
-
   def count: Int = childNodes.size
 
   /**

--- a/src/main/scala/com/atomist/tree/utils/TreeNodeFinders.scala
+++ b/src/main/scala/com/atomist/tree/utils/TreeNodeFinders.scala
@@ -7,41 +7,33 @@ import com.atomist.tree.{ContainerTreeNode, TerminalTreeNode, TreeNode}
   */
 object TreeNodeFinders {
 
-  def requiredSingleChild(parent: TreeNode): TreeNode = parent match {
-    case ctn: ContainerTreeNode =>
-      if (ctn.childNodes.size != 1)
-        throw new IllegalArgumentException(s"Found ${ctn.childNodes.size} matches rather than 1 under " +
-          s"${parent.nodeName}:${parent.nodeType}[${parent.value}] with children [${ctn.childNodeNames.mkString(",")}]")
-      else ctn.childNodes.head
-    case x => ???
+  def requiredSingleChild(parent: TreeNode): TreeNode = {
+    if (parent.childNodes.size != 1)
+      throw new IllegalArgumentException(s"Found ${parent.childNodes.size} matches rather than 1 under " +
+        s"${parent.nodeName}:${parent.nodeType}[${parent.value}] with children [${parent.childNodeNames.mkString(",")}]")
+    else parent.childNodes.head
   }
 
-  def requiredSingleChild(parent: TreeNode, name: String): TreeNode = parent match {
-    case ctn: ContainerTreeNode =>
-      val hits = ctn.childrenNamed(name)
-      if (hits.size != 1)
-        throw new IllegalArgumentException(s"Found ${hits.size} matches rather than 1 for [$name] in " +
-          s"${parent.nodeName}:${parent.nodeType}[${parent.value}] with children [${ctn.childNodeNames.mkString(",")}]")
-      else hits.head
-    case x => ???
+  def requiredSingleChild(parent: TreeNode, name: String): TreeNode = {
+    val hits = parent.childrenNamed(name)
+    if (hits.size != 1)
+      throw new IllegalArgumentException(s"Found ${hits.size} matches rather than 1 for [$name] in " +
+        s"${parent.nodeName}:${parent.nodeType}[${parent.value}] with children [${parent.childNodeNames.mkString(",")}]")
+    else hits.head
   }
 
-  def singleChild(parent: TreeNode, name: String): Option[TreeNode] = parent match {
-    case ctn: ContainerTreeNode =>
-      val hits = ctn.childrenNamed(name)
-      if (hits.size == 1)
-        Some(hits.head)
-      else None
-    case x => None
+  def singleChild(parent: TreeNode, name: String): Option[TreeNode] = {
+    val hits = parent.childrenNamed(name)
+    if (hits.size == 1)
+      Some(hits.head)
+    else None
   }
 
-  def requiredSingleFieldValue(parent: TreeNode, name: String): String = parent match {
-    case ctn: ContainerTreeNode =>
-      ctn.childrenNamed(name) match {
-        case Seq(tn: TerminalTreeNode) => tn.value
-        case Nil =>  throw new IllegalArgumentException(s"Found no fields for [$name] in $parent: Needed exactly 1")
-      }
-    case _ => ???
+  def requiredSingleFieldValue(parent: TreeNode, name: String): String = {
+    parent.childrenNamed(name) match {
+      case Seq(tn: TerminalTreeNode) => tn.value
+      case Nil => throw new IllegalArgumentException(s"Found no fields for [$name] in $parent: Needed exactly 1")
+    }
   }
 
   /**
@@ -52,13 +44,9 @@ object TreeNodeFinders {
     * @param in       where to look
     * @return sequence of field values
     */
-  def findByName(nodeName: String, in: TreeNode): Seq[TreeNode] = in match {
-    case ofv: ContainerTreeNode =>
-      (ofv.childNodes collect {
+  def findByName(nodeName: String, in: TreeNode): Seq[TreeNode] =
+      (in.childNodes collect {
         case hasName if hasName.nodeName.equals(nodeName) => Seq(hasName)
         case whatever => findByName(nodeName, whatever)
       }).flatten
-
-    case _ => Nil
-  }
 }

--- a/src/main/scala/com/atomist/tree/utils/TreeNodeUtils.scala
+++ b/src/main/scala/com/atomist/tree/utils/TreeNodeUtils.scala
@@ -42,8 +42,8 @@ object TreeNodeUtils {
       s"${f.nodeName} (${f.getClass.getSimpleName}#${f.hashCode()}) ${offset(f)}:[${showValue(f, 50)}]"
 
     def toShortStr(fv: TreeNode, depth: Int): String = fv match {
-      case ofv: ContainerTreeNode =>
-        tabs(depth) + info(ofv) + (if (ofv.childNodes.nonEmpty) ":\n" else "") + ofv.childNodes.map(toShortStr(_, depth + 1)).mkString("\n")
+      case ctn: ContainerTreeNode =>
+        tabs(depth) + info(ctn) + (if (ctn.childNodes.nonEmpty) ":\n" else "") + ctn.childNodes.map(toShortStr(_, depth + 1)).mkString("\n")
       case f => tabs(depth) + info(f) + "\n"
     }
 

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandlerTest.scala
@@ -10,7 +10,7 @@ import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
 import com.atomist.rug.TestUtils
 import com.atomist.rug.kind.service.{Action, ActionRegistry, Callback, ConsoleMessageBuilder, Rug}
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
-import com.atomist.tree.TreeNode
+import com.atomist.tree.{TerminalTreeNode, TreeNode}
 import com.atomist.tree.pathexpression.PathExpression
 import com.atomist.util.Visitor
 import org.scalatest.{FlatSpec, Matchers}
@@ -125,7 +125,7 @@ object SimpleActionRegistry extends ActionRegistry {
 
   override def findByName(name: String): Action = Action(name, Callback(rug), new util.ArrayList[ParameterValue]())
 
-  override def bindParameter(action: Action, name: String, value: Object) = {
+  override def bindParameter(action: Action, name: String, value: Object): Action = {
     val params = new util.ArrayList[ParameterValue](action.parameters)
     params.add(SimpleParameterValue(name,value))
     Action(action.title,action.callback,params)
@@ -134,19 +134,10 @@ object SimpleActionRegistry extends ActionRegistry {
 
 object SysEvent extends SystemEvent ("blah", "issue", 0l)
 
-class IssueTreeNode extends TreeNode {
-  /**
-    * Name of the node. This may vary with individual nodes: For example,
-    * with files. However, node names do not always need to be unique.
-    *
-    * @return name of the individual node
-    */
+class IssueTreeNode extends TerminalTreeNode {
+
   override def nodeName: String = "issue"
 
-  /**
-    * All nodes have values: Either a terminal value or the
-    * values built up from subnodes.
-    */
   override def value: String = "blah"
 
   def state(): String = "closed"
@@ -157,7 +148,6 @@ class IssueTreeNode extends TreeNode {
 
   val owner: String = "atomist"
 
-  override def accept(v: Visitor, depth: Int): Unit = ???
 }
 
 object TestTreeMaterializer extends TreeMaterializer {

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarTest.scala
@@ -1,10 +1,9 @@
 package com.atomist.tree.content.text.microgrammar
 
-import com.atomist.tree.{ContainerTreeNode, SimpleTerminalTreeNode, TerminalTreeNode, TreeNode}
-import com.atomist.tree.content.text.{MutableContainerTreeNode, MutableTerminalTreeNode, TreeNodeOperations}
 import com.atomist.tree.content.text.grammar.{AbstractMatchListener, MatchListener, PositionalString}
 import com.atomist.tree.content.text.microgrammar.matchers.Break
-import com.atomist.tree.utils.TreeNodeUtils
+import com.atomist.tree.content.text.{MutableContainerTreeNode, MutableTerminalTreeNode}
+import com.atomist.tree.{ContainerTreeNode, SimpleTerminalTreeNode, TerminalTreeNode, TreeNode}
 import org.scalatest.{FlatSpec, Matchers}
 
 class MatcherMicrogrammarTest extends FlatSpec with Matchers {
@@ -330,10 +329,10 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
   }
 
   class SavingMatchListener extends AbstractMatchListener("test") {
-    var hits: List[ContainerTreeNode] = Nil
+    var hits: List[TreeNode] = Nil
     var skipped: List[PositionalString] = Nil
 
-    override protected def onMatchInternal(m: ContainerTreeNode): Unit = {
+    override protected def onMatchInternal(m: TreeNode): Unit = {
       hits = hits :+ m
     }
 

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarUsageInPathExpressionTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarUsageInPathExpressionTest.scala
@@ -38,11 +38,9 @@ class MicrogrammarUsageInPathExpressionTest extends FlatSpec with Matchers {
       case mtn: MutableTreeNode =>
         mtn.update(highlyImprobableValue)
         val newContent = pmv.findFile("pom.xml").content
-        println(s"New content=\n$newContent")
         newContent.contains(highlyImprobableValue) should be(true)
       case x =>
-        println(s"what is this $x")
-        fail
+        fail(s"What is this? $x")
 
     }
   }


### PR DESCRIPTION
Pulled methods from ContainerTreeNode up. ContainerTreeNode is now a tag trait, which eliminates the need for matching in many places.