### PR TITLE
Describe the types in the union

### DIFF
--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -134,6 +134,8 @@ private object jsSafeCommittingProxy {
   */
 private case class UnionType(types: Set[Typed]) extends Typed {
 
+  override val name = s"Union(${types.map(_.name)})"
+
   private val typesToUnion = Set(TypeOperation.TreeNodeType) ++ types
 
   override def description: String = s"Union-${typesToUnion.map(_.name).mkString(":")}"

--- a/src/main/scala/com/atomist/rug/spi/TypeInformation.scala
+++ b/src/main/scala/com/atomist/rug/spi/TypeInformation.scala
@@ -103,6 +103,7 @@ object TypeOperation {
     new ReflectiveStaticTypeInformation(classOf[TreeNode])
 
   val TreeNodeType = new Typed {
+    override val name = "TreeNode"
     override def description: String = "TreeNode operations"
     override def typeInformation: TypeInformation = TreeNodeTypeInformation
   }


### PR DESCRIPTION
The existing exception message wasn't really useful as it was
logging something empty in one of the use case.

Also, the description field seems to have a more useful
set of information than the name of a UnionType.