### PR TITLE
Make pad a transformation, for conceptual reasons

### DIFF
--- a/src/main/scala/com/atomist/tree/content/text/PositionedTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/PositionedTreeNode.scala
@@ -1,6 +1,6 @@
 package com.atomist.tree.content.text
 
-import com.atomist.tree.TreeNode
+import com.atomist.tree.{MutableTreeNode, TreeNode}
 
 trait Positioned {
 


### PR DESCRIPTION
Conceptually, pad transforms a node from a PositionedTreeNode to a MutableTreeNode.
conceptually, PositionedTreeNodes must not be updated
while it's OK to update a Mutable TreeNode.
Padding is the transition, when offsets get translated to padding so that
the file can be rewritten by concatenating the values of the nodes.
Each character in the file then belongs to exactly one node.

In practice, in the current codebase, these nodes are all both PositionedTreeNode
and MutableTreeNode, and pad mutates it into MutableTreeNode.
Changing that will be work, so instead:

Make pad a static method that transforms a PositionTreeNode into a MutableTreeNode.
Then shoehorn that into the existing implementation.

This will make pad testable. It's a crucial, complicated method so this is useful.