### PR TITLE
Add optional predicates and relative path expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Generators are now declared with the `generator` keyword
 
+-   Optional predicates in tree expressions
+
 ### Fixed
 
 -   LinkedJsonTreeDeserializer now properly returns string values

--- a/src/main/scala/com/atomist/rug/parser/CommonRugProductionsParser.scala
+++ b/src/main/scala/com/atomist/rug/parser/CommonRugProductionsParser.scala
@@ -55,7 +55,7 @@ abstract class CommonRugProductionsParser extends PathExpressionParser with Comm
 
   protected def parameterName: Parser[String]
 
-  protected def pathExpressionBlock: Parser[PathExpressionValue] = "$(" ~ pathExpression ~ ")" ~
+  protected def pathExpressionBlock: Parser[PathExpressionValue] = "$(" ~ absolutePathExpression ~ ")" ~
     opt("." ~> identifierRefString(ReservedWordsToAvoidInBody, ident)) ^^ {
     case _ ~ pe ~ _ ~ prop => PathExpressionValue(pe, prop)
   }

--- a/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/Predicate.scala
@@ -101,6 +101,34 @@ case class OrPredicate(a: Predicate, b: Predicate) extends Predicate {
 }
 
 /**
+  * Predicate that may or may not exist.  This is typically used with
+  * NestedPathExpressionPredicates so they get materialized in the returned
+  * node tree.
+  *
+  * @param p
+  */
+case class OptionalPredicate(p: Predicate) extends Predicate {
+  override def toString: String = p.name + "?"
+
+  /**
+    * Always returns true.
+    *
+    * @param root
+    * @param returnedNodes all nodes returned. This argument is
+    *                      often ignored, but can be used to discern the index of the target node.
+    * @param ee
+    * @param typeRegistry
+    * @param nodePreparer
+    * @return
+    */
+  override def evaluate(root: TreeNode,
+                        returnedNodes: Seq[TreeNode],
+                        ee: ExpressionEngine,
+                        typeRegistry: TypeRegistry,
+                        nodePreparer: Option[NodePreparer]): Boolean = true
+}
+
+/**
   * Test for the index of the given node among all returned nodes.
   * XPath indexes from 1, and unfortunately we need to do that also.
   */
@@ -121,7 +149,7 @@ case class IndexPredicate(i: Int) extends Predicate {
 
 case class PropertyValuePredicate(property: String, expectedValue: String) extends Predicate {
 
-  override def toString: String = s"$property=[$expectedValue]"
+  override def toString: String = s"@$property=$expectedValue"
 
   override def evaluate(n: TreeNode,
                         returnedNodes: Seq[TreeNode],
@@ -149,7 +177,7 @@ case class PropertyValuePredicate(property: String, expectedValue: String) exten
 
 case class NodeNamePredicate(expectedName: String) extends Predicate {
 
-  override def toString: String = s"name=[$expectedName]"
+  override def toString: String = s"@name=$expectedName"
 
   override def evaluate(n: TreeNode,
                         returnedNodes: Seq[TreeNode],
@@ -161,7 +189,7 @@ case class NodeNamePredicate(expectedName: String) extends Predicate {
 
 case class NodeTypePredicate(expectedType: String) extends Predicate {
 
-  override def toString: String = s"type=[$expectedType]"
+  override def toString: String = s"@type=$expectedType"
 
   override def evaluate(n: TreeNode,
                         returnedNodes: Seq[TreeNode],

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
@@ -245,7 +245,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
     repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
     issue.addField(repo)
-    val expr = """/Issue()[@state='open'][/belongsTo::Repo()[@name2='rug-cli']]"""
+    val expr = """/Issue()[@state='open'][belongsTo::Repo()[@name2='rug-cli']]"""
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
@@ -258,11 +258,82 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
     repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
     issue.addField(repo)
-    val expr = """/Issue()[@state='open'][/nonsense::Repo()[@name2='rug-cli']]"""
+    val expr = """/Issue()[@state='open'][nonsense::Repo()[@name2='rug-cli']]"""
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
     rtn.right.get should equal (Nil)
   }
 
+  it should "match with an optional predicate" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val expr = """/Issue()[@state='open']?"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
+
+  it should "match with a non-matching optional predicate" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val expr = """/Issue()[@state='closed']?"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
+
+  it should "match with a required and an optional predicate" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
+    repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
+    issue.addField(repo)
+    val expr = """/Issue()[@state='open'][belongsTo::Repo()[@name2='rug-cli']]?"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
+
+  it should "match with a required and a non-matching optional predicate" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
+    repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
+    issue.addField(repo)
+    val expr = """/Issue()[@state='open'][nonsense::Repo()[@name2='rug-cli']]?"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
+
+  it should "match with an optional nested predicate" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
+    repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
+    issue.addField(repo)
+    val expr = """/Issue()[@state='open'][belongsTo::Repo()[@name2='rug-cli']?]"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
+
+  it should "match with a non-matching optional nested predicate that does not" in {
+    val issue = new ContainerTreeNodeImpl("Issue", "Issue")
+    issue.addField(SimpleTerminalTreeNode("state", "open"))
+    val repo = new ContainerTreeNodeImpl("belongsTo", "Repo")
+    repo.addField(SimpleTerminalTreeNode("name2", "rug-cli"))
+    issue.addField(repo)
+    val expr = """/Issue()[@state='open'][belongsTo::Repo()[@name2='rig-cli']?]"""
+    val parent = new ContainerTreeNodeImpl("root", "root")
+    parent.addField(issue)
+    val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
+    rtn.right.get should equal (Seq(issue))
+  }
 }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionsAgainstProjectTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionsAgainstProjectTest.scala
@@ -307,7 +307,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     // Second filter is really a no op
     for (nestedType <- types) {
-      val expr2 = s"/src//File()[/$nestedType()]"
+      val expr2 = s"/src//File()[$nestedType()]"
       val rtn2 = ee.evaluate(pmv, expr2, DefaultTypeRegistry)
       val nodes = rtn2.right.get
       nodes.size should be > 1


### PR DESCRIPTION
Path expression location steps can have optional predicates, indicated
by appending the predicate block with a question mark, `[...]?`.

Since most path expressions in predicates will be relative to the
context node, support relative tree expressions.  Only absolute path
expressions are allowed at the top level.  Currently, the tree returned
by the parser does not distinguish between relative and absolute paths,
but that can be added later if needed.

Improve toString method for property predicates.