### PR TITLE
First version of support for types implemented in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Support for a new TS (JS) Handler programming model as per
     https://github.com/atomist/rug/issues/105
 
+-   Support for Type extensions/TreeNode written in TypeScript as
+    per https://github.com/atomist/rug/issues/214
+
 ### Fixed
 
 -   TS generators are now passed project name as second argument as

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingExecutor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingExecutor.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.runtime.js
 
 import com.atomist.project.{Executor, ProjectOperationArguments}
 import com.atomist.rug.kind.service.{ServiceSource, ServicesMutableView, ServicesType}
-import com.atomist.rug.runtime.js.interop.SafeCommittingProxy
+import com.atomist.rug.runtime.js.interop.jsSafeCommittingProxy
 import com.atomist.source.ArtifactSource
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
@@ -18,7 +18,7 @@ class JavaScriptInvokingExecutor(
 
   override def execute(serviceSource: ServiceSource, poa: ProjectOperationArguments): Unit = {
     val smv = new ServicesMutableView(rugAs, serviceSource)
-    val wsmv = new SafeCommittingProxy(new ServicesType, smv)
+    val wsmv = new jsSafeCommittingProxy(new ServicesType, smv)
     //val reviewContext = new ReviewContext
     invokeMemberWithParameters("execute", wsmv, poa)
   }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperation.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperation.scala
@@ -7,7 +7,7 @@ import com.atomist.rug.{InvalidRugParameterDefaultValue, InvalidRugParameterPatt
 import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.parser.DefaultIdentifierResolver
-import com.atomist.rug.runtime.js.interop.SafeCommittingProxy
+import com.atomist.rug.runtime.js.interop.jsSafeCommittingProxy
 import com.atomist.rug.runtime.rugdsl.ContextAwareProjectOperation
 import com.atomist.rug.spi.TypeRegistry
 import com.atomist.source.ArtifactSource
@@ -155,8 +155,8 @@ abstract class JavaScriptInvokingProjectOperation(
     * @param pmv project to wrap
     * @return proxy TypeScript callers can use
     */
-  protected def wrapProject(pmv: ProjectMutableView): SafeCommittingProxy = {
-    new SafeCommittingProxy(projectType, pmv)
+  protected def wrapProject(pmv: ProjectMutableView): jsSafeCommittingProxy = {
+    new jsSafeCommittingProxy(projectType, pmv)
   }
 
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProvider.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProvider.scala
@@ -1,0 +1,63 @@
+package com.atomist.rug.runtime.js.interop
+
+import java.util.Objects
+
+import com.atomist.rug.kind.core.FileType
+import com.atomist.rug.kind.dynamic.{ChildResolver, MutableContainerMutableView}
+import com.atomist.rug.spi.{TypeProvider, Typed}
+import com.atomist.tree.TreeNode
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+
+import scala.collection.JavaConverters._
+import NashornUtils._
+
+/**
+  * Type provider backed by a JavaScript object
+  */
+class JavaScriptBackedTypeProvider(
+                                    jsTypeProvider: ScriptObjectMirror)
+  extends TypeProvider(classOf[MutableContainerMutableView])
+    with ChildResolver {
+
+  override val name: String = stringProperty(jsTypeProvider, "typeName")
+
+  override def description: String = s"JavaScript-backed type [$name]"
+
+  override def resolvesFromNodeTypes: Set[String] =
+    Set(Typed.typeClassToTypeName(classOf[FileType]))
+
+  override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = {
+    val r = jsTypeProvider.callMember("find", context)
+    val nodes: Seq[TreeNode] = toScalaSeq(r).map(e =>
+      new ScriptObjectBackedTreeNode(e.asInstanceOf[ScriptObjectMirror])
+    )
+    Some(nodes)
+  }
+}
+
+
+/**
+  * TreeNode backed by a JavaScript object
+  */
+private class ScriptObjectBackedTreeNode(som: ScriptObjectMirror) extends TreeNode {
+
+  override def nodeName: String = stringFunction(som, "nodeName")
+
+  lazy val kids: Seq[TreeNode] =
+    toScalaSeq(som.callMember("children")) map {
+      case som: ScriptObjectMirror => new ScriptObjectBackedTreeNode(som)
+    }
+
+  override def nodeType: Set[String] =
+    toScalaSeq(som.callMember("nodeType")).map(s => Objects.toString(s)).toSet
+
+  override def value: String = stringFunction(som, "value")
+
+  override def childNodeNames: Set[String] = kids.map(k => k.nodeName).toSet
+
+  override def childNodeTypes: Set[String] = kids.flatMap(k => k.nodeType).toSet
+
+  override def childrenNamed(key: String): Seq[TreeNode] =
+    kids.filter(k => k.nodeName == key)
+
+}

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/NashornUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/NashornUtils.scala
@@ -17,7 +17,16 @@ object NashornUtils {
 
   def toJavaType(nashornReturn: Object): Object = nashornReturn match {
     case s: ConsString => s.toString
+    case r: ScriptObjectMirror if r.isArray =>
+      //println(s"Array size is ${r.values().size()}")
+      r.values().asScala
     case x => x
+  }
+
+  def toScalaSeq(nashornReturn: Object): Seq[Object] = nashornReturn match {
+    case r: ScriptObjectMirror if r.isArray =>
+      //println(s"Array size is ${r.values().size()}")
+      r.values().asScala.toSeq
   }
 
   /**
@@ -25,6 +34,16 @@ object NashornUtils {
     */
   def stringProperty(som: ScriptObjectMirror, name: String): String = {
     som.get(name) match {
+      case null => null
+      case x => Objects.toString(x)
+    }
+  }
+
+  /**
+    * Call the given JavaScript function, which must return a string
+    */
+  def stringFunction(som: ScriptObjectMirror, name: String): String = {
+    som.callMember(name) match {
       case null => null
       case x => Objects.toString(x)
     }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/SafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/SafeCommittingProxy.scala
@@ -44,9 +44,12 @@ class SafeCommittingProxy(types: Set[Typed],
           // Navigation on a node
           new FixedReturnProxy(name, node)
         }
-        else
-          throw new RugRuntimeException(null,
+        else node match {
+          case sobtn: ScriptObjectBackedTreeNode =>
+            sobtn.invoke(name)
+          case _ => throw new RugRuntimeException(null,
             s"Attempt to invoke method [$name] on type [${typ.name}]: No exported method with that name: Found $possibleOps")
+        }
       }
       else
         new MethodInvocationProxy(name, possibleOps)

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -76,6 +76,10 @@ class jsPathExpressionEngine(
       matcherRegistry += parsedMatcher
       val mg = new MatcherMicrogrammar(parsedMatcher, name)
       new MicrogrammarTypeProvider(mg)
+    case som: ScriptObjectMirror if hasDefinedProperties(som, "typeName") =>
+      // It's a type provider coded in JavaScript
+      val tp = new JavaScriptBackedTypeProvider(som)
+      tp
     case x =>
       throw new RugRuntimeException(null, s"Unrecognized dynamic type $x")
 

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -119,7 +119,7 @@ class jsPathExpressionEngine(
   // If the node is a SafeCommittingProxy, find the underlying object
   private def toTreeNode(o: Object): TreeNode = o match {
     case tn: TreeNode => tn
-    case scp: SafeCommittingProxy => scp.node
+    case scp: jsSafeCommittingProxy => scp.node
   }
 
   /**
@@ -195,7 +195,7 @@ class jsPathExpressionEngine(
       node.nodeType.flatMap(t => typeRegistry.findByName(t))
 
     def proxify(n: TreeNode): Object = n match {
-      case _ => new SafeCommittingProxy(nodeTypes(n), n, cr)
+      case _ => new jsSafeCommittingProxy(nodeTypes(n), n, cr)
     }
 
     new JavaScriptArray(

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -17,9 +17,9 @@ import jdk.nashorn.api.scripting.AbstractJSObject
   * @param types Rug types we are fronting. This is a union type.
   * @param node  node we are fronting
   */
-class SafeCommittingProxy(types: Set[Typed],
-                          val node: TreeNode,
-                          commandRegistry: CommandRegistry)
+class jsSafeCommittingProxy(types: Set[Typed],
+                            val node: TreeNode,
+                            commandRegistry: CommandRegistry)
   extends AbstractJSObject {
 
   def this(t: Typed, node: TreeNode, commandRegistry: CommandRegistry = DefaultCommandRegistry) =
@@ -29,7 +29,7 @@ class SafeCommittingProxy(types: Set[Typed],
 
   private val typ = UnionType(types)
 
-  import SafeCommittingProxy.MagicJavaScriptMethods
+  import jsSafeCommittingProxy.MagicJavaScriptMethods
 
   override def getMember(name: String): AnyRef = typ.typeInformation match {
     case _ if MagicJavaScriptMethods.contains(name) =>
@@ -118,7 +118,7 @@ class SafeCommittingProxy(types: Set[Typed],
 
 }
 
-private object SafeCommittingProxy {
+private object jsSafeCommittingProxy {
 
   /**
     * Set of JavaScript magic methods that we should let Nashorn superclass handle.

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MicrogrammarTypeProvider.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MicrogrammarTypeProvider.scala
@@ -2,7 +2,7 @@ package com.atomist.tree.content.text.microgrammar
 
 import com.atomist.rug.kind.core.{FileArtifactBackedMutableView, FileType}
 import com.atomist.rug.kind.dynamic.{ChildResolver, MutableContainerMutableView, MutableTreeNodeUpdater}
-import com.atomist.rug.spi.{MutableView, TypeProvider, Typed}
+import com.atomist.rug.spi.{TypeProvider, Typed}
 import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.grammar.MatchListener
@@ -28,7 +28,7 @@ class MicrogrammarTypeProvider(microgrammar: Microgrammar)
     */
   override def resolvesFromNodeTypes: Set[String] = Set(Typed.typeClassToTypeName(classOf[FileType]))
 
-  override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
+  override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = context match {
     case f: FileArtifactBackedMutableView =>
       val l: Option[MatchListener] = None
       val views = microgrammar.findMatches(f.content, l) collect {

--- a/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
@@ -35,7 +35,7 @@ case class ObjectType(typeName: String)
             case Some(cr) => cr.findAllIn(mv).getOrElse(Nil)
             case None =>
               throw new IllegalArgumentException(
-                s"No type with name [$typeName]: Node=$tn, Kids=$directKids")
+                s"No type with name [$typeName]: Node=$tn, Kids=$directKids, known types=[${typeRegistry.typeNames}]")
           }
         case x =>
           throw new UnsupportedOperationException(s"Type ${x.getClass} not yet supported for resolution")

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -31,6 +31,16 @@ interface TreeNode {
 
   update(newValue: string)
 
+  children(): TreeNode[]
+
+}
+
+interface TypeProvider extends DynamicType {
+
+    typeName: string
+
+    find(context: TreeNode): TreeNode[]
+
 }
 
 /*
@@ -85,5 +95,6 @@ export {Match}
 export {PathExpression}
 export {PathExpressionEngine}
 export {TreeNode}
+export {TypeProvider}
 export {DynamicType}
 export {Microgrammar}

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
@@ -84,11 +84,9 @@ class TwoLevel implements ProjectEditor {
     description: string = "Uses single microgrammar"
 
     edit(project: Project) {
-      //console.log("Editing")
       let mg = new FruitererType()
       let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
 
-      let i = 0
       eng.with<MutatingBanana>(project, "//File()/fruiterer()/mutatingBanana()", n => {
         n.mutate()
       })

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
@@ -1,0 +1,97 @@
+import {Project, File} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from '@atomist/rug/operations/RugOperation'
+
+
+class FruitererType implements TypeProvider {
+
+ typeName = "fruiterer"
+
+ private isFile(f: TreeNode): f is File {
+   return true
+ }
+
+ find(context: TreeNode): TreeNode[] {
+   if (this.isFile(context)) {
+     let f = context as File
+     console.log(f.name())
+     if (f.isJava())
+      return [ new Fruiterer(f) ]
+      else return []
+   }
+   else 
+    return []
+ }
+
+}
+
+class Fruiterer implements TreeNode {
+
+  constructor(public file: File) {}
+
+  nodeName(): string { return "fruiterer" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "" }
+
+  update(newValue: string) {}
+
+  children() { return [ new MutatingBanana(this.file), new Pear() ] }
+
+}
+
+class MutatingBanana implements TreeNode {
+
+  constructor(public file: File) {}
+
+  nodeName(): string { return "mutatingBanana" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "yellow" }
+
+  update(newValue: string) {}
+
+  children() { return [] }
+
+  mutate(): void { 
+    this.file.prepend("I am evil")
+  }
+
+}
+
+class Pear implements TreeNode {
+
+  nodeName(): string { return "pear" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "green" }
+
+  update(newValue: string) {}
+
+  children() { return [] }
+
+}
+
+class TwoLevel implements ProjectEditor {
+
+    name: string = "Constructed"
+    description: string = "Uses single microgrammar"
+
+    edit(project: Project) {
+      //console.log("Editing")
+      let mg = new FruitererType()
+      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
+
+      let i = 0
+      eng.with<MutatingBanana>(project, "//File()/fruiterer()/mutatingBanana()", n => {
+        n.mutate()
+      })
+    }
+  }
+  var editor = new TwoLevel()

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleBanana.ts
@@ -1,0 +1,53 @@
+import {Project} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from '@atomist/rug/operations/RugOperation'
+
+
+class BananaType implements TypeProvider {
+
+ typeName = "banana"
+
+ find(context: TreeNode): TreeNode[] {
+   return [ new Banana()]
+ }
+
+}
+
+class Banana implements TreeNode {
+
+  nodeName(): string { return "banana" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "yellow" }
+
+  update(newValue: string) {}
+
+  children() { return [] }
+
+}
+
+class SimpleBanana implements ProjectEditor {
+    name: string = "Constructed"
+    description: string = "Uses single microgrammar"
+
+    edit(project: Project) {
+      console.log("Editing")
+      let mg = new BananaType()
+      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
+
+      let i = 0
+      eng.with<any>(project, "//File()/banana()", n => {
+        //console.log("Checking color of banana")
+        if (n.value() != "yellow")
+         throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
+        i++
+      })
+      if (i == 0)
+       throw new Error("No bananas tested. Sad.")
+    }
+  }
+  var editor = new SimpleBanana()

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleBanana.ts
@@ -40,7 +40,7 @@ class SimpleBanana implements ProjectEditor {
       let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
 
       let i = 0
-      eng.with<any>(project, "//File()/banana()", n => {
+      eng.with<Banana>(project, "//File()/banana()", n => {
         //console.log("Checking color of banana")
         if (n.value() != "yellow")
          throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/TwoLevel.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/TwoLevel.ts
@@ -1,0 +1,82 @@
+import {Project} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from '@atomist/rug/operations/RugOperation'
+
+
+class FruitererType implements TypeProvider {
+
+ typeName = "fruiterer"
+
+ find(context: TreeNode): TreeNode[] {
+   return [ new Fruiterer() ]
+ }
+
+}
+
+class Fruiterer implements TreeNode {
+
+  nodeName(): string { return "fruiterer" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "" }
+
+  update(newValue: string) {}
+
+  children() { return [ new Banana(), new Pear() ] }
+
+}
+
+class Banana implements TreeNode {
+
+  nodeName(): string { return "banana" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "yellow" }
+
+  update(newValue: string) {}
+
+  children() { return [] }
+
+}
+
+class Pear implements TreeNode {
+
+  nodeName(): string { return "pear" }
+
+  nodeType(): string[] { return [ this.nodeName()] }
+
+  value(): string { return "green" }
+
+  update(newValue: string) {}
+
+  children() { return [] }
+
+}
+
+class TwoLevel implements ProjectEditor {
+
+    name: string = "Constructed"
+    description: string = "Uses single microgrammar"
+
+    edit(project: Project) {
+      //console.log("Editing")
+      let mg = new FruitererType()
+      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
+
+      let i = 0
+      eng.with<any>(project, "//File()/fruiterer()/banana()", n => {
+        //console.log("Checking color of banana")
+        if (n.value() != "yellow")
+         throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
+        i++
+      })
+      if (i == 0)
+       throw new Error("No bananas tested. Sad.")
+    }
+  }
+  var editor = new TwoLevel()

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/TwoLevel.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/TwoLevel.ts
@@ -1,4 +1,4 @@
-import {Project} from '@atomist/rug/model/Core'
+import {Project, File} from '@atomist/rug/model/Core'
 import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
 import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
 import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
@@ -10,8 +10,20 @@ class FruitererType implements TypeProvider {
 
  typeName = "fruiterer"
 
+ private isFile(f: TreeNode): f is File {
+   return true
+ }
+
  find(context: TreeNode): TreeNode[] {
-   return [ new Fruiterer() ]
+   if (this.isFile(context)) {
+     let f = context as File
+     console.log(f.name())
+     if (f.isJava())
+      return [ new Fruiterer() ]
+      else return []
+   }
+   else 
+    return []
  }
 
 }
@@ -69,14 +81,14 @@ class TwoLevel implements ProjectEditor {
       let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
 
       let i = 0
-      eng.with<any>(project, "//File()/fruiterer()/banana()", n => {
+      eng.with<Banana>(project, "//File()/fruiterer()/banana()", n => {
         //console.log("Checking color of banana")
         if (n.value() != "yellow")
          throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
         i++
       })
-      if (i == 0)
-       throw new Error("No bananas tested. Sad.")
+      if (i != 2)
+       throw new Error(`Two bananas should have been tested, not ${i}. Sad.`)
     }
   }
   var editor = new TwoLevel()

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
@@ -1,0 +1,175 @@
+package com.atomist.rug.runtime.js.interop
+
+import com.atomist.parse.java.ParsingTargets
+import com.atomist.project.SimpleProjectOperationArguments
+import com.atomist.project.edit.NoModificationNeeded
+import com.atomist.rug.TestUtils
+import com.atomist.rug.runtime.js.{JavaScriptInvokingProjectEditor, JavaScriptOperationFinder}
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, FunSuite, Matchers}
+
+class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
+
+  val InvokesTree: String =
+    """import {Project} from '@atomist/rug/model/Core'
+      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+      |import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+      |import {Match} from '@atomist/rug/tree/PathExpression'
+      |import {Parameter} from '@atomist/rug/operations/RugOperation'
+      |
+      |
+      |class BananaType implements TypeProvider {
+      |
+      | typeName = "banana"
+      |
+      | find(context: TreeNode): TreeNode[] {
+      |   return [ new Banana()]
+      | }
+      |
+      |}
+      |
+      |class Banana implements TreeNode {
+      |
+      |  nodeName(): string { return "banana" }
+      |
+      |  nodeType(): string[] { return [ this.nodeName()] }
+      |
+      |  value(): string { return "yellow" }
+      |
+      |  update(newValue: string) {}
+      |
+      |  children() { return [] }
+      |
+      |}
+      |
+      |class MgEditor implements ProjectEditor {
+      |    name: string = "Constructed"
+      |    description: string = "Uses single microgrammar"
+      |
+      |    edit(project: Project) {
+      |      console.log("Editing")
+      |      let mg = new BananaType()
+      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
+      |
+      |      let i = 0
+      |      eng.with<any>(project, "//File()/banana()", n => {
+      |        //console.log("Checking color of banana")
+      |        if (n.value() != "yellow")
+      |         throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
+      |        i++
+      |      })
+      |      if (i == 0)
+      |       throw new Error("No bananas tested. Sad.")
+      |    }
+      |  }
+      |  var editor = new MgEditor()
+      | """.stripMargin
+
+  it should "invoke tree finder with one level only" in {
+    val as = TestUtils.compileWithModel(SimpleFileBasedArtifactSource(
+      StringFileArtifact(s".atomist/editors/SimpleEditor.ts", InvokesTree)))
+    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    val target = ParsingTargets.SpringIoGuidesRestServiceSource
+    jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
+      case nmn: NoModificationNeeded =>
+    }
+    jsed
+  }
+
+  val TwoLevels: String =
+    """import {Project} from '@atomist/rug/model/Core'
+      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+      |import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+      |import {Match} from '@atomist/rug/tree/PathExpression'
+      |import {Parameter} from '@atomist/rug/operations/RugOperation'
+      |
+      |
+      |class FruitererType implements TypeProvider {
+      |
+      | typeName = "fruiterer"
+      |
+      | find(context: TreeNode): TreeNode[] {
+      |   return [ new Fruiterer() ]
+      | }
+      |
+      |}
+      |
+      |class Fruiterer implements TreeNode {
+      |
+      |  nodeName(): string { return "fruiterer" }
+      |
+      |  nodeType(): string[] { return [ this.nodeName()] }
+      |
+      |  value(): string { return "" }
+      |
+      |  update(newValue: string) {}
+      |
+      |  children() { return [ new Banana(), new Pear() ] }
+      |
+      |}
+      |
+      |class Banana implements TreeNode {
+      |
+      |  nodeName(): string { return "banana" }
+      |
+      |  nodeType(): string[] { return [ this.nodeName()] }
+      |
+      |  value(): string { return "yellow" }
+      |
+      |  update(newValue: string) {}
+      |
+      |  children() { return [] }
+      |
+      |}
+      |
+      |class Pear implements TreeNode {
+      |
+      |  nodeName(): string { return "pear" }
+      |
+      |  nodeType(): string[] { return [ this.nodeName()] }
+      |
+      |  value(): string { return "green" }
+      |
+      |  update(newValue: string) {}
+      |
+      |  children() { return [] }
+      |
+      |}
+      |
+      |class MgEditor implements ProjectEditor {
+      |    name: string = "Constructed"
+      |    description: string = "Uses single microgrammar"
+      |
+      |    edit(project: Project) {
+      |      console.log("Editing")
+      |      let mg = new FruitererType()
+      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
+      |
+      |      let i = 0
+      |      eng.with<any>(project, "//File()/fruiterer()/banana()", n => {
+      |        //console.log("Checking color of banana")
+      |        if (n.value() != "yellow")
+      |         throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
+      |        i++
+      |      })
+      |      if (i == 0)
+      |       throw new Error("No bananas tested. Sad.")
+      |    }
+      |  }
+      |  var editor = new MgEditor()
+      | """.stripMargin
+
+  it should "invoke tree finder with two levels" in {
+    val as = TestUtils.compileWithModel(SimpleFileBasedArtifactSource(
+      StringFileArtifact(s".atomist/editors/SimpleEditor.ts", TwoLevels)))
+    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    val target = ParsingTargets.SpringIoGuidesRestServiceSource
+    jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
+      case nmn: NoModificationNeeded =>
+    }
+    jsed
+  }
+
+}

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
@@ -5,6 +5,7 @@ import com.atomist.project.SimpleProjectOperationArguments
 import com.atomist.project.edit.NoModificationNeeded
 import com.atomist.rug.TestUtils
 import com.atomist.rug.runtime.js.{JavaScriptInvokingProjectEditor, JavaScriptOperationFinder}
+import com.atomist.source.file.ClassPathArtifactSource
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, FunSuite, Matchers}
 
@@ -77,94 +78,8 @@ class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
     jsed
   }
 
-  val TwoLevels: String =
-    """import {Project} from '@atomist/rug/model/Core'
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-      |import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
-      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-      |import {Match} from '@atomist/rug/tree/PathExpression'
-      |import {Parameter} from '@atomist/rug/operations/RugOperation'
-      |
-      |
-      |class FruitererType implements TypeProvider {
-      |
-      | typeName = "fruiterer"
-      |
-      | find(context: TreeNode): TreeNode[] {
-      |   return [ new Fruiterer() ]
-      | }
-      |
-      |}
-      |
-      |class Fruiterer implements TreeNode {
-      |
-      |  nodeName(): string { return "fruiterer" }
-      |
-      |  nodeType(): string[] { return [ this.nodeName()] }
-      |
-      |  value(): string { return "" }
-      |
-      |  update(newValue: string) {}
-      |
-      |  children() { return [ new Banana(), new Pear() ] }
-      |
-      |}
-      |
-      |class Banana implements TreeNode {
-      |
-      |  nodeName(): string { return "banana" }
-      |
-      |  nodeType(): string[] { return [ this.nodeName()] }
-      |
-      |  value(): string { return "yellow" }
-      |
-      |  update(newValue: string) {}
-      |
-      |  children() { return [] }
-      |
-      |}
-      |
-      |class Pear implements TreeNode {
-      |
-      |  nodeName(): string { return "pear" }
-      |
-      |  nodeType(): string[] { return [ this.nodeName()] }
-      |
-      |  value(): string { return "green" }
-      |
-      |  update(newValue: string) {}
-      |
-      |  children() { return [] }
-      |
-      |}
-      |
-      |class MgEditor implements ProjectEditor {
-      |    name: string = "Constructed"
-      |    description: string = "Uses single microgrammar"
-      |
-      |    edit(project: Project) {
-      |      console.log("Editing")
-      |      let mg = new FruitererType()
-      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
-      |
-      |      let i = 0
-      |      eng.with<any>(project, "//File()/fruiterer()/banana()", n => {
-      |        //console.log("Checking color of banana")
-      |        if (n.value() != "yellow")
-      |         throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
-      |        i++
-      |      })
-      |      if (i == 0)
-      |       throw new Error("No bananas tested. Sad.")
-      |    }
-      |  }
-      |  var editor = new MgEditor()
-      | """.stripMargin
-
   it should "invoke tree finder with two levels" in {
-    val as = TestUtils.compileWithModel(SimpleFileBasedArtifactSource(
-      StringFileArtifact(s".atomist/editors/SimpleEditor.ts", TwoLevels)))
-    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    val jsed = TestUtils.editorInSideFile(this, "TwoLevel.ts")
     val target = ParsingTargets.SpringIoGuidesRestServiceSource
     jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
       case nmn: NoModificationNeeded =>

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
@@ -4,78 +4,16 @@ import com.atomist.parse.java.ParsingTargets
 import com.atomist.project.SimpleProjectOperationArguments
 import com.atomist.project.edit.{NoModificationNeeded, SuccessfulModification}
 import com.atomist.rug.TestUtils
-import com.atomist.rug.runtime.js.{JavaScriptInvokingProjectEditor, JavaScriptOperationFinder}
-import com.atomist.source.file.ClassPathArtifactSource
-import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
-import org.scalatest.{FlatSpec, FunSuite, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 
 class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
 
-  val InvokesTree: String =
-    """import {Project} from '@atomist/rug/model/Core'
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-      |import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
-      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-      |import {Match} from '@atomist/rug/tree/PathExpression'
-      |import {Parameter} from '@atomist/rug/operations/RugOperation'
-      |
-      |
-      |class BananaType implements TypeProvider {
-      |
-      | typeName = "banana"
-      |
-      | find(context: TreeNode): TreeNode[] {
-      |   return [ new Banana()]
-      | }
-      |
-      |}
-      |
-      |class Banana implements TreeNode {
-      |
-      |  nodeName(): string { return "banana" }
-      |
-      |  nodeType(): string[] { return [ this.nodeName()] }
-      |
-      |  value(): string { return "yellow" }
-      |
-      |  update(newValue: string) {}
-      |
-      |  children() { return [] }
-      |
-      |}
-      |
-      |class MgEditor implements ProjectEditor {
-      |    name: string = "Constructed"
-      |    description: string = "Uses single microgrammar"
-      |
-      |    edit(project: Project) {
-      |      console.log("Editing")
-      |      let mg = new BananaType()
-      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
-      |
-      |      let i = 0
-      |      eng.with<any>(project, "//File()/banana()", n => {
-      |        //console.log("Checking color of banana")
-      |        if (n.value() != "yellow")
-      |         throw new Error(`Banana is not yellow but [${n.value()}]. Sad.`)
-      |        i++
-      |      })
-      |      if (i == 0)
-      |       throw new Error("No bananas tested. Sad.")
-      |    }
-      |  }
-      |  var editor = new MgEditor()
-      | """.stripMargin
-
   it should "invoke tree finder with one level only" in {
-    val as = TestUtils.compileWithModel(SimpleFileBasedArtifactSource(
-      StringFileArtifact(s".atomist/editors/SimpleEditor.ts", InvokesTree)))
-    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    val jsed = TestUtils.editorInSideFile(this, "SimpleBanana.ts")
     val target = ParsingTargets.SpringIoGuidesRestServiceSource
     jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
       case nmn: NoModificationNeeded =>
     }
-    jsed
   }
 
   it should "invoke tree finder with two levels" in {
@@ -84,7 +22,6 @@ class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
     jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
       case nmn: NoModificationNeeded =>
     }
-    jsed
   }
 
   it should "invoke side effecting tree finder with two levels" in {
@@ -94,7 +31,6 @@ class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
       case sm: SuccessfulModification =>
         sm.result.allFiles.exists(f => f.name.endsWith(".java") && f.content.startsWith("I am evil!"))
     }
-    jsed
   }
 
 }

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.runtime.js.interop
 
 import com.atomist.parse.java.ParsingTargets
 import com.atomist.project.SimpleProjectOperationArguments
-import com.atomist.project.edit.NoModificationNeeded
+import com.atomist.project.edit.{NoModificationNeeded, SuccessfulModification}
 import com.atomist.rug.TestUtils
 import com.atomist.rug.runtime.js.{JavaScriptInvokingProjectEditor, JavaScriptOperationFinder}
 import com.atomist.source.file.ClassPathArtifactSource
@@ -83,6 +83,16 @@ class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
     val target = ParsingTargets.SpringIoGuidesRestServiceSource
     jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
       case nmn: NoModificationNeeded =>
+    }
+    jsed
+  }
+
+  it should "invoke side effecting tree finder with two levels" in {
+    val jsed = TestUtils.editorInSideFile(this, "MutatingBanana.ts")
+    val target = ParsingTargets.SpringIoGuidesRestServiceSource
+    jsed.modify(target, SimpleProjectOperationArguments.Empty) match {
+      case sm: SuccessfulModification =>
+        sm.result.allFiles.exists(f => f.name.endsWith(".java") && f.content.startsWith("I am evil!"))
     }
     jsed
   }

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
@@ -10,14 +10,14 @@ import com.atomist.tree.TreeNode
 import jdk.nashorn.api.scripting.AbstractJSObject
 import org.scalatest.{FlatSpec, Matchers}
 
-class SafeCommittingProxyTest extends FlatSpec with Matchers {
+class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
 
   it should "not allow invocation of non export function" in {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
 
-    val sc = new SafeCommittingProxy(typed, fmv)
+    val sc = new jsSafeCommittingProxy(typed, fmv)
     intercept[RugRuntimeException] {
       sc.getMember("bla")
     }
@@ -27,7 +27,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    val sc = new SafeCommittingProxy(typed, fmv)
+    val sc = new jsSafeCommittingProxy(typed, fmv)
      sc.getMember("setContent")
   }
 
@@ -36,7 +36,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
     val fc = new FakeCommand
-    val sc = new SafeCommittingProxy(typed, fmv, new FakeCommandRegistry(fc))
+    val sc = new jsSafeCommittingProxy(typed, fmv, new FakeCommandRegistry(fc))
     val ajs: AbstractJSObject = sc.getMember("execute").asInstanceOf[AbstractJSObject]
     val afc = ajs.call(fmv, null)
     fc.fmv should be(fmv)
@@ -47,7 +47,7 @@ class SafeCommittingProxyTest extends FlatSpec with Matchers {
     val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    val sc = new SafeCommittingProxy(typed, fmv, new FakeCommandRegistry)
+    val sc = new jsSafeCommittingProxy(typed, fmv, new FakeCommandRegistry)
     intercept[RugRuntimeException] {
       sc.getMember("delete")
     }


### PR DESCRIPTION
We may still want to load these automatically as in @kipz branch, but we can add this to the present model of dynamic registration. 

Also added a convenient way of loading `.ts` files in tests to avoid needed to code them in Scala strings, and renamed `SafeCommittingProxy` `jsSafeCommittingProxy` for consistency in classes that are intended to be invoked by JavaScript, not Java or Scala.