### PR TITLE
Path expression fixes for //

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/python3/PythonRawFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonRawFileType.scala
@@ -1,15 +1,15 @@
 package com.atomist.rug.kind.python3
 
+import com.atomist.rug.kind.core.FileArtifactBackedMutableView
 import com.atomist.rug.kind.grammar.AntlrRawFileType
 import com.atomist.rug.kind.python3.PythonFileType._
-import com.atomist.source.FileArtifact
 
 class PythonRawFileType
   extends AntlrRawFileType("classpath:grammars/antlr/Python3.g4") {
 
   override def description = "Python file"
 
-  override protected def isOfType(f: FileArtifact): Boolean =
-    f.name.endsWith(PythonExtension)
+  override protected def isOfType(f: FileArtifactBackedMutableView): Boolean =
+    f.filename.endsWith(PythonExtension)
 
 }

--- a/src/main/scala/com/atomist/tree/pathexpression/AxisSpecifier.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/AxisSpecifier.scala
@@ -40,13 +40,17 @@ object Descendant extends AxisSpecifier {
   // TODO this is very inefficient and needs to be optimized.
   // Subclasses can help, or knowing a plan
   def allDescendants(tn: TreeNode): Seq[TreeNode] = {
-    val v = new SaveAllDescendantsVisitor
-    tn.accept(v, 0)
     // Remove this node
-    v.nodes.diff(Seq(tn))
+    selfAndAllDescendants(tn).diff(Seq(tn))
   }
 
-  private class SaveAllDescendantsVisitor extends Visitor {
+  def selfAndAllDescendants(tn: TreeNode): Seq[TreeNode] = {
+    val v = new SaveAllDescendantsVisitor
+    tn.accept(v, 0)
+    v.nodes
+  }
+
+    private class SaveAllDescendantsVisitor extends Visitor {
 
     private val _nodes = ListBuffer.empty[TreeNode]
 

--- a/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NodeTest.scala
@@ -47,7 +47,6 @@ abstract class PredicatedNodeTest(name: String, predicate: Predicate) extends No
     case Child =>
       val kids = tn.childNodes.toList
       ExecutionResult(kids)
-
     case Descendant =>
       val kids = Descendant.allDescendants(tn).toList
       ExecutionResult(kids)

--- a/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
@@ -128,14 +128,22 @@ case class PropertyValuePredicate(property: String, expectedValue: String) exten
                         ee: ExpressionEngine,
                         typeRegistry: TypeRegistry,
                         nodePreparer: Option[NodePreparer]): Boolean = {
-    val extracted = n.childrenNamed(property)
-    if (extracted.size == 1) {
-      val result = extracted.head.value.equals(expectedValue)
-      //println(s"Comparing property [$property] of [${extracted.head.value}] against expected [$expectedValue] gave $result")
-      result
+    if (property == "value") {
+      // Treat the value property specially
+      n.value == expectedValue
     }
-    else
-      false
+    else {
+      val extracted = n.childrenNamed(property)
+      if (extracted.size == 1) {
+        val result = extracted.head.value.equals(expectedValue)
+        //println(s"Comparing property [$property] of [${extracted.head.value}] against expected [$expectedValue] gave $result")
+        result
+      }
+      else {
+        // TODO try to invoke a method?
+        false
+      }
+    }
   }
 }
 

--- a/src/test/resources/com/atomist/rug/kind/python3/ChangeImports.ts
+++ b/src/test/resources/com/atomist/rug/kind/python3/ChangeImports.ts
@@ -1,0 +1,26 @@
+import {Project,File} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from '@atomist/rug/operations/RugOperation'
+
+class ChangeImports implements ProjectEditor {
+    name: string = "Constructed"
+    description: string = "Uses single microgrammar"
+
+    edit(project: Project) {
+      let eng: PathExpressionEngine = project.context().pathExpressionEngine()
+
+      let count = 0
+      eng.with<TreeNode>(project, "//File()/PythonRawFile()//import_from()//dotted_name[@value='flask']", n => {
+        console.log(`The import was '${n.value()}'`)
+        n.update("newImport")
+        count++
+      })
+
+      if (count == 0)
+       throw new Error("No files with flask imports found. Sad.")
+    }
+  }
+export let editor = new ChangeImports();

--- a/src/test/resources/com/atomist/rug/kind/python3/Imports.ts
+++ b/src/test/resources/com/atomist/rug/kind/python3/Imports.ts
@@ -1,4 +1,4 @@
-import {Project} from '@atomist/rug/model/Core'
+import {Project,File} from '@atomist/rug/model/Core'
 import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
 import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
 import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
@@ -12,12 +12,21 @@ class Imports implements ProjectEditor {
     edit(project: Project) {
       let eng: PathExpressionEngine = project.context().pathExpressionEngine()
 
-      let i = 0
 
-      // eng.with<File>(project, "//File()[/PythonRawFile()//import_from()//FROM[@value='flask']]", n => {
-      //   console.log(`The file path is ${n.path()}`)
-      //   i++
-      // })
+    eng.with<TreeNode>(project, "//File()/PythonRawFile()//import_from()//dotted_name", n => {
+        console.log(`The FROM value is '${n.value()}'`)
+      })
+
+      let count = 0
+      eng.with<File>(project, "//File()[/PythonRawFile()//import_from()//dotted_name[@value='flask']]", n => {
+        console.log(`The file path is '${n.path()}'`)
+        count++
+      })
+
+      if (count == 0)
+       throw new Error("No files with flask imports found. Sad.")
+
+      let i = 0
 
       eng.with<TreeNode>(project, "//File()/PythonRawFile()//import_stmt()", n => {
         console.log(`The node is ${n.value()}`)

--- a/src/test/resources/com/atomist/rug/kind/python3/ListImports.ts
+++ b/src/test/resources/com/atomist/rug/kind/python3/ListImports.ts
@@ -25,15 +25,6 @@ class Imports implements ProjectEditor {
 
       if (count == 0)
        throw new Error("No files with flask imports found. Sad.")
-
-      let i = 0
-
-      eng.with<TreeNode>(project, "//File()/PythonRawFile()//import_stmt()", n => {
-        console.log(`The node is ${n.value()}`)
-        i++
-      })
-      if (i == 0)
-       throw new Error("No Pythons found. Sad.")
     }
   }
 export let editor = new Imports();

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
@@ -49,9 +49,9 @@ class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "modify imports in single file" in pendingUntilFixed {
+  it should "modify imports in single file" in {
     val r = modifyPythonAndReparseSuccessfully("ChangeImports.ts", Flask1)
-    val f = r.findFile("setup.py").get
+    val f = r.findFile("hello.py").get
     f.content.contains("newImport") should be(true)
   }
 

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonRawFileTypeUsageTest.scala
@@ -40,7 +40,7 @@ class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
   }
 
   it should "enumerate imports in simple project" in {
-    val r = executePython("Imports.ts", Flask1)
+    val r = executePython("ListImports.ts", Flask1)
     r match {
       case nmn: NoModificationNeeded =>
       case sm: SuccessfulModification =>
@@ -49,17 +49,8 @@ class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
     }
   }
 
-  /*
-  it should "modify imports in simple file" in {
-    val prog =
-      """
-        |editor ImportUpdater
-        |
-        |with PythonFile
-        | with import
-        |   do setName "newImport"
-      """.stripMargin
-    val r = modifyPythonAndReparseSuccessfully(prog, Simple)
+  it should "modify imports in single file" in pendingUntilFixed {
+    val r = modifyPythonAndReparseSuccessfully("ChangeImports.ts", Flask1)
     val f = r.findFile("setup.py").get
     f.content.contains("newImport") should be(true)
   }
@@ -71,6 +62,7 @@ class PythonRawFileTypeUsageTest extends FlatSpec with Matchers {
       |    return "Hello World!"
     """.stripMargin
 
+  /*
   it should "add Flask route to Python file" in {
     val prog =
       """

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
@@ -79,7 +79,22 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     rtn.right.get should equal (Seq(fooNode1, fooNode2))
   }
 
-  it should "match on node type" in {
+  it should "match on node name with /@name" in
+    matchOnNodeName("/nested/level2/*[@name='foo']")
+
+  it should "match on node name with //@name" in
+    matchOnNodeName("/nested/level2//*[@name='foo']")
+
+  it should "match on node name with //foo" in
+    matchOnNodeName("/nested/level2//foo")
+
+  it should "match on node name with /foo and or predicate" in
+    matchOnNodeName("/nested/level2/*[@value='foo1' or @value='foo2']")
+
+  it should "match on node name with //foo and or predicate" in
+    matchOnNodeName("/nested/level2//*[@value='foo1' or @value='foo2']")
+
+  private def matchOnNodeName(expr: String) {
     val tn = new ParsedMutableContainerTreeNode("name")
     val prop1 = new ParsedMutableContainerTreeNode("nested")
     val prop11 = new ParsedMutableContainerTreeNode("level2")
@@ -90,7 +105,6 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     prop11.appendField(fooNode2)
     tn.appendField(prop1)
     tn.appendField(SimpleTerminalTreeNode("bar", "bar"))
-    val expr = "/nested/level2/*[@name='foo']"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
     rtn.right.get should equal (Seq(fooNode1, fooNode2))
   }


### PR DESCRIPTION
Makes `NamedNodeTest` work under `//`--previously it broke with a match error.

Makes `value` property work in `PropertyValuePredicate`.

Implementation of `PropertyValuePredicate` is a bit inelegant, but we can refine later.