### PR TITLE
Deserialize linked json to arbitrary depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+-   LinkedJsonTreeDeserializer now works when an already linked object
+    is updated
+
 -   TS generators are now passed project name as second argument as
     per TS contract
 

--- a/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
+++ b/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
@@ -103,7 +103,7 @@ private class LinkableContainerTreeNode(
 
   def link(c: LinkableContainerTreeNode, link: String): Unit = {
     // Add a child with the appropriate name
-    val nn = new LinkableContainerTreeNode(link, c.nodeType, c.fieldValues)
+    val nn = new WrappingLinkableContainerTreeNode(c, link)
     fieldValues = fieldValues :+ nn
   }
 
@@ -118,4 +118,17 @@ private class LinkableContainerTreeNode(
   override def childrenNamed(key: String): Seq[TreeNode] =
     fieldValues.filter(n => n.nodeName.equals(key))
 
+}
+
+private class WrappingLinkableContainerTreeNode(val wrappedNode: LinkableContainerTreeNode,
+                                                override val nodeName: String)
+  extends ContainerTreeNode {
+
+  override def value: String = ???
+
+  override def childNodeNames: Set[String] = wrappedNode.childNodeNames
+
+  override def childNodeTypes: Set[String] = wrappedNode.childNodeTypes
+
+  override def childrenNamed(key: String): Seq[TreeNode] = wrappedNode.childrenNamed(key)
 }

--- a/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
@@ -47,9 +47,118 @@ class LinkedJsonTreeDeserializerTest extends FlatSpec with Matchers {
       |]
     """.stripMargin
 
+  val t2: String =
+    """
+     |[
+     |   {
+     |      "build_url":"https://travis-ci.org/something",
+     |      "id":"192756197",
+     |      "timestamp":"2017-01-17T17:21:48.374Z",
+     |      "started_at":"2017-01-17T17:18:57Z",
+     |      "nodeId":4770,
+     |      "name":"333",
+     |      "compare_url":"https://github.com/something",
+     |      "status":"Passed",
+     |      "type":[
+     |         "Build"
+     |      ],
+     |      "finished_at":"2017-01-17T17:21:45Z"
+     |   },
+     |   {
+     |      "message":"Commit message",
+     |      "sha":"sha",
+     |      "timestamp":"2017-01-17T11:18:51-06:00",
+     |      "nodeId":4767,
+     |      "type":[
+     |         "Commit"
+     |      ]
+     |   },
+     |   {
+     |      "name":"user-name",
+     |      "login":"user-login",
+     |      "email":"user-email",
+     |      "nodeId":2900,
+     |      "type":[
+     |         "GitHubId"
+     |      ]
+     |   },
+     |   {
+     |      "owner":"owner",
+     |      "name":"repo-name",
+     |      "nodeId":2391,
+     |      "type":[
+     |         "Repo"
+     |      ]
+     |   },
+     |   {
+     |      "name":"channel-name",
+     |      "id":"channel-id",
+     |      "nodeId":2200,
+     |      "type":[
+     |         "ChatChannel",
+     |         "SlackChannel"
+     |      ]
+     |   },
+     |   {
+     |      "before":"before-sha",
+     |      "after":"after-sha",
+     |      "branch":"git-branch",
+     |      "timestamp":"2017-01-17T17:18:52.943Z",
+     |      "nodeId":4766,
+     |      "type":[
+     |         "Push"
+     |      ]
+     |   },
+     |   {
+     |      "startNodeId":4767,
+     |      "endNodeId":4770,
+     |      "type":"HAS_BUILD"
+     |   },
+     |   {
+     |      "startNodeId":4767,
+     |      "endNodeId":2900,
+     |      "type":"AUTHOR"
+     |   },
+     |   {
+     |      "startNodeId":4770,
+     |      "endNodeId":2391,
+     |      "type":"ON"
+     |   },
+     |   {
+     |      "startNodeId":2391,
+     |      "endNodeId":2200,
+     |      "type":"CHANNEL"
+     |   },
+     |   {
+     |      "startNodeId":4770,
+     |      "endNodeId":4766,
+     |      "type":"TRIGGERED_BY"
+     |   },
+     |   {
+     |      "startNodeId":4766,
+     |      "endNodeId":4767,
+     |      "type":"CONTAINS"
+     |   },
+     |   {
+     |      "startNodeId":4767,
+     |      "endNodeId":2900,
+     |      "type":"AUTHOR"
+     |   }
+     |]
+    """.stripMargin
+
   it should "deserialize simple tree" in {
     val node = LinkedJsonTreeDeserializer.fromJson(t1)
     node.nodeType should be (Set("Issue"))
     node.childrenNamed("number").size should be (1)
+  }
+
+  it should "deserialize a tree of n depth" in {
+    val node = LinkedJsonTreeDeserializer.fromJson(t2)
+    node.nodeType should be (Set("Build"))
+    val repo = node.childrenNamed("ON").head
+    repo.childrenNamed("owner").size should be (1)
+    val chatChannel = repo.childrenNamed("CHANNEL").head
+    chatChannel.childrenNamed("name").size should be (1)
   }
 }


### PR DESCRIPTION
Previously we were creating a new object to update the link. This means
that subsequent updates to those objects were not being reflected by
objects that referenced them: as they were no longer references. This
introduces a wrapper that allows us to override the link name whilst
still holding a reference to the original object so that updates are
reflected across the tree.