### PR TITLE
Decorator TS parameters. New js rug instance per invocation #229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Support for @parameter TS class field decorators as per
+        https://github.com/atomist/rug/issues/229
+
 -   Support for a new TS (JS) Handler programming model as per
     https://github.com/atomist/rug/issues/105
 
@@ -35,6 +38,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     https://github.com/atomist/rug/issues/199
 
 ### Changed
+
+-   We now create a new JS rug for each thread for safety.
+    https://github.com/atomist/rug/issues/78
 
 -   **BREAKING** all JS based Rugs must export (a la Common-JS) vars implementing
     the associated interfaces. Previously we scanned for all top level vars.

--- a/src/main/scala/com/atomist/event/archive/HandlerArchiveReader.scala
+++ b/src/main/scala/com/atomist/event/archive/HandlerArchiveReader.scala
@@ -42,7 +42,7 @@ class HandlerArchiveReader(
     if (handlers.nonEmpty) {
       handlers
     } else {
-      JavaScriptHandlerFinder.fromJavaScriptArchive(rugArchive, new JavaScriptHandlerContext(teamId, treeMaterializer, messageBuilder), None)
+      JavaScriptHandlerFinder.fromJavaScriptArchive(rugArchive, new JavaScriptHandlerContext(teamId, treeMaterializer, messageBuilder))
     }
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptHandlerFinder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptHandlerFinder.scala
@@ -1,5 +1,7 @@
 package com.atomist.rug.runtime.js
 
+import javax.script.SimpleBindings
+
 import com.atomist.event.SystemEventHandler
 import com.atomist.param.Tag
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
@@ -16,7 +18,7 @@ import scala.util.Try
 object JavaScriptHandlerFinder {
 
   /**
-    * Find and handlers operations in the given Rug archive
+    * Find handler operations in the given Rug archive
     *
     * @param rugAs   archive to look into
     * @param atomist facade to Atomist
@@ -26,24 +28,18 @@ object JavaScriptHandlerFinder {
   def registerHandlers(rugAs: ArtifactSource,
                        atomist: AtomistFacade,
                        atomistConfig: AtomistConfig = DefaultAtomistConfig): Unit = {
-    val jsc = new JavaScriptContext()
 
     //TODO - remove this when new Handler model put in
-    jsc.engine.put("atomist", atomist)
-    jsc.load(rugAs)
+    val bindings = new SimpleBindings()
+    bindings.put("atomist", atomist)
+    new JavaScriptContext(rugAs,atomistConfig,bindings)
   }
 
   def fromJavaScriptArchive(rugAs: ArtifactSource,
-                            ctx: JavaScriptHandlerContext,
-                            context: Option[JavaScriptContext]): Seq[SystemEventHandler] = {
+                            ctx: JavaScriptHandlerContext): Seq[SystemEventHandler] = {
 
-    val jsc: JavaScriptContext =
-      if (context.isEmpty)
-        new JavaScriptContext()
-      else
-        context.get
+    val jsc = new JavaScriptContext(rugAs)
 
-    jsc.load(rugAs)
     handlersFromVars(rugAs, jsc, ctx)
   }
 

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinder.scala
@@ -33,16 +33,8 @@ object JavaScriptOperationFinder {
     * @param rugAs archive to look into
     * @return a sequence of instantiated operations backed by JavaScript
     */
-  def fromJavaScriptArchive(rugAs: ArtifactSource,
-                            context: JavaScriptContext = null): Seq[ProjectOperation] = {
-    val jsc: JavaScriptContext =
-      if (context == null)
-        new JavaScriptContext()
-      else
-        context
-
-    jsc.load(rugAs)
-    operationsFromVars(rugAs, jsc)
+  def fromJavaScriptArchive(rugAs: ArtifactSource): Seq[ProjectOperation] = {
+    operationsFromVars(rugAs, new JavaScriptContext(rugAs))
   }
 
   // TODO clean up this dispatch/signature stuff - too coupled

--- a/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
@@ -30,19 +30,23 @@ abstract class Pattern {
   public static uuid: string ="@uuid"
 }
 
-interface Parameter {
+interface BaseParameter {
+  pattern: string
   required?: boolean
-  name: string
   description?: string
   displayName?: string
   validInput?: string
   displayable?: boolean
-  default?: string
-  pattern: string
   maxLength?: number
   minLength?: number
   tags?: string[]
 }
+
+interface Parameter extends BaseParameter{
+  name: string
+  default?: string
+}
+
 
 /**
  * Status of an operation.
@@ -93,4 +97,41 @@ class ReviewResult {
       public comments: ReviewComment[]) {}
 }
 
-export {RugOperation, Parameter, Pattern, Result, Status, ReviewResult, ReviewComment, Severity}
+
+
+//used by annotation functions
+
+function set_metadata(obj: any, key: string, value: any){
+  Object.defineProperty(obj, key, {value: value, writable: false, enumerable: false})
+}
+
+
+function get_metadata(obj: any, key: string){
+   let desc =  Object.getOwnPropertyDescriptor(obj, key);
+   if((desc == null || desc == undefined) && (obj.prototype != undefined)){
+     desc = Object.getOwnPropertyDescriptor(obj.prototype, key);
+   }
+   if(desc != null || desc != undefined){
+     return desc.value;
+   }
+   return null;
+}
+
+
+/**
+* Decorator for parameters. Adds to object properties
+*/
+function parameter(details: BaseParameter) {
+  return function (target: any, propertyKey: string) {
+    var params = get_metadata(target, "parameters");
+    if(params == null){
+      params = []
+    }
+    details["name"] = propertyKey
+    details["decorated"] = true
+    params.push(details);
+    set_metadata(target, "parameters", params);
+  }
+}
+
+export {RugOperation, Parameter, Pattern, Result, Status, ReviewResult, ReviewComment, Severity, BaseParameter, parameter}

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTypeScriptEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTypeScriptEditorTest.scala
@@ -27,12 +27,8 @@ class ElmTypeScriptEditorTest extends FlatSpec with Matchers {
 
     withClue(s"README content----------\n$readme\n----------\n") {
       readme.contains( s"# ${projectName}") should be(true)
-
       readme.contains(s"${System.lineSeparator()}${description}${System.lineSeparator()}") should be(true)
-
-     // readme.contains(s"https://${org}.github.io/${repo}") should be(true)
     }
-
   }
 
   def singleFileArtifactSource(projectName: String): SimpleFileBasedArtifactSource = {

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptContextTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptContextTest.scala
@@ -13,7 +13,7 @@ class JavaScriptContextTest extends FlatSpec with Matchers {
   it should "throw an exception containing the JS file name if there are error during eval" in {
     val filename = ".atomist/editors/SimpleEditor.js"
     val caught = intercept[RugJavaScriptException] {
-      new JavaScriptContext().load(SimpleFileBasedArtifactSource(StringFileArtifact(filename, SimpleEditorWithoutParameters)))
+      new JavaScriptContext(SimpleFileBasedArtifactSource(StringFileArtifact(filename, SimpleEditorWithoutParameters)))
     }
     caught.getMessage should include(filename)
   }

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperationTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperationTest.scala
@@ -207,6 +207,15 @@ class JavaScriptInvokingProjectOperationTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "create two separate js objects for each operation" in {
+    val tsf = StringFileArtifact(s".atomist/reviewers/SimpleEditor.ts", SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters)
+    val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
+    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    val v1 = jsed.cloneVar(jsed.jsVar)
+    v1.put("name", "dude")
+    jsed.jsVar.get("name") should be ("Simple")
+  }
+
   private def invokeAndVerifySimpleEditor(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinderTest.scala
@@ -1,0 +1,132 @@
+package com.atomist.rug.runtime.js
+
+import com.atomist.project.SimpleProjectOperationArguments
+import com.atomist.rug.ts.TypeScriptBuilder
+import com.atomist.source.{FileArtifact, SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, Matchers}
+import com.atomist.util.Timing._
+
+
+class JavaScriptOperationFinderTest  extends FlatSpec with Matchers {
+
+  val SimpleProjectEditorWithParametersArray: String =
+    s"""
+       |import {Project} from '@atomist/rug/model/Core'
+       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+       |import {File} from '@atomist/rug/model/Core'
+       |import {Parameter} from '@atomist/rug/operations/RugOperation'
+       |
+       |class SimpleEditor implements ProjectEditor {
+       |    name: string = "Simple"
+       |    description: string = "A nice little editor"
+       |    parameters: Parameter[] = [{name: "content", description: "Content", pattern: "^.*$$", maxLength: 100}]
+       |    edit(project: Project, {content} : {content: string}) {
+       |    }
+       |  }
+       |export let editor = new SimpleEditor()
+    """.stripMargin
+
+  val SimpleProjectEditorWithAnnotatedParameters: String =
+    s"""
+       |import {Project} from '@atomist/rug/model/Core'
+       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+       |import {File} from '@atomist/rug/model/Core'
+       |import {parameter} from '@atomist/rug/operations/RugOperation'
+       |
+       |class SimpleEditor implements ProjectEditor {
+       |    name: string = "Simple"
+       |    description: string = "A nice little editor"
+       |
+       |    @parameter({pattern: "^.*$$", description: "foo bar"})
+       |    content: string = "Test String";
+       |
+       |    @parameter({pattern: "^\\d+$$", description: "A nice round number"})
+       |    amount: number = 10;
+       |
+       |    @parameter({pattern: "^\\d+$$", description: "A nice round number"})
+       |    nope: boolean;
+       |
+       |    edit(project: Project) {
+       |       if(this.amount != 10) {
+       |          throw new Error("Number should be 10!");
+       |       }
+       |       if(this.content != "woot") {
+       |          throw new Error("Name should be woot");
+       |       }
+       |    }
+       |  }
+       |export let editor = new SimpleEditor()
+    """.stripMargin
+
+  it should "find an editor with a parameters list" in {
+    val eds = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleProjectEditorWithParametersArray))
+    eds.parameters.size should be(1)
+  }
+
+  it should "find an editor using annotated parameters" in {
+    val eds = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleProjectEditorWithAnnotatedParameters))
+    eds.parameters.size should be(3)
+    eds.parameters(0).getDefaultValue should be("Test String")
+    eds.parameters(1).getDefaultValue should be("10")
+    eds.parameters(2).getDefaultValue should be("")
+
+  }
+
+  it should "run fast, especially when run a whole bunch of times" in {
+    //runPerfTest()
+  }
+
+  private def runPerfTest(): Unit = {
+    val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
+    val (as, compileTime) = time {
+      val tsf = StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleProjectEditorWithAnnotatedParameters)
+      TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
+    }
+    println(s"Compiling took: $compileTime ms")
+
+    val (ed, evalTime) = time {
+      JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    }
+    println(s"Loading editor took: $evalTime ms")
+
+    val (_, run1) = time {
+      1 to 2 foreach { _ => ed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))}
+    }
+    println(s"1 run took: -> $run1 ms")
+
+    val (_, run10) = time {
+      1 to 10 foreach { _ => ed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))}
+    }
+    println(s"10 runs took: -> ${run10/10d} ms/run")
+
+    val (_, run100) = time {
+      1 to 100 foreach { _ => ed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))}
+    }
+    println(s"100 runs took: -> ${run100/100d} ms/run")
+
+    val (_, run1000) = time {
+      1 to 1000 foreach { _ => ed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))}
+    }
+    println(s"1000 runs took: -> ${run1000/1000d} ms/run")
+
+    val (_, run100000) = time {
+      1 to 100000 foreach { _ => ed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))}
+    }
+    println(s"100000 runs took: -> ${run100000/100000d} ms/run")
+
+    val (_, run1000000) = time {
+      1 to 1000000 foreach { _ => ed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))}
+    }
+    println(s"1000000 runs took: -> ${run1000000/1000000d} ms/run")
+  }
+
+
+  private def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
+    val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
+    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    jsed.name should be("Simple")
+    val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
+    jsed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))
+    jsed
+  }
+}

