### PR TITLE
Antlr tree

### DIFF
--- a/src/main/resources/META-INF/services/com.atomist.rug.spi.Typed
+++ b/src/main/resources/META-INF/services/com.atomist.rug.spi.Typed
@@ -18,6 +18,8 @@ com.atomist.rug.kind.pom.EveryPomType
 
 com.atomist.rug.kind.dynamic.MutableContainerTypeProvider
 com.atomist.rug.kind.python3.PythonFileType
+com.atomist.rug.kind.python3.PythonRawFileType
+
 com.atomist.rug.kind.python3.RequirementsType
 com.atomist.rug.kind.python3.PythonRequirementsTxtType
 com.atomist.rug.kind.properties.PropertiesType

--- a/src/main/scala/com/atomist/rug/kind/grammar/AntlrRawFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/AntlrRawFileType.scala
@@ -1,0 +1,68 @@
+package com.atomist.rug.kind.grammar
+
+import java.nio.charset.StandardCharsets
+
+import com.atomist.project.ProjectOperationArguments
+import com.atomist.rug.kind.core.{FileMutableView, ProjectMutableView}
+import com.atomist.rug.kind.dynamic.{ContextlessViewFinder, MutableContainerMutableView}
+import com.atomist.rug.parser.Selected
+import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
+import com.atomist.rug.spi.{ReflectivelyTypedType, Type}
+import com.atomist.source.{ArtifactSource, FileArtifact}
+import com.atomist.tree.TreeNode
+import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.util.Utils.withCloseable
+import org.apache.commons.io.IOUtils
+import org.springframework.core.io.DefaultResourceLoader
+
+/**
+  * Convenient superclass for Antlr grammars.
+  * @param evaluator used to evaluate expressions
+  * @param grammar g4 file
+  */
+abstract class AntlrRawFileType(
+                         evaluator: Evaluator,
+                         grammar: String
+                       )
+  extends Type(evaluator)
+    with ReflectivelyTypedType
+    with ContextlessViewFinder {
+
+  def this(grammar: String) = this(DefaultEvaluator, grammar)
+
+  private val cp = new DefaultResourceLoader()
+
+  private val r = cp.getResource(grammar)
+
+  private val g4 = withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8))
+
+  private lazy val antlrGrammar = new AntlrGrammar(g4, "file_input")
+
+  final override def resolvesFromNodeTypes = Set("Project", "File")
+
+  protected def isOfType(f: FileArtifact): Boolean
+
+  override def viewManifest: Manifest[MutableContainerMutableView] = manifest[MutableContainerMutableView]
+
+  override protected def findAllIn(rugAs: ArtifactSource,
+                                   selected: Selected,
+                                   context: TreeNode,
+                                   poa: ProjectOperationArguments,
+                                   identifierMap: Map[String, Object]): Option[Seq[TreeNode]] = {
+    context match {
+      case pmv: ProjectMutableView =>
+        Some(pmv.currentBackingObject
+          .files
+          .filter(isOfType)
+          .map(f => toView(f, pmv))
+        )
+      case f: FileMutableView if isOfType(f.currentBackingObject) =>
+        Some(Seq(toView(f.currentBackingObject, f.parent)))
+      case _ => None
+    }
+  }
+
+  private def toView(f: FileArtifact, pmv: ProjectMutableView): TreeNode = {
+    antlrGrammar.parse(f.content, None)
+  }
+}

