### PR TITLE
Fix values in LinkedJsonTreeDeserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+-   LinkedJsonTreeDeserializer now properly returns string values
+
 -   LinkedJsonTreeDeserializer now works when an already linked object
     is updated
 

--- a/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
+++ b/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
@@ -55,7 +55,12 @@ object LinkedJsonTreeDeserializer extends LazyLogging {
             k <- m.keys
             if !SpecialProperties.contains(k)
           } yield {
-            SimpleTerminalTreeNode(k, m.get(k).toString)
+            val nodeValue = m.get(k) match {
+              case Some(s: String) => s
+              case Some(ns) => ns.toString
+              case None => null
+            }
+            SimpleTerminalTreeNode(k, nodeValue)
           }
         val ctn = new LinkableContainerTreeNode(nodeName, Set(nodeType), simpleFields.toSeq)
         val nodeId: String = requiredStringEntry(m, NodeId)

--- a/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
@@ -156,9 +156,11 @@ class LinkedJsonTreeDeserializerTest extends FlatSpec with Matchers {
   it should "deserialize a tree of n depth" in {
     val node = LinkedJsonTreeDeserializer.fromJson(t2)
     node.nodeType should be (Set("Build"))
+    node.childrenNamed("status").head.value should be ("Passed")
     val repo = node.childrenNamed("ON").head
     repo.childrenNamed("owner").size should be (1)
     val chatChannel = repo.childrenNamed("CHANNEL").head
     chatChannel.childrenNamed("name").size should be (1)
+    chatChannel.childrenNamed("id").head.value should be ("channel-id")
   }
 }


### PR DESCRIPTION
Previously values were strings like "Some(valueInHere)" as it was calling .toString on the object. This fix returns values correctly.