### PR TITLE
Reduced dependency on MutableView: Instead using TreeNode directly.

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/core/FileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class FileType(
                 evaluator: Evaluator
@@ -22,7 +23,7 @@ class FileType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     (selected.kind, context) match {
@@ -36,7 +37,7 @@ class FileType(
 
   override type Self = this.type
 
-  override def findAllIn(context: MutableView[_]): Option[Seq[MutableView[_]]] = context match {
+  override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = context match {
     case pmv: ProjectMutableView =>
       Some(pmv.currentBackingObject.allFiles.map(f => new FileMutableView(f, pmv)))
     case x => None

--- a/src/main/scala/com/atomist/rug/kind/core/LineType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/LineType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 /**
   * Type representing a line within a file
@@ -29,7 +30,7 @@ class LineType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/core/ProjectType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/ProjectType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class ProjectType(
                    evaluator: Evaluator
@@ -24,9 +25,9 @@ class ProjectType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
-                                   identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
+                                   identifierMap: Map[String, Object]): Option[Seq[TreeNode]] = {
     // Special case where we want only one
     context match {
       case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/docker/DockerFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/docker/DockerFileType.scala
@@ -7,6 +7,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 import scala.collection.immutable.Map
 
@@ -29,9 +30,9 @@ class DockerFileType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
-                                   identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
+                                   identifierMap: Map[String, Object]): Option[Seq[TreeNode]] = {
     context match {
       case pmv: ProjectMutableView =>
         Some(pmv.currentBackingObject

--- a/src/main/scala/com/atomist/rug/kind/dynamic/DefaultViewFinder.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/DefaultViewFinder.scala
@@ -20,8 +20,8 @@ class DefaultViewFinder(typeRegistry: TypeRegistry)
     * Finds views, first looking at children of current scope,
     * then identifiers in scope, then global identifiers.
     */
-  override def findAllIn(rugAs: ArtifactSource, selected: Selected, context: MutableView[_],
-                         poa: ProjectOperationArguments, identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
+  override def findAllIn(rugAs: ArtifactSource, selected: Selected, context: TreeNode,
+                         poa: ProjectOperationArguments, identifierMap: Map[String, Object]): Option[Seq[TreeNode]] = {
 
     val fromIdentifierInScope: Option[Seq[MutableView[_]]] = identifierMap.get(selected.kind).flatMap(typ => {
       logger.debug(s"Getting type '${selected.kind}' from $typ")
@@ -60,7 +60,7 @@ class DefaultViewFinder(typeRegistry: TypeRegistry)
       }
     })
 
-    val childOfCurrentContext: Option[Seq[MutableView[_]]] =
+    val childOfCurrentContext: Option[Seq[TreeNode]] =
       if (context.childNodeTypes.contains(selected.kind))
         Some(context.childrenNamed(selected.kind).collect {
           case mv: MutableView[_] => mv
@@ -71,7 +71,7 @@ class DefaultViewFinder(typeRegistry: TypeRegistry)
         })
       else None
 
-    val fromGlobalTypes: Option[Seq[MutableView[_]]] =
+    val fromGlobalTypes: Option[Seq[TreeNode]] =
       typeRegistry.findByName(selected.kind) flatMap {
         case t: Type =>
           t.findIn(rugAs, selected, context, poa, identifierMap)

--- a/src/main/scala/com/atomist/rug/kind/elm/ElmModuleType.scala
+++ b/src/main/scala/com/atomist/rug/kind/elm/ElmModuleType.scala
@@ -7,6 +7,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class ElmModuleType(
                      evaluator: Evaluator
@@ -27,7 +28,7 @@ class ElmModuleType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/java/JavaProjectMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/JavaProjectMutableView.scala
@@ -10,6 +10,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.{ArtifactSource, FileArtifact}
+import com.atomist.tree.TreeNode
 import com.atomist.util.lang.JavaHelpers
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
@@ -17,7 +18,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
 import scala.collection.JavaConverters._
 
 class JavaProjectType(
-                                    evaluator: Evaluator
+                       evaluator: Evaluator
                                   )
   extends Type(evaluator)
     with ReflectivelyTypedType {
@@ -30,7 +31,7 @@ class JavaProjectType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/java/JavaSourceType.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/JavaSourceType.scala
@@ -7,6 +7,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 import com.typesafe.scalalogging.LazyLogging
 
 /**
@@ -31,7 +32,7 @@ class JavaSourceType(evaluator: Evaluator)
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/java/JavaTypeType.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/JavaTypeType.scala
@@ -9,6 +9,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr.{MarkerAnnotationExpr, NameExpr}
 
@@ -35,7 +36,7 @@ class JavaTypeType(evaluator: Evaluator)
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] =
     context match {

--- a/src/main/scala/com/atomist/rug/kind/java/SpringBootProjectMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/SpringBootProjectMutableView.scala
@@ -9,6 +9,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 import com.atomist.util.lang.JavaHelpers
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
@@ -33,7 +34,7 @@ class SpringBootProjectType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/js/PackageJsonType.scala
+++ b/src/main/scala/com/atomist/rug/kind/js/PackageJsonType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class PackageJsonType(
                        evaluator: Evaluator
@@ -21,7 +22,7 @@ class PackageJsonType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/json/JsonType.scala
+++ b/src/main/scala/com/atomist/rug/kind/json/JsonType.scala
@@ -31,7 +31,7 @@ class JsonType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/pom/EveryPomType.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/EveryPomType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 /**
   * Maven POM type
@@ -26,7 +27,7 @@ class EveryPomType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/pom/PomType.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/PomType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 /**
   * Maven POM type
@@ -26,7 +27,7 @@ class PomType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/properties/PropertiesType.scala
+++ b/src/main/scala/com/atomist/rug/kind/properties/PropertiesType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class PropertiesType(
                       evaluator: Evaluator
@@ -21,7 +22,7 @@ class PropertiesType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
@@ -7,6 +7,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.{ArtifactSource, FileArtifact}
+import com.atomist.tree.TreeNode
 
 /**
   * Contains aliases for navigation down simplified AST.
@@ -48,7 +49,7 @@ class PythonFileType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonRequirementsTxtType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonRequirementsTxtType.scala
@@ -9,6 +9,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.{ArtifactSource, FileArtifact}
+import com.atomist.tree.TreeNode
 
 class RequirementsType(
                         evaluator: Evaluator
@@ -24,7 +25,7 @@ class RequirementsType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {
@@ -58,7 +59,9 @@ class PythonRequirementsTxtType(
 
   override def description = "Python requirements text file"
 
-  override protected def findAllIn(rugAs: ArtifactSource, selected: Selected, context: MutableView[_],
+  override protected def findAllIn(rugAs: ArtifactSource,
+                                   selected: Selected,
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/rug/archive/RugArchiveProjectType.scala
+++ b/src/main/scala/com/atomist/rug/kind/rug/archive/RugArchiveProjectType.scala
@@ -3,6 +3,7 @@ package com.atomist.rug.kind.rug.archive
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.runtime.rugdsl.DefaultEvaluator
 import com.atomist.rug.spi.{ReflectivelyTypedType, Type}
+import com.atomist.tree.TreeNode
 
 class RugArchiveProjectType
   extends Type(DefaultEvaluator)
@@ -15,7 +16,7 @@ class RugArchiveProjectType
   // Members declared in com.atomist.rug.kind.dynamic.ViewFinder
   protected def findAllIn(rugAs: com.atomist.source.ArtifactSource,
                           selected: com.atomist.rug.parser.Selected,
-                          context: com.atomist.rug.spi.MutableView[_],
+                          context: TreeNode,
                           poa: com.atomist.project.ProjectOperationArguments,
                           identifierMap: Map[String,Object]): Option[Seq[com.atomist.rug.spi.MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/rug/dsl/RugType.scala
+++ b/src/main/scala/com/atomist/rug/kind/rug/dsl/RugType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.Evaluator
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.{ArtifactSource, FileArtifact}
+import com.atomist.tree.TreeNode
 
 class EditorType(evaluator: Evaluator) extends Type(evaluator) with ReflectivelyTypedType {
   /** Describe the MutableView subclass to allow for reflective function export */
@@ -14,7 +15,7 @@ class EditorType(evaluator: Evaluator) extends Type(evaluator) with Reflectively
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] =
     context match {

--- a/src/main/scala/com/atomist/rug/kind/service/ServicesType.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/ServicesType.scala
@@ -7,6 +7,7 @@ import com.atomist.rug.parser.{RunOtherOperation, Selected}
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class ServicesType(
                     evaluator: Evaluator
@@ -22,7 +23,7 @@ class ServicesType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/xml/XmlType.scala
+++ b/src/main/scala/com/atomist/rug/kind/xml/XmlType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class XmlType(
                evaluator: Evaluator
@@ -21,7 +22,7 @@ class XmlType(
 
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/yml/YmlType.scala
+++ b/src/main/scala/com/atomist/rug/kind/yml/YmlType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 class YmlType(
                evaluator: Evaluator
@@ -29,7 +30,7 @@ class YmlType(
   //  }
   override protected def findAllIn(rugAs: ArtifactSource,
                                    selected: Selected,
-                                   context: MutableView[_],
+                                   context: TreeNode,
                                    poa: ProjectOperationArguments,
                                    identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = ???
 

--- a/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectPredicate.scala
+++ b/src/main/scala/com/atomist/rug/runtime/rugdsl/RugDrivenProjectPredicate.scala
@@ -10,6 +10,7 @@ import com.atomist.rug.kind.dynamic.ViewFinder
 import com.atomist.rug.parser.{Computation, DoStep, With}
 import com.atomist.rug.spi.{MutableView, TypeRegistry}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 /**
   * A Rug predicate enables use of Rug matching and navigation syntax to return true/false results.
@@ -54,7 +55,7 @@ class RugDrivenProjectPredicate(
                                        withBlock: With,
                                        poa: ProjectOperationArguments,
                                        identifierMap: Map[String, Object],
-                                       t: MutableView[_]): PartialFunction[DoStep, Object] = {
+                                       t: TreeNode): PartialFunction[DoStep, Object] = {
     case _ =>
       reviewContext.comment(ReviewComment("anything will do", Severity.FINE))
       null

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MicrogrammarTypeProvider.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MicrogrammarTypeProvider.scala
@@ -3,6 +3,7 @@ package com.atomist.tree.content.text.microgrammar
 import com.atomist.rug.kind.core.{FileArtifactBackedMutableView, FileType}
 import com.atomist.rug.kind.dynamic.{ChildResolver, MutableContainerMutableView, MutableTreeNodeUpdater}
 import com.atomist.rug.spi.{MutableView, TypeProvider, Typed}
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.grammar.MatchListener
 
@@ -27,7 +28,7 @@ class MicrogrammarTypeProvider(microgrammar: Microgrammar)
     */
   override def resolvesFromNodeTypes: Set[String] = Set(Typed.typeClassToTypeName(classOf[FileType]))
 
-  override def findAllIn(context: MutableView[_]): Option[Seq[MutableView[_]]] = context match {
+  override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
     case f: FileArtifactBackedMutableView =>
       val l: Option[MatchListener] = None
       val views = microgrammar.findMatches(f.content, l) collect {

--- a/src/test/scala/com/atomist/rug/kind/test/ReplacerCljType.scala
+++ b/src/test/scala/com/atomist/rug/kind/test/ReplacerCljType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectiveStaticTypeInformation, Type, TypeInformation}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 
 import scala.reflect.ManifestFactory
 
@@ -23,7 +24,7 @@ class ReplacerCljType(ev: Evaluator) extends Type(ev) {
 
   protected def listViews(rugAs: ArtifactSource,
                           selected: Selected,
-                          context: MutableView[_],
+                          context: TreeNode,
                           poa: ProjectOperationArguments,
                           identifierMap: Map[String, AnyRef]): Seq[MutableView[_]] = context match {
     case pmv: ProjectMutableView =>
@@ -32,8 +33,11 @@ class ReplacerCljType(ev: Evaluator) extends Type(ev) {
     case _ => Nil
   }
 
-  def findAllIn(rugAs: ArtifactSource, selected: Selected, context: MutableView[_],
-                poa: ProjectOperationArguments, identifierMap: Map[String, AnyRef]): Option[Seq[MutableView[_]]] = {
+  def findAllIn(rugAs: ArtifactSource,
+                selected: Selected,
+                context: TreeNode,
+                poa: ProjectOperationArguments,
+                identifierMap: Map[String, AnyRef]): Option[Seq[MutableView[_]]] = {
     val l = listViews(rugAs, selected, context, poa, identifierMap)
     Option.apply(l)
   }

--- a/src/test/scala/com/atomist/rug/kind/test/ReplacerType.scala
+++ b/src/test/scala/com/atomist/rug/kind/test/ReplacerType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi.{MutableView, ReflectiveStaticTypeInformation, Type, TypeInformation}
 import com.atomist.source.ArtifactSource
+import com.atomist.tree.TreeNode
 import org.springframework.beans.factory.annotation.Autowired
 
 import scala.reflect.ManifestFactory
@@ -26,7 +27,7 @@ class ReplacerType(ev: Evaluator) extends Type(ev) {
 
   protected def listViews(rugAs: ArtifactSource,
                           selected: Selected,
-                          context: MutableView[_],
+                          context: TreeNode,
                           poa: ProjectOperationArguments,
                           identifierMap: Map[String, AnyRef]): Seq[MutableView[_]] = context match {
     case pmv: ProjectMutableView =>
@@ -35,7 +36,7 @@ class ReplacerType(ev: Evaluator) extends Type(ev) {
     case _ => Nil
   }
 
-  def findAllIn(rugAs: ArtifactSource, selected: Selected, context: MutableView[_],
+  def findAllIn(rugAs: ArtifactSource, selected: Selected, context: TreeNode,
                 poa: ProjectOperationArguments, identifierMap: Map[String, AnyRef]): Option[Seq[MutableView[_]]] = {
     val l = listViews(rugAs, selected, context, poa, identifierMap)
     Option.apply(l)


### PR DESCRIPTION
View resolvers now look under `TreeNode` instead of `MutableView`. This is a first step on what might amount to removing the need for `MutableView`s altogether.

Note that there are a couple of classes where there's a hacky cast to get to the `evaluator` property of `MutableView`. This isn't a concern as those classes will go when the Rug -> TypeScript transpiler is ready.