--- a/src/test/scala/com/atomist/rug/ts/TypeScriptBuilder.scala
+++ b/src/test/scala/com/atomist/rug/ts/TypeScriptBuilder.scala
@@ -6,6 +6,7 @@ import com.atomist.project.SimpleProjectOperationArguments
 import com.atomist.rug.compiler.typescript.TypeScriptCompiler
 import com.atomist.source.ArtifactSource
 import com.atomist.source.file.{FileSystemArtifactSource, FileSystemArtifactSourceIdentifier}
+import com.atomist.source.filter.ArtifactFilter
 
 /**
   * Helps us compile TypeScript archives.
@@ -18,7 +19,9 @@ object TypeScriptBuilder {
   val userModel: ArtifactSource = {
     val generator = new TypeScriptInterfaceGenerator
     val output = generator.generate("stuff", SimpleProjectOperationArguments("", Map(generator.OutputPathParam -> "Core.ts")))
-    val src = new FileSystemArtifactSource(FileSystemArtifactSourceIdentifier(new File("src/main/typescript"))) // THIS ONLY WORKS IN TESTS NOT IN PRODUCTION
+    val src = new FileSystemArtifactSource(FileSystemArtifactSourceIdentifier(new File("src/main/typescript")), new ArtifactFilter {
+      override def apply(s: String) = {!s.endsWith(".js")}
+    }) // THIS ONLY WORKS IN TESTS NOT IN PRODUCTION BY DESIGN
     val compiled = compiler.compile(src.underPath("node_modules/@atomist").withPathAbove(".atomist") + output.withPathAbove(".atomist/rug/model"))
     compiled.underPath(".atomist").withPathAbove(".atomist/node_modules/@atomist")
   }

--- a/src/test/scala/com/atomist/util/lang/JavaScriptArrayTest.scala
+++ b/src/test/scala/com/atomist/util/lang/JavaScriptArrayTest.scala
@@ -20,23 +20,14 @@ class JavaScriptArrayTest extends FlatSpec with Matchers {
       |
       |import {Result,Status, Parameter} from '@atomist/rug/operations/RugOperation'
       |
-      |
-      |declare var Java
-      |
-      |var ArrayList = Java.type("java.util.ArrayList");
-      |var jlist = new ArrayList;
-      |jlist.add("blah");
-      |var FancyList = Java.type("com.atomist.util.lang.JavaScriptArray");
-      |var javaList = new FancyList(jlist);
-      |
       |class ConstructedEditor implements ProjectEditor {
       |    name: string = "Constructed"
       |    description: string = "A nice little editor"
       |    parameters: Parameter[] = [{name: "packageName", description: "The java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100}]
       |    lyst: string[]
-      |    edit(project: Project, {packageName}: {packageName: string}) {
+      |    edit(project: Project, {packageName, strings}: {packageName: string, strings: string[]}) {
       |
-      |       this.lyst = javaList as string[];
+      |       this.lyst = strings
       |
       |       this.lyst[0].toString()
       |
@@ -246,26 +237,17 @@ class JavaScriptArrayTest extends FlatSpec with Matchers {
   private def invokeAndVerifyConstructed(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 
-    val ctx = new JavaScriptContext(Set("java.util.ArrayList","com.atomist.util.lang.JavaScriptArray"))
-    ctx.load(as)
-    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as, ctx).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+    val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
     jsed.name should be("Constructed")
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
 
-    jsed.modify(target, SimpleProjectOperationArguments("", Map("packageName" -> "com.atomist.crushed"))) match {
+    val lyzt = new util.ArrayList[String]()
+    lyzt.add("blah")
+    jsed.modify(target, SimpleProjectOperationArguments("", Map("packageName" -> "com.atomist.crushed", "strings" -> new JavaScriptArray(lyzt)))) match {
       case sm: NoModificationNeeded =>
       sm.comment.contains("OK") should be(true)
     }
     jsed
-  }
-
-  object TemporaryRegistry extends UserModelContext{
-
-    val lyst = new util.ArrayList[String]()
-    lyst.add("blah")
-    override val registry = Map(
-      "PathExpressionEngine" -> new JavaScriptArray[String](lyst)
-    )
   }
 }


### PR DESCRIPTION
- add support for decorated parameters
- decorate actually just populates the 'parameters' property
   - totally backwards compatible and interchangeable

```typescript
import {Project} from '@atomist/rug/model/Core'
import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
import {File} from '@atomist/rug/model/Core'
import {parameter} from '@atomist/rug/operations/RugOperation'

class SimpleEditor implements ProjectEditor {
    name: string = "Simple"
    description: string = "A nice little editor"

    @parameter({pattern: "^.*$$", description: "foo bar"})
    content: string = "Test String";

    @parameter({pattern: "^\\d+$$", description: "A nice round number"})
    amount: number = 10;

    @parameter({pattern: "^\\d+$$", description: "A nice round number"})
    nope: boolean;

    edit(project: Project) {
       if(this.amount != 10) {
          throw new Error("Number should be 10!");
       }
       if(this.content != "woot") {
          throw new Error("Name should be woot");
       }
    }
  }
export let editor = new SimpleEditor()
```