### PR TITLE
All TreeOperations and ViewTrees have descriptions

### DIFF
--- a/src/main/scala/com/atomist/tree/content/text/ViewTree.scala
+++ b/src/main/scala/com/atomist/tree/content/text/ViewTree.scala
@@ -13,12 +13,12 @@ object ViewTree {
     * @param of tree to put view over
     * @param t  FieldTransformer
     */
-  def apply(of: MutableContainerTreeNode, t: NodeTransformer): ViewTree = {
+  def apply(of: MutableContainerTreeNode, t: NodeTransformer, description: String, depth: Int = 0): ViewTree = {
 
     val filtered1 = of.fieldValues map (tn => {
       val transformed = t(tn)
       transformed.map {
-        case ctn: MutableContainerTreeNode => ViewTree(ctn, t)
+        case ctn: MutableContainerTreeNode => ViewTree(ctn, t, s"$description", depth + 1)
         case x => x
       }
     })
@@ -27,11 +27,11 @@ object ViewTree {
     // TODO this is a bit ugly
     val _fieldValues = ListBuffer.empty[TreeNode]
     _fieldValues.appendAll(filtered)
-    new ViewTree(of, filtered)
+    new ViewTree(of, filtered, description)
   }
 }
 
-class ViewTree(of: MutableContainerTreeNode, filtered: Seq[TreeNode])
+class ViewTree(of: MutableContainerTreeNode, filtered: Seq[TreeNode], val description: String)
   extends MutableContainerTreeNode {
 
   def delegate: ContainerTreeNode = of

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -15,11 +15,13 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
   // Transformation to run on matched nodes
   private val transform = collapse(
     ctn => ctn.nodeName.equals(Concat.DefaultConcatName)
-  ) andThen RemovePadding andThen Prune
+    , "it's a concat") andThen RemovePadding andThen Prune
 
   override def findMatches(input: CharSequence, l: Option[MatchListener]): Seq[MutableContainerTreeNode] = {
     val matches = findMatchesInternal(input, l)
-    val processedNodes = matches.map{ case (m, o) => outputNode(input)(m,o)}
+    val processedNodes = matches.map { case (m, o) =>
+      outputNode(input)(m, o)
+    }
     processedNodes
   }
 

--- a/src/main/scala/com/atomist/tree/utils/TreeNodeUtils.scala
+++ b/src/main/scala/com/atomist/tree/utils/TreeNodeUtils.scala
@@ -45,7 +45,7 @@ object TreeNodeUtils {
       case vt: ViewTree =>
         val contents = vt.delegate
         def stillShown(c: TreeNode) = vt.childNodes.contains(c) && shown(c)
-        tabs(depth) + info(vt) + " around \n" + toShortStr(contents, depth + 1, stillShown)
+        tabs(depth) + info(vt) + s" because '${vt.description}' around \n" + toShortStr(contents, depth + 1, stillShown)
       case ctn: ContainerTreeNode =>
         def star(c: TreeNode) = if (shown(c)) "*" else ""
         tabs(depth) + info(ctn) + (if (ctn.childNodes.nonEmpty) ":\n" else "") + ctn.childNodes.map(c => star(c) + toShortStr(c, depth + 1, shown)).mkString("\n")


### PR DESCRIPTION
because i can't println a function. Give a description every time.

This helps with debugging in tests, and it makes the code a bit more documented IMO