--- a/src/main/scala/com/atomist/rug/kind/python3/Python3Parser.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/Python3Parser.scala
@@ -32,9 +32,13 @@ class Python3Parser extends Parser {
     removeReservedWordTokens(PythonReservedWords)
 
   override def parse(input: String, ml: Option[MatchListener] = None): MutableContainerTreeNode = {
-    val raw = pythonGrammar.parse(input, ml)
+    val raw = rawTree(input, ml)
     val ast = (stripPythonReservedWords andThen removeNewlines andThen RemovePadding andThen Prune)(raw)
     ast
+  }
+
+  def rawTree(input: String, ml: Option[MatchListener] = None): MutableContainerTreeNode = {
+    pythonGrammar.parse(input, ml)
   }
 }
 

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
@@ -46,7 +46,7 @@ class PythonFileType(
 
   override def description = "Python file"
 
-  override def resolvesFromNodeTypes = Set("File")
+  override def resolvesFromNodeTypes = Set("File", "Project")
 
   override def viewManifest: Manifest[MutableContainerMutableView] = manifest[MutableContainerMutableView]
 

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
@@ -1,8 +1,8 @@
 package com.atomist.rug.kind.python3
 
 import com.atomist.project.ProjectOperationArguments
-import com.atomist.rug.kind.core.ProjectMutableView
-import com.atomist.rug.kind.dynamic.MutableContainerMutableView
+import com.atomist.rug.kind.core.{FileMutableView, ProjectMutableView}
+import com.atomist.rug.kind.dynamic.{ContextlessViewFinder, MutableContainerMutableView}
 import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
@@ -36,14 +36,17 @@ object PythonFileType {
 import com.atomist.rug.kind.python3.PythonFileType._
 
 class PythonFileType(
-                  evaluator: Evaluator
-                )
+                      evaluator: Evaluator
+                    )
   extends Type(evaluator)
-    with ReflectivelyTypedType {
+    with ReflectivelyTypedType
+    with ContextlessViewFinder {
 
   def this() = this(DefaultEvaluator)
 
   override def description = "Python file"
+
+  override def resolvesFromNodeTypes = Set("File")
 
   override def viewManifest: Manifest[MutableContainerMutableView] = manifest[MutableContainerMutableView]
 
@@ -51,7 +54,7 @@ class PythonFileType(
                                    selected: Selected,
                                    context: TreeNode,
                                    poa: ProjectOperationArguments,
-                                   identifierMap: Map[String, Object]): Option[Seq[MutableView[_]]] = {
+                                   identifierMap: Map[String, Object]): Option[Seq[TreeNode]] = {
     context match {
       case pmv: ProjectMutableView =>
         Some(pmv.currentBackingObject
@@ -59,11 +62,13 @@ class PythonFileType(
           .filter(f => f.name.endsWith(PythonExtension))
           .map(f => toView(f, pmv))
         )
+      case f: FileMutableView if f.filename.endsWith(PythonExtension) =>
+        Some(Seq(toView(f.currentBackingObject, f.parent)))
       case _ => None
     }
   }
 
-  private def toView(f: FileArtifact, pmv: ProjectMutableView): MutableView[_] = {
+  private def toView(f: FileArtifact, pmv: ProjectMutableView): TreeNode = {
     new PythonFileMutableView(f, pmv)
   }
 }

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonRawFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonRawFileType.scala
@@ -1,0 +1,15 @@
+package com.atomist.rug.kind.python3
+
+import com.atomist.rug.kind.grammar.AntlrRawFileType
+import com.atomist.rug.kind.python3.PythonFileType._
+import com.atomist.source.FileArtifact
+
+class PythonRawFileType
+  extends AntlrRawFileType("classpath:grammars/antlr/Python3.g4") {
+
+  override def description = "Python file"
+
+  override protected def isOfType(f: FileArtifact): Boolean =
+    f.name.endsWith(PythonExtension)
+
+}

--- a/src/main/scala/com/atomist/tree/MutableTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/MutableTreeNode.scala
@@ -1,24 +1,12 @@
 package com.atomist.tree
 
 /**
-  * Extended by TreeNode implementations that allow updates from a string value.
-  * Terminal nodes will have their value changed: container nodes
-  * will overwrite their child structure.
-  * Also adds the ability to add additional types to nodes.
+  * Extended by TreeNode implementations with
+  * the ability to add additional types to nodes.
   */
-trait MutableTreeNode extends TreeNode {
+trait AnnotatableTreeNode extends TreeNode {
 
   private var types: Set[String] = Set()
-
-  /**
-    * Update String contents to this content. May
-    * involve updating an entire structure.
-    *
-    * @return
-    */
-  def update(to: String): Unit
-
-  def dirty: Boolean
 
   override final def nodeType: Set[String] = types
 
@@ -38,5 +26,25 @@ trait MutableTreeNode extends TreeNode {
   def addTypes(s: Set[String]): Unit = {
     types = types ++ s
   }
+
+}
+
+/**
+  * Extended by TreeNode implementations that allow updates from a string value.
+  * Terminal nodes will have their value changed: container nodes
+  * will overwrite their child structure.
+  * Also adds the ability to add additional types to nodes.
+  */
+trait MutableTreeNode extends AnnotatableTreeNode {
+
+  /**
+    * Update String contents to this content. May
+    * involve updating an entire structure.
+    *
+    * @return
+    */
+  def update(to: String): Unit
+
+  def dirty: Boolean
 
 }

--- a/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
+++ b/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
@@ -1,6 +1,6 @@
 package com.atomist.tree.content.text
 
-import com.atomist.tree.content.text.grammar.antlr.EmptyContainerTreeNode
+import com.atomist.tree.content.text.grammar.antlr.EmptyAntlrContainerTreeNode
 import com.atomist.tree.{ContainerTreeNode, PaddingTreeNode, TerminalTreeNode, TreeNode}
 import org.springframework.util.ReflectionUtils
 

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AbstractInMemAntlrGrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AbstractInMemAntlrGrammar.scala
@@ -46,7 +46,7 @@ abstract class AbstractInMemAntlrGrammar
     }
   }
 
-  protected val config = setup
+  protected val config: ParserSetup = setup
 
   logger.debug(s"Compiling grammar-----\n$config\n-----")
   compileGrammar(config.parser)

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AntlrGrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AntlrGrammar.scala
@@ -17,7 +17,7 @@ class AntlrGrammar(
   extends AbstractInMemAntlrGrammar
     with Parser {
 
-  override protected def setup = {
+  override protected def setup: ParserSetup = {
     // Extract the grammar name from the relevant line
     val grammarRe = "grammar ([A-Z][a-zA-Z0-9]*);.*".r
     val names = grammar.lines.flatMap {
@@ -49,7 +49,7 @@ class AntlrGrammar(
 
     val updatedResult = l.results.head
     updatedResult match {
-      case asu: AbstractMutableContainerTreeNode => asu.pad(input, true)
+      case asu: AbstractMutableContainerTreeNode => asu.pad(input, topLevel = true)
     }
     updatedResult
   }

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -152,7 +152,7 @@ class ModelBuildingListener(
         // However, populate it with the possible field names
         val possibleFieldNames =
           typ.getDeclaredMethods.map(_.getName) ++ typ.getDeclaredFields.map(_.getName)
-        Seq(EmptyContainerTreeNode(name, possibleFieldNames.toSet, Set(name)))
+        Seq(EmptyAntlrContainerTreeNode(name, possibleFieldNames.toSet, Set(name)))
     }
     r
   }
@@ -162,9 +162,9 @@ class ModelBuildingListener(
   * Empty container field value including fieldName information about possible fields,
   * that are not present in this instance. This allows Rug type checking to work.
   */
-case class EmptyContainerTreeNode(nodeName: String,
-                                  override val childNodeNames: Set[String],
-                                  types: Set[String] = Set())
+case class EmptyAntlrContainerTreeNode(nodeName: String,
+                                       override val childNodeNames: Set[String],
+                                       types: Set[String] = Set())
   extends ContainerTreeNode {
 
   override def childNodes: Seq[TreeNode] = Nil

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -61,7 +61,8 @@ class ModelBuildingListener(
       OffsetInputPosition(rc.getStop.getStopIndex + 1)
 
     // Create an empty model node that we'll fill
-    val mof = new SimpleMutableContainerTreeNode(rule, Nil, startPos, endPos)
+    val tn = new SimpleMutableContainerTreeNode(rule, Nil, startPos, endPos)
+    tn.addType(rule)
 
     // We only want methods on the generated class itself
     val valueMethods = rc.getClass
@@ -93,8 +94,8 @@ class ModelBuildingListener(
     for {
       f <- deduped
     }
-      mof.insertFieldCheckingPosition(f)
-    mof
+      tn.insertFieldCheckingPosition(f)
+    tn
   }
 
   // Remove duplicate fields. The ones with lower case can replace the ones with upper case
@@ -129,18 +130,20 @@ class ModelBuildingListener(
     val r = value match {
       case en: ErrorNode =>
         logger.info(s"ErrorNode: $name=$en")
-        val sf = SimpleTerminalTreeNode(name, "")
+        val sf = SimpleTerminalTreeNode(name, "", Set(name))
         Seq(sf)
       case ct: Token if ct.getText.startsWith(s"<missing ") =>
         // Handle Antlr empty values
         val sf = new MutableTerminalTreeNode(name, "", position(ct))
+        sf.addType(name)
         Seq(sf)
       case ct: Token =>
         val sf = new MutableTerminalTreeNode(name, ct.getText, position(ct))
+        sf.addType(name)
         Seq(sf)
       case tn: TerminalNode =>
         makeField(name, tn.getSymbol, classOf[String])
-      case l: java.util.List[Object @unchecked] =>
+      case l: java.util.List[Object@unchecked] =>
         l.asScala.flatMap(e => makeField(name, e, classOf[Object]))
       case prc: ParserRuleContext =>
         Seq(treeToContainerField(prc))
@@ -149,7 +152,7 @@ class ModelBuildingListener(
         // However, populate it with the possible field names
         val possibleFieldNames =
           typ.getDeclaredMethods.map(_.getName) ++ typ.getDeclaredFields.map(_.getName)
-        Seq(EmptyContainerTreeNode(name, possibleFieldNames.toSet))
+        Seq(EmptyContainerTreeNode(name, possibleFieldNames.toSet, Set(name)))
     }
     r
   }
@@ -159,14 +162,16 @@ class ModelBuildingListener(
   * Empty container field value including fieldName information about possible fields,
   * that are not present in this instance. This allows Rug type checking to work.
   */
-case class EmptyContainerTreeNode(nodeName: String, override val childNodeNames: Set[String])
+case class EmptyContainerTreeNode(nodeName: String,
+                                  override val childNodeNames: Set[String],
+                                  types: Set[String] = Set())
   extends ContainerTreeNode {
 
   override def childNodes: Seq[TreeNode] = Nil
 
   override def childrenNamed(key: String): Seq[TreeNode] = Nil
 
-  override def nodeType: Set[String] = Set("empty")
+  override def nodeType: Set[String] = Set("empty") ++ types
 
   override def childNodeTypes: Set[String] = Set()
 

--- a/src/main/scala/com/atomist/tree/pathexpression/NamedNodeTest.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NamedNodeTest.scala
@@ -1,0 +1,38 @@
+package com.atomist.tree.pathexpression
+
+import com.atomist.rug.spi.TypeRegistry
+import com.atomist.tree.TreeNode
+import com.atomist.tree.content.text.TreeNodeOperations
+import com.atomist.tree.pathexpression.ExecutionResult.ExecutionResult
+
+/**
+  * Follow children of the given name. If not, methods of that name.
+  * @param name
+  */
+case class NamedNodeTest(name: String)
+  extends NodeTest {
+
+  override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult = axis match {
+    case Child =>
+      val kids: List[TreeNode] =
+        tn.childrenNamed(name).toList match {
+          case Nil =>
+            TreeNodeOperations.invokeMethodIfPresent[TreeNode](tn, name).
+              map {
+                case s: List[TreeNode@unchecked] =>
+                  s
+                case t: TreeNode =>
+                  List(t)
+                case x =>
+                  Nil
+              }.getOrElse {
+              val allKids = tn.childNodes
+              val filteredKids = allKids.filter(n => name.equals(n.nodeName))
+              filteredKids.toList
+            }
+          case l => l
+        }
+      Right(kids)
+  }
+
+}

--- a/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
@@ -62,34 +62,3 @@ abstract class PredicatedNodeTest(name: String, predicate: Predicate) extends No
   */
 object All extends PredicatedNodeTest("All", TruePredicate)
 
-case class NamedNodeTest(name: String)
-  extends NodeTest {
-
-  override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult = axis match {
-    case Child =>
-      tn match {
-        case ctn: ContainerTreeNode =>
-          val kids: List[TreeNode] =
-            ctn.childrenNamed(name).toList match {
-              case Nil =>
-                TreeNodeOperations.invokeMethodIfPresent[TreeNode](tn, name).
-                  map {
-                    case s: List[TreeNode@unchecked] =>
-                      s
-                    case t: TreeNode =>
-                      List(t)
-                    case x =>
-                      Nil
-                  }.getOrElse {
-                  val allKids = ctn.childNodes
-                  val filteredKids = allKids.filter(n => name.equals(n.nodeName))
-                  filteredKids.toList
-                }
-              case l => l
-            }
-          Right(kids)
-        case x => Left(s"Cannot find property [$name] on non-container tree node [$x]")
-      }
-  }
-
-}

--- a/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
@@ -2,8 +2,8 @@ package com.atomist.tree.pathexpression
 
 import com.atomist.rug.kind.dynamic.ChildResolver
 import com.atomist.rug.spi.{MutableView, TypeRegistry}
+import com.atomist.tree.TreeNode
 import com.atomist.tree.pathexpression.ExecutionResult.ExecutionResult
-import com.atomist.tree.{ContainerTreeNode, TreeNode}
 import com.atomist.util.misc.SerializationFriendlyLazyLogging
 
 /**
@@ -29,13 +29,7 @@ case class ObjectType(typeName: String)
     if (directKids.nonEmpty)
       directKids
     else
-      childResolver(typeRegistry) match {
-        case Some(cr) => cr.findAllIn(tn).getOrElse(Nil)
-        case None =>
-          Nil
-//          throw new IllegalArgumentException(
-//            s"No type with name [$typeName]: Looking under node [$tn], Kids=$directKids, known types=[${typeRegistry.typeNames}]")
-      }
+      childResolver(typeRegistry).flatMap(cr => cr.findAllIn(tn)).getOrElse(Nil)
   }
 
   override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult = {

--- a/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
@@ -32,8 +32,9 @@ case class ObjectType(typeName: String)
       childResolver(typeRegistry) match {
         case Some(cr) => cr.findAllIn(tn).getOrElse(Nil)
         case None =>
-          throw new IllegalArgumentException(
-            s"No type with name [$typeName]: Node=$tn, Kids=$directKids, known types=[${typeRegistry.typeNames}]")
+          Nil
+//          throw new IllegalArgumentException(
+//            s"No type with name [$typeName]: Looking under node [$tn], Kids=$directKids, known types=[${typeRegistry.typeNames}]")
       }
   }
 

--- a/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
@@ -24,13 +24,12 @@ case class ObjectType(typeName: String)
   private val eligibleNode: TreeNode => Boolean = n => n.nodeType.contains(typeName)
 
   // Attempt to find nodes of the require type under the given node
-  private def findMeUnder(tn: TreeNode, typeRegistry: TypeRegistry): Seq[TreeNode] = {
-    val directKids = tn.childNodes.filter(eligibleNode)
-    if (directKids.nonEmpty)
-      directKids
-    else
-      childResolver(typeRegistry).flatMap(cr => cr.findAllIn(tn)).getOrElse(Nil)
-  }
+  private def findMeUnder(tn: TreeNode, typeRegistry: TypeRegistry): Seq[TreeNode] =
+    tn.childNodes.filter(eligibleNode) match {
+      case Nil =>
+        childResolver(typeRegistry).flatMap(cr => cr.findAllIn(tn)).getOrElse(Nil)
+      case kids => kids
+    }
 
   override def follow(tn: TreeNode, axis: AxisSpecifier, ee: ExpressionEngine, typeRegistry: TypeRegistry): ExecutionResult = {
     axis match {

--- a/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/ObjectType.scala
@@ -29,16 +29,11 @@ case class ObjectType(typeName: String)
     if (directKids.nonEmpty)
       directKids
     else
-      tn match {
-        case mv: MutableView[_] =>
-          childResolver(typeRegistry) match {
-            case Some(cr) => cr.findAllIn(mv).getOrElse(Nil)
-            case None =>
-              throw new IllegalArgumentException(
-                s"No type with name [$typeName]: Node=$tn, Kids=$directKids, known types=[${typeRegistry.typeNames}]")
-          }
-        case x =>
-          throw new UnsupportedOperationException(s"Type ${x.getClass} not yet supported for resolution")
+      childResolver(typeRegistry) match {
+        case Some(cr) => cr.findAllIn(tn).getOrElse(Nil)
+        case None =>
+          throw new IllegalArgumentException(
+            s"No type with name [$typeName]: Node=$tn, Kids=$directKids, known types=[${typeRegistry.typeNames}]")
       }
   }
 

--- a/src/main/scala/com/atomist/tree/simpleTreeNodes.scala
+++ b/src/main/scala/com/atomist/tree/simpleTreeNodes.scala
@@ -6,8 +6,13 @@ package com.atomist.tree
   * @param nodeName name of the field (usually unimportant)
   * @param value field content.
   */
-case class SimpleTerminalTreeNode(nodeName: String, value: String)
-  extends TerminalTreeNode
+case class SimpleTerminalTreeNode(nodeName: String,
+                                  value: String,
+                                  types: Set[String] = Set())
+  extends TerminalTreeNode {
+
+  override val nodeType: Set[String] = super.nodeType ++ types
+}
 
 /**
   * Convenient class for padding nodes

--- a/src/test/resources/com/atomist/rug/kind/python3/Imports.ts
+++ b/src/test/resources/com/atomist/rug/kind/python3/Imports.ts
@@ -1,0 +1,24 @@
+import {Project} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from '@atomist/rug/operations/RugOperation'
+
+class Imports implements ProjectEditor {
+    name: string = "Constructed"
+    description: string = "Uses single microgrammar"
+
+    edit(project: Project) {
+      let eng: PathExpressionEngine = project.context().pathExpressionEngine()
+
+      let i = 0
+      eng.with<TreeNode>(project, "//File()/PythonRawFile()//import_stmt()", n => {
+        console.log(`The node is ${n.value()}`)
+        i++
+      })
+      if (i == 0)
+       throw new Error("No Pythons found. Sad.")
+    }
+  }
+export let editor = new Imports();

--- a/src/test/resources/com/atomist/rug/kind/python3/Imports.ts
+++ b/src/test/resources/com/atomist/rug/kind/python3/Imports.ts
@@ -13,6 +13,12 @@ class Imports implements ProjectEditor {
       let eng: PathExpressionEngine = project.context().pathExpressionEngine()
 
       let i = 0
+
+      // eng.with<File>(project, "//File()[/PythonRawFile()//import_from()//FROM[@value='flask']]", n => {
+      //   console.log(`The file path is ${n.path()}`)
+      //   i++
+      // })
+
       eng.with<TreeNode>(project, "//File()/PythonRawFile()//import_stmt()", n => {
         console.log(`The node is ${n.value()}`)
         i++

--- a/src/test/scala/com/atomist/rug/kind/python3/Python3ParserTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/Python3ParserTest.scala
@@ -1,19 +1,10 @@
 package com.atomist.rug.kind.python3
 
-import com.atomist.parse.java.ParsingTargets
-import com.atomist.project.archive.DefaultAtomistConfig
-import com.atomist.rug.kind.DefaultTypeRegistry
-import com.atomist.rug.kind.core.ProjectMutableView
-import com.atomist.rug.kind.java.JavaClassOrInterfaceView
-import com.atomist.source.{EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.content.text.MutableContainerTreeNode
-import com.atomist.tree.pathexpression.{PathExpressionEngine, PathExpressionParser}
-import com.atomist.tree.utils.TreeNodeUtils
 import org.scalatest.{FlatSpec, Matchers}
 
-class Python3ParserTest extends FlatSpec with Matchers {
 
-  private val pex = new PathExpressionEngine
+class Python3ParserTest extends FlatSpec with Matchers {
 
   lazy val parser = new Python3Parser
 
@@ -44,30 +35,6 @@ class Python3ParserTest extends FlatSpec with Matchers {
 
   it should "parse simple script and write out unchanged" in
     parseAndVerifyValueCanBeWrittenOutUnchanged(dateParserDotPy)
-
-  it should "find Python file type using path expression" in {
-    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/setup.py", setupDotPy))
-    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
-    val expr = "/src/File()/PythonFile()"
-    val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
-//    rtn.right.get.foreach {
-//      case p: PythonFileMutableView =>
-//    }
-  }
-
-  it should "drill down to Python import statement using path expression" in {
-    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/setup.py", setupDotPy))
-    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
-    val expr = "/src/File()/PythonRawFile()//import_stmt()"
-    val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
-    rtn.right.get.size should be>(2)
-    rtn.right.get.foreach {
-      case n: MutableContainerTreeNode =>
-        println(n.value)
-      case x => println(x)
-    }
-  }
 
   private def parseAndVerifyValueCanBeWrittenOutUnchanged(pyProg: String): MutableContainerTreeNode = {
     if (pyProg.lines.exists(_.trim.startsWith("|")))

--- a/src/test/scala/com/atomist/rug/kind/python3/Python3ParserTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/Python3ParserTest.scala
@@ -1,9 +1,13 @@
 package com.atomist.rug.kind.python3
 
+import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.tree.content.text.MutableContainerTreeNode
+import com.atomist.tree.pathexpression.{PathExpressionEngine, PathExpressionParser}
 import org.scalatest.{FlatSpec, Matchers}
 
 class Python3ParserTest extends FlatSpec with Matchers {
+
+  private val pex = new PathExpressionEngine
 
   lazy val parser = new Python3Parser
 
@@ -18,7 +22,7 @@ class Python3ParserTest extends FlatSpec with Matchers {
 
   def stringShowingIndices(s: String) = {
     val z = s.zipWithIndex
-    "len=" + s.length + " :"  + z.mkString(",")
+    "len=" + s.length + " :" + z.mkString(",")
   }
 
   it should "parse simplest file and write out unchanged" in {
@@ -34,6 +38,13 @@ class Python3ParserTest extends FlatSpec with Matchers {
 
   it should "parse simple script and write out unchanged" in
     parseAndVerifyValueCanBeWrittenOutUnchanged(dateParserDotPy)
+
+  it should "parse path expression" in {
+    val node = parser.rawTree(setupDotPy)
+    val pe = "//import()"
+    val pep = PathExpressionParser.parseString(pe)
+    val r = pex.evaluate(node, pep, DefaultTypeRegistry, None)
+  }
 
   private def parseAndVerifyValueCanBeWrittenOutUnchanged(pyProg: String): MutableContainerTreeNode = {
     if (pyProg.lines.exists(_.trim.startsWith("|")))

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
@@ -1,9 +1,8 @@
 package com.atomist.rug.kind.python3
 
 import com.atomist.project.SimpleProjectOperationArguments
-import com.atomist.project.edit.{ModificationAttempt, NoModificationNeeded, ProjectEditor, SuccessfulModification}
-import com.atomist.rug.{DefaultRugPipeline, TestUtils}
-import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.project.edit.{ModificationAttempt, NoModificationNeeded, SuccessfulModification}
+import com.atomist.rug.TestUtils
 import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -16,7 +15,7 @@ class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
       StringFileArtifact("setup.py", setupDotPy)
     ))
 
-  val Flask1: ArtifactSource = new SimpleFileBasedArtifactSource("name",
+  val Flask1: ArtifactSource = Simple + new SimpleFileBasedArtifactSource("name",
     Seq(
       StringFileArtifact("hello.py", flask1)
     ))
@@ -40,8 +39,8 @@ class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "enumerate imports in simple file" in {
-    val r = executePython("Imports.ts", Simple)
+  it should "enumerate imports in simple project" in {
+    val r = executePython("Imports.ts", Flask1)
     r match {
       case nmn: NoModificationNeeded =>
       case sm: SuccessfulModification =>

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
@@ -1,0 +1,97 @@
+package com.atomist.rug.kind.python3
+
+import com.atomist.project.SimpleProjectOperationArguments
+import com.atomist.project.edit.{ModificationAttempt, NoModificationNeeded, ProjectEditor, SuccessfulModification}
+import com.atomist.rug.{DefaultRugPipeline, TestUtils}
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, Matchers}
+
+class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
+
+  import Python3ParserTest._
+
+  val Simple: ArtifactSource = new SimpleFileBasedArtifactSource("name",
+    Seq(
+      StringFileArtifact("setup.py", setupDotPy)
+    ))
+
+  val Flask1: ArtifactSource = new SimpleFileBasedArtifactSource("name",
+    Seq(
+      StringFileArtifact("hello.py", flask1)
+    ))
+
+  def executePython(tsFilename: String, as: ArtifactSource, params: Map[String,String] = Map()): ModificationAttempt = {
+    val pe = TestUtils.editorInSideFile(this, tsFilename)
+    pe.modify(as, SimpleProjectOperationArguments("", params))
+  }
+
+  import PythonFileType._
+
+  def modifyPythonAndReparseSuccessfully(tsFilename: String, as: ArtifactSource, params: Map[String,String] = Map()): ArtifactSource = {
+    val parser = new Python3Parser
+    executePython(tsFilename, as, params) match {
+      case sm: SuccessfulModification =>
+        sm.result.allFiles
+          .filter(_.name.endsWith(PythonExtension))
+          .map(py => parser.parse(py.content))
+          .map(tree => tree.childNodes.nonEmpty)
+        sm.result
+    }
+  }
+
+  it should "enumerate imports in simple file" in {
+    val r = executePython("Imports.ts", Simple)
+    r match {
+      case nmn: NoModificationNeeded =>
+      case sm: SuccessfulModification =>
+        val f = sm.result.findFile("setup.py").get
+        fail
+    }
+  }
+
+  /*
+  it should "modify imports in simple file" in {
+    val prog =
+      """
+        |editor ImportUpdater
+        |
+        |with PythonFile
+        | with import
+        |   do setName "newImport"
+      """.stripMargin
+    val r = modifyPythonAndReparseSuccessfully(prog, Simple)
+    val f = r.findFile("setup.py").get
+    f.content.contains("newImport") should be(true)
+  }
+
+  private val newRoute =
+    """
+      |@app.route("/")
+      |def hello2():
+      |    return "Hello World!"
+    """.stripMargin
+
+  it should "add Flask route to Python file" in {
+    val prog =
+      """
+        |editor AddFlaskRoute
+        |
+        |param new_route: ^[\s\S]*$
+        |
+        |with PythonFile when filename = "hello.py"
+        | do append new_route
+      """.stripMargin
+    val r = modifyPythonAndReparseSuccessfully(prog, Flask1, Map(
+      "new_route" -> newRoute
+    ))
+    val f = r.findFile("hello.py").get
+    f.content.contains(newRoute) should be(true)
+
+    val reparsed = pythonParser.parse(f.content)
+    // TODO assert 2 methods
+    // reparsed.f
+  }
+
+*/
+}

--- a/src/test/scala/com/atomist/rug/kind/python3/RawPython3Test.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/RawPython3Test.scala
@@ -4,6 +4,7 @@ import com.atomist.project.archive.DefaultAtomistConfig
 import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.source.{EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.pathexpression.{PathExpressionEngine, PathExpressionParser}
 import org.scalatest.{FlatSpec, Matchers}
@@ -32,9 +33,23 @@ class RawPython3Test extends FlatSpec with Matchers {
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
     rtn.right.get.size should be>(2)
     rtn.right.get.foreach {
-      case n: MutableContainerTreeNode =>
+      case n: TreeNode if n.value.nonEmpty =>
         println(n.value)
-      case x => println(x)
+      case x => println(s"Was empty: $x")
+    }
+  }
+
+  it should "drill down to Python import from statement using path expression" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/setup.py", setupDotPy))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr = "/src/File()/PythonRawFile()//import_from()"
+    val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
+    rtn.right.get.size should be>(2)
+    rtn.right.get.foreach {
+      case n: TreeNode if n.value.nonEmpty =>
+        println(n.value)
+        println(n)
+      case x => println(s"Was empty: $x")
     }
   }
 }

--- a/src/test/scala/com/atomist/rug/kind/python3/RawPython3Test.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/RawPython3Test.scala
@@ -1,0 +1,40 @@
+package com.atomist.rug.kind.python3
+
+import com.atomist.project.archive.DefaultAtomistConfig
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.kind.core.ProjectMutableView
+import com.atomist.source.{EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
+import com.atomist.tree.content.text.MutableContainerTreeNode
+import com.atomist.tree.pathexpression.{PathExpressionEngine, PathExpressionParser}
+import org.scalatest.{FlatSpec, Matchers}
+
+class RawPython3Test extends FlatSpec with Matchers {
+
+  import Python3ParserTest._
+
+  private val pex = new PathExpressionEngine
+
+  it should "find Python file type using path expression" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/setup.py", setupDotPy))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr = "/src/File()/PythonRawFile()"
+    val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
+    rtn.right.get.size should be(1)
+    //    rtn.right.get.foreach {
+    //      case p: PythonFileMutableView =>
+    //    }
+  }
+
+  it should "drill down to Python import statement using path expression" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/setup.py", setupDotPy))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr = "/src/File()/PythonRawFile()//import_stmt()"
+    val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
+    rtn.right.get.size should be>(2)
+    rtn.right.get.foreach {
+      case n: MutableContainerTreeNode =>
+        println(n.value)
+      case x => println(x)
+    }
+  }
+}


### PR DESCRIPTION
Path expressions are wonderful at filtering out noise. This PR adds an easy way of creating a type from a _raw_ tree from an Antlr grammar. If we use path expressions, AST noise is no longer such an issue.

See `PythonRawFileType` for an example.

It also makes path expressions not blow up descending into unknown types.