### PR TITLE
Antlr node mapping

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.kind.grammar.{AntlrRawFileType, RawNodeUnderFileMutableVi
 import com.atomist.rug.spi.{ExportFunction, ExportFunctionParameterDescription}
 import com.atomist.source.FileArtifact
 import com.atomist.tree.content.text.MutableContainerTreeNode
+import com.atomist.tree.content.text.grammar.antlr.FromGrammarNamingStrategy
 import com.atomist.tree.pathexpression.{PathExpression, PathExpressionParser}
 
 object CSharpFileType {
@@ -15,6 +16,7 @@ object CSharpFileType {
 
 class CSharpFileType
   extends AntlrRawFileType(topLevelProduction = "compilation_unit",
+    FromGrammarNamingStrategy,
     "classpath:grammars/antlr/CSharpLexer.g4",
     "classpath:grammars/antlr/CSharpParser.g4"
   ) {

--- a/src/main/scala/com/atomist/rug/kind/dynamic/ContainerTreeNodeView.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/ContainerTreeNodeView.scala
@@ -70,7 +70,7 @@ class ScalarValueView(
 
   override def dirty: Boolean = originalBackingObject.dirty
 
-  addTypes(currentBackingObject.nodeType)
+  addTypes(currentBackingObject.nodeType ++ Set("MutableTerminal"))
 
   override def nodeName: String = originalBackingObject.nodeName
 

--- a/src/main/scala/com/atomist/rug/kind/grammar/AntlrRawFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/AntlrRawFileType.scala
@@ -12,7 +12,7 @@ import com.atomist.source.{ArtifactSource, FileArtifact}
 import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.grammar.MatchListener
-import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.tree.content.text.grammar.antlr.{AntlrGrammar, AstNodeNamingStrategy}
 import com.atomist.util.Utils.withCloseable
 import org.apache.commons.io.IOUtils
 import org.springframework.core.io.DefaultResourceLoader
@@ -27,6 +27,7 @@ import scala.collection.JavaConverters._
   */
 abstract class AntlrRawFileType(
                                  topLevelProduction: String,
+                                 namingStrategy: AstNodeNamingStrategy,
                                  grammars: String*
                                )
   extends Type(DefaultEvaluator)
@@ -39,7 +40,7 @@ abstract class AntlrRawFileType(
     resources.map(r => withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8)))
   }
 
-  private lazy val antlrGrammar = new AntlrGrammar(topLevelProduction, g4s: _*)
+  private lazy val antlrGrammar = new AntlrGrammar(topLevelProduction, namingStrategy, g4s: _*)
 
   final override def resolvesFromNodeTypes = Set("Project", "File")
 

--- a/src/main/scala/com/atomist/rug/kind/javascript/JavaScriptParser.scala
+++ b/src/main/scala/com/atomist/rug/kind/javascript/JavaScriptParser.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.kind.javascript
 
 import java.nio.charset.StandardCharsets
 
-import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.tree.content.text.grammar.antlr.{AntlrGrammar, FromGrammarNamingStrategy}
 import com.atomist.tree.content.text.grammar.{MatchListener, Parser}
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.TreeNodeOperations._
@@ -21,7 +21,7 @@ class JavaScriptParser extends Parser {
     withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8))
   }
 
-  private lazy val jsGrammar = new AntlrGrammar("program", g4)
+  private lazy val jsGrammar = new AntlrGrammar("program", FromGrammarNamingStrategy, g4)
 
   override def parse(input: String, ml: Option[MatchListener] = None): Option[MutableContainerTreeNode] = {
     jsGrammar.parse(input, ml)

--- a/src/main/scala/com/atomist/rug/kind/json/JsonParser.scala
+++ b/src/main/scala/com/atomist/rug/kind/json/JsonParser.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.kind.json
 
 import java.nio.charset.StandardCharsets
 
-import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.tree.content.text.grammar.antlr.{AntlrGrammar, FromGrammarNamingStrategy}
 import com.atomist.tree.content.text.grammar.{MatchListener, Parser}
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.TreeNodeOperations._
@@ -21,7 +21,7 @@ class JsonParser extends Parser {
     withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8))
   }
 
-  private lazy val jsGrammar = new AntlrGrammar("json", g4)
+  private lazy val jsGrammar = new AntlrGrammar("json", FromGrammarNamingStrategy, g4)
 
   override def parse(input: String, ml: Option[MatchListener] = None): Option[MutableContainerTreeNode] = {
     jsGrammar.parse(input, ml).map(raw => {

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.kind.python3
 
 import com.atomist.rug.kind.grammar.AntlrRawFileType
 import com.atomist.source.FileArtifact
+import com.atomist.tree.content.text.grammar.antlr.FromGrammarNamingStrategy
 
 object PythonFileType {
 
@@ -10,7 +11,9 @@ object PythonFileType {
 }
 
 class PythonFileType
-  extends AntlrRawFileType("file_input", "classpath:grammars/antlr/Python3.g4") {
+  extends AntlrRawFileType("file_input",
+    FromGrammarNamingStrategy,
+    "classpath:grammars/antlr/Python3.g4") {
 
   import PythonFileType._
 

--- a/src/main/scala/com/atomist/tree/content/text/AbstractMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/AbstractMutableContainerTreeNode.scala
@@ -21,6 +21,8 @@ abstract class AbstractMutableContainerTreeNode(val nodeName: String)
 
   private var _padded = false
 
+  protected def markPadded = _padded = true
+
   override def padded: Boolean = _padded
 
   final override def childNodes: Seq[TreeNode] = _fieldValues
@@ -254,6 +256,8 @@ class MutableButNotPositionedContainerTreeNode(
   initialFieldValues.foreach(insertFieldCheckingPosition)
 
   override def childrenNamed(key: String): Seq[TreeNode] = fieldValues.filter(n => n.nodeName.equals(key))
+
+  markPadded
 
   var endPosition: InputPosition = _
 

--- a/src/main/scala/com/atomist/tree/content/text/MutableTerminalTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/MutableTerminalTreeNode.scala
@@ -1,7 +1,8 @@
 package com.atomist.tree.content.text
 
 import com.atomist.rug.spi.{ExportFunction, TypeProvider}
-import com.atomist.tree.{MutableTreeNode, TerminalTreeNode}
+import com.atomist.tree.TreeNode.{Signal, Significance, Noise, Undeclared}
+import com.atomist.tree.{MutableTreeNode, TerminalTreeNode, TreeNode}
 
 class MutableTerminalTreeNodeTypeProvider
   extends TypeProvider(classOf[MutableTerminalTreeNode]) {
@@ -14,10 +15,10 @@ class MutableTerminalTreeNodeTypeProvider
   *
   * @param nodeName name of the field
   */
-class MutableTerminalTreeNode(
-                               val nodeName: String,
-                               val initialValue: String,
-                               val startPosition: InputPosition)
+class MutableTerminalTreeNode(val nodeName: String,
+                              val initialValue: String,
+                              val startPosition: InputPosition,
+                              override val significance: Significance = TreeNode.Signal)
   extends TerminalTreeNode
     with PositionedTreeNode
     with MutableTreeNode {
@@ -46,6 +47,12 @@ class MutableTerminalTreeNode(
   def longString =
     s"scalar:${getClass.getSimpleName}: $nodeName=[$currentValue], position=$startPosition"
 
-  override def toString =
-    s"[scalar:name='$nodeName'; value='$currentValue'; $startPosition]"
+  override def toString = {
+    val sig = significance match {
+      case Noise => "noise "
+      case Signal => "signal "
+      case Undeclared => ""
+    }
+    s"[${sig}scalar:name='$nodeName'; value='$currentValue'; $startPosition]"
+  }
 }

--- a/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
@@ -1,12 +1,14 @@
 package com.atomist.tree.content.text
 
 import com.atomist.tree.TreeNode
+import com.atomist.tree.TreeNode.Significance
 
 class SimpleMutableContainerTreeNode(
                                       name: String,
                                       val initialFieldValues: Seq[TreeNode],
                                       val startPosition: InputPosition,
-                                      val endPosition: InputPosition
+                                      val endPosition: InputPosition,
+                                      override val significance: Significance = TreeNode.Noise
                                     )
   extends AbstractMutableContainerTreeNode(name) {
 
@@ -41,9 +43,9 @@ object SimpleMutableContainerTreeNode {
     * @param kids nodes to wrap
     * @return wrapper node containing the single child
     */
-  def wrap(name: String, kids: Seq[PositionedTreeNode]): SimpleMutableContainerTreeNode = {
+  def wrap(name: String, kids: Seq[PositionedTreeNode], significance: Significance = TreeNode.Noise): SimpleMutableContainerTreeNode = {
     require(kids.nonEmpty, "Must have children to wrap")
-    val moo = new SimpleMutableContainerTreeNode(name, kids, kids.head.startPosition, kids.last.endPosition)
+    val moo = new SimpleMutableContainerTreeNode(name, kids, kids.head.startPosition, kids.last.endPosition, significance)
     moo
   }
 
@@ -54,5 +56,5 @@ object SimpleMutableContainerTreeNode {
     * @return wrapper node containing the single child
     */
   def wrap(name: String, tn: PositionedTreeNode): SimpleMutableContainerTreeNode =
-    wrap(name, Seq(tn))
+    wrap(name, Seq(tn), significance = TreeNode.Signal) // we wouldn't be wrapping one node without a reason
 }

--- a/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
@@ -8,9 +8,12 @@ class SimpleMutableContainerTreeNode(
                                       val initialFieldValues: Seq[TreeNode],
                                       val startPosition: InputPosition,
                                       val endPosition: InputPosition,
-                                      override val significance: Significance = TreeNode.Noise
+                                      override val significance: Significance = TreeNode.Noise,
+                                      val additionalTypes: Set[String] = Set()
                                     )
   extends AbstractMutableContainerTreeNode(name) {
+
+  additionalTypes.foreach(addType(_))
 
   initialFieldValues.foreach(insertFieldCheckingPosition)
 

--- a/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
+++ b/src/main/scala/com/atomist/tree/content/text/TreeNodeOperations.scala
@@ -34,7 +34,9 @@ object TreeNodeOperations {
     // We put in a new temporary root to ensure that the root node itself gets
     val artificialRoot = new ParsedMutableContainerTreeNode("temporary-artificial-root")
     artificialRoot.appendField(mtn)
-    ViewTree(artificialRoot, ft, s"temporary artificial root with filter $description").childNodes.head.asInstanceOf[MutableContainerTreeNode]
+    val why = ViewTree(artificialRoot, ft, s"temporary artificial root with filter $description")
+    require(why.childNodes.size == 1, s"Trying to $description but nodes are disappearing or something, I don't understand this function. Input was $mtn" )
+    why.childNodes.head.asInstanceOf[MutableContainerTreeNode]
   }
 
   /**
@@ -85,7 +87,7 @@ object TreeNodeOperations {
     * Remove empty container nodes
     */
   val Prune: TreeOperation = treeOperation ({
-    case ofv: ContainerTreeNode if ofv.childNodes.isEmpty =>
+    case ofv: ContainerTreeNode if ofv.childNodes.isEmpty && ofv.significance != TreeNode.Signal =>
       None
     case x =>
       Some(x)
@@ -97,9 +99,18 @@ object TreeNodeOperations {
   val RemovePadding: TreeOperation = treeOperation ({
     case _: PaddingTreeNode =>
       None
+    case n: TerminalTreeNode if n.significance == TreeNode.Noise =>
+      None
     case x =>
       Some(x)
   }, "Remove padding")
+
+  val RemoveNoise: TreeOperation = treeOperation ({
+    case n : TerminalTreeNode if n.significance == TreeNode.Noise =>
+      None
+    case x =>
+      Some(x)
+  }, "Remove noise literals")
 
   def removeReservedWordTokens(reservedWords: Set[String]): TreeOperation = treeOperation ({
     case tok: TerminalTreeNode if reservedWords.contains(tok.value) =>

--- a/src/main/scala/com/atomist/tree/content/text/ViewTree.scala
+++ b/src/main/scala/com/atomist/tree/content/text/ViewTree.scala
@@ -2,6 +2,7 @@ package com.atomist.tree.content.text
 
 import com.atomist.tree.{ContainerTreeNode, TreeNode}
 import TreeNodeOperations.NodeTransformer
+import com.atomist.tree.TreeNode.Significance
 
 import scala.collection.mutable.ListBuffer
 
@@ -60,4 +61,6 @@ class ViewTree(of: MutableContainerTreeNode, filtered: Seq[TreeNode], val descri
     s"${getClass.getSimpleName}($nodeName:$nodeType){${childNodes.mkString(",")}}"
 
   override def dirty: Boolean = of.dirty
+
+  override def significance: Significance = of.significance
 }

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AntlrGrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AntlrGrammar.scala
@@ -14,6 +14,7 @@ import org.snt.inmemantlr.GenericParser
   */
 class AntlrGrammar(
                     production: String,
+                    namingStrategy: AstNodeNamingStrategy,
                     grammars: String*)
   extends AbstractInMemAntlrGrammar
     with Parser {
@@ -26,7 +27,7 @@ class AntlrGrammar(
 
   override def parse(input: String, ml: Option[MatchListener]): Option[MutableContainerTreeNode] = {
     logger.debug(s"Using grammars:\n$grammars")
-    val l = new ModelBuildingListener(production, ml)
+    val l = new ModelBuildingListener(production, ml, namingStrategy)
     try {
       val parser = config.parser
       parser.setListener(l)

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -24,7 +24,8 @@ object Excludes {
   */
 class ModelBuildingListener(
                              matchRule: String,
-                             ml: Option[MatchListener])
+                             ml: Option[MatchListener],
+                             namingStrategy: AstNodeNamingStrategy)
   extends DefaultListener with LazyLogging {
 
   private val results = new ListBuffer[MutableContainerTreeNode]()
@@ -65,7 +66,6 @@ class ModelBuildingListener(
     val endPos = // position(rc.stop) + rc.getStop.getText.size
       OffsetInputPosition(rc.getStop.getStopIndex + 1)
 
-
     // We only want methods on the generated class itself
     val valueMethods = rc.getClass
       .getDeclaredMethods
@@ -79,7 +79,7 @@ class ModelBuildingListener(
           case p: PositionedTreeNode if ptn.hasSamePositionAs(p) => true
           case _ => false
         })
-        fieldsToAdd.append(f)
+          fieldsToAdd.append(f)
       case tn =>
         fieldsToAdd.append(tn)
     }
@@ -100,7 +100,13 @@ class ModelBuildingListener(
     }
 
     val deduped = deduplicate(fieldsToAdd)
-    new SimpleMutableContainerTreeNode(rule, deduped, startPos, endPos, TreeNode.Undeclared, Set(rule))
+    new SimpleMutableContainerTreeNode(
+      namingStrategy.nameForContainer(rule, deduped),
+      deduped,
+      startPos,
+      endPos,
+      TreeNode.Undeclared,
+      namingStrategy.tagsForContainer(rule, deduped))
   }
 
   // Remove duplicate fields. The ones with lower case can replace the ones with upper case
@@ -190,6 +196,29 @@ class ModelBuildingListener(
     r
   }
 }
+
+/**
+  * Enables us to rename nodes from the grammar.
+  */
+trait AstNodeNamingStrategy {
+
+  def nameForContainer(rule: String, fields: Seq[TreeNode]): String
+
+  def tagsForContainer(rule: String, fields: Seq[TreeNode]): Set[String]
+
+}
+
+/**
+  * Default implementation of AstNodeNamingStrategy that takes node names from
+  * underlying Antlr grammar
+  */
+object FromGrammarNamingStrategy extends AstNodeNamingStrategy {
+
+  override def nameForContainer(rule: String, fields: Seq[TreeNode]): String = rule
+
+  override def tagsForContainer(rule: String, fields: Seq[TreeNode]): Set[String] = Set(rule)
+}
+
 
 /**
   * Empty container field value including fieldName information about possible fields,

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -65,9 +65,6 @@ class ModelBuildingListener(
     val endPos = // position(rc.stop) + rc.getStop.getText.size
       OffsetInputPosition(rc.getStop.getStopIndex + 1)
 
-    // Create an empty model node that we'll fill
-    val tn = new SimpleMutableContainerTreeNode(rule, Nil, startPos, endPos)
-    tn.addType(rule)
 
     // We only want methods on the generated class itself
     val valueMethods = rc.getClass
@@ -103,11 +100,7 @@ class ModelBuildingListener(
     }
 
     val deduped = deduplicate(fieldsToAdd)
-    for {
-      f <- deduped
-    }
-      tn.insertFieldCheckingPosition(f)
-    tn
+    new SimpleMutableContainerTreeNode(rule, deduped, startPos, endPos, TreeNode.Undeclared, Set(rule))
   }
 
   // Remove duplicate fields. The ones with lower case can replace the ones with upper case

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Concat.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Concat.scala
@@ -1,6 +1,6 @@
 package com.atomist.tree.content.text.microgrammar
 
-import com.atomist.tree.ContainerTreeNode
+import com.atomist.tree.{ContainerTreeNode, TreeNode}
 import com.atomist.tree.content.text.microgrammar.Matcher.MatchPrefixResult
 import com.atomist.tree.content.text.{PositionedTreeNode, SimpleMutableContainerTreeNode}
 import com.typesafe.scalalogging.Logger
@@ -46,13 +46,13 @@ case class Concat(left: Matcher, right: Matcher, name: String = Concat.DefaultCo
               case (None, Some(r)) => Some(r)
               case (Some(l), Some(r)) =>
                 val mergedFields = (l match {
-                  case ctn: ContainerTreeNode => ctn.childNodes
+                  case ctn: ContainerTreeNode if ctn.significance != TreeNode.Signal => ctn.childNodes
                   case n => Seq(n)
                 }) ++ (r match {
-                  case ctn: ContainerTreeNode => ctn.childNodes
+                  case ctn: ContainerTreeNode if ctn.significance != TreeNode.Signal => ctn.childNodes
                   case n => Seq(n)
                 })
-                Some(new SimpleMutableContainerTreeNode(name, mergedFields, l.startPosition, r.endPosition))
+                Some(new SimpleMutableContainerTreeNode(name, mergedFields, l.startPosition, r.endPosition, significance = TreeNode.Noise))
             }
             Right(PatternMatch(mergedTree,
               leftMatch.matched + rightMatch.matched,

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/DismatchReport.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/DismatchReport.scala
@@ -1,6 +1,6 @@
 package com.atomist.tree.content.text.microgrammar
 
-import com.atomist.tree.{ContainerTreeNode, TerminalTreeNode}
+import com.atomist.tree.{ContainerTreeNode, TerminalTreeNode, TreeNode}
 import com.atomist.tree.content.text.{OffsetInputPosition, PositionedTreeNode}
 
 case class DismatchReport(why: String,
@@ -11,6 +11,13 @@ case class DismatchReport(why: String,
 
   def at(startOffset: OffsetInputPosition, endOffset: OffsetInputPosition) = {
     copy(startOffset = Some(startOffset), endOffset = Some(endOffset))
+  }
+
+  def lengthOfClosestMatch: Int = {
+    val priorMatchLen =
+    for { m <- priorMatch
+          n <- m.node } yield n.value.length
+    (Seq(0) ++ causes.map(_.lengthOfClosestMatch) ++ priorMatchLen).max
   }
 
   def andSo(consequence: String): DismatchReport = DismatchReport(consequence, Seq(this), startOffset = startOffset, endOffset = endOffset)
@@ -64,7 +71,11 @@ object DismatchReport {
           pf
       }
 
-    insertCharacter("[", startOffset,
+    val name = if(node.significance == TreeNode.Signal)
+      s"${node.nodeName}="
+    else
+       ""
+    insertCharacter(s"[$name", startOffset,
       markChildren(
         insertCharacter("]", endOffset, input)))
 

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Literal.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Literal.scala
@@ -1,5 +1,6 @@
 package com.atomist.tree.content.text.microgrammar
 
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.microgrammar.Matcher.MatchPrefixResult
 import com.atomist.tree.content.text.{MutableTerminalTreeNode, OffsetInputPosition}
 
@@ -10,19 +11,23 @@ import com.atomist.tree.content.text.{MutableTerminalTreeNode, OffsetInputPositi
   * @param named   name (optional) if we are returning a node
   */
 case class Literal(literal: String, named: Option[String] = None) extends Matcher {
+  import Literal._
 
-  override def name: String = named.getOrElse("literal")
+  override def name: String = named.getOrElse(LiteralDefaultName)
 
   override def matchPrefixInternal(inputState: InputState): MatchPrefixResult = {
     val (matched, is) = inputState.take(literal.length)
     if (matched == literal) {
-      val nodeOption = named.map { name => val node =
-        new MutableTerminalTreeNode(name, literal, inputState.inputPosition)
-        node.addType(name)
-        node
+      val node = named match {
+        case Some(name) =>
+          val node = new MutableTerminalTreeNode(name, literal, inputState.inputPosition)
+          node.addType(name)
+          node
+        case None =>
+          new MutableTerminalTreeNode(LiteralDefaultName, literal, inputState.inputPosition, significance = TreeNode.Noise)
       }
       Right(PatternMatch(
-        nodeOption,
+        Some(node),
         literal,
         is,
         this.toString))
@@ -35,6 +40,8 @@ case class Literal(literal: String, named: Option[String] = None) extends Matche
 }
 
 object Literal {
+
+  val LiteralDefaultName = ".literal"
 
   implicit def stringToMatcher(s: String): Matcher = Literal(s)
 }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -1,9 +1,9 @@
 package com.atomist.tree.content.text.microgrammar
 
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.TreeNodeOperations._
 import com.atomist.tree.content.text._
 import com.atomist.tree.content.text.grammar.MatchListener
-import com.atomist.tree.{ContainerTreeNode, TreeNode}
 
 import scala.collection.mutable.ListBuffer
 
@@ -14,11 +14,11 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
 
   // Transformation to run on matched nodes
   private val transform = collapse(
-    ctn => ctn.nodeName.equals(Concat.DefaultConcatName)
-    , "it's a concat") andThen RemovePadding andThen Prune
+    ctn => ctn.significance == TreeNode.Noise
+    , "it's a concat") andThen RemovePadding andThen RemoveNoise andThen Prune
 
   override def findMatches(input: CharSequence, l: Option[MatchListener]): Seq[MutableContainerTreeNode] = {
-    val matches = findMatchesInternal(input, l)
+    val (matches, dismatches) = findMatchesInternal(input, l)
     val processedNodes = matches.map { case (m, o) =>
       outputNode(input)(m, o)
     }
@@ -46,12 +46,14 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
 
 
   private[microgrammar] def findMatchesInternal(input: CharSequence,
-                                                listeners: Option[MatchListener]): Seq[(PatternMatch, OffsetInputPosition)] = {
+                                                listeners: Option[MatchListener]): (Seq[(PatternMatch, OffsetInputPosition)], Seq[DismatchReport]) = {
     val matches = ListBuffer.empty[(PatternMatch, OffsetInputPosition)]
+    val dismatches = ListBuffer.empty[DismatchReport]
     var is = InputState(input)
     while (!is.exhausted) {
       matcher.matchPrefix(is) match {
-        case Left(whyNot) =>
+        case Left(dismatchReport) =>
+          dismatches.append(dismatchReport)
           is = is.advance
         case Right(matchFound) =>
           listeners.foreach(l => matchFound.node.map(l.onMatch(_)))
@@ -60,7 +62,8 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
           is = matchFound.resultingInputState
       }
     }
-    matches
+
+    (matches, dismatches)
   }
 
   override def toString: String = s"MatcherMicrogrammar wrapping [$matcher]"
@@ -73,7 +76,7 @@ private class MicrogrammarNode(name: String,
                                 startPosition: InputPosition,
                                 endPosition: InputPosition)
   extends SimpleMutableContainerTreeNode(
-    name: String, fields, startPosition, endPosition) {
+    name: String, fields, startPosition, endPosition, significance = TreeNode.Signal) {
 
   addType(typ)
   addType(MicrogrammarNode.MicrogrammarNodeType)

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Regex.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Regex.scala
@@ -1,17 +1,22 @@
 package com.atomist.tree.content.text.microgrammar
 
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableTerminalTreeNode
 import com.atomist.tree.content.text.microgrammar.Matcher.MatchPrefixResult
 
 /**
   * Matches a regex.
   */
-case class Regex(name: String, regex: String, config: MatcherConfig = MatcherConfig())
+case class Regex(regex: String, givenName: Option[String], config: MatcherConfig = MatcherConfig())
   extends ConfigurableMatcher {
+  import Regex._
 
   // TODO look at greedy
 
   private val rex = regex.r
+
+  private val treeNodeSignificance = if (givenName.isDefined) TreeNode.Signal else TreeNode.Noise
+  val name = givenName.getOrElse(DefaultRegexName)
 
   override def matchPrefixInternal(inputState: InputState): MatchPrefixResult =
     if (!inputState.exhausted) {
@@ -19,7 +24,7 @@ case class Regex(name: String, regex: String, config: MatcherConfig = MatcherCon
         case Some(m) =>
           Right(PatternMatch(
             Some(
-              new MutableTerminalTreeNode(name, m.matched, inputState.inputPosition)),
+              new MutableTerminalTreeNode(name, m.matched, inputState.inputPosition, significance = treeNodeSignificance)),
             m.matched,
             inputState.take(m.matched.length)._2,
             this.toString))
@@ -28,6 +33,13 @@ case class Regex(name: String, regex: String, config: MatcherConfig = MatcherCon
     }
     else
       Left(DismatchReport("we have reached the end"))
+}
+
+object Regex {
+  @deprecated
+  def apply(name: String, regex: String): Regex = Regex(regex, Some(name))
+
+  val DefaultRegexName = ".regex"
 }
 
 /**
@@ -47,6 +59,6 @@ class Placeholder extends Matcher {
       Left(DismatchReport("no input remains")) // why can't we put a placeholder at the very end?
 }
 
-object Whitespace extends Discard(Regex("whitespace", """\s+"""))
+object Whitespace extends Discard(Regex("""\s+""", None))
 
 object WhitespaceOrNewLine extends Discard(Regex("whitespace-or-newline", """[\s\n]+"""))

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Rep.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Rep.scala
@@ -46,7 +46,7 @@ case class Rep(m: Matcher, name: String = "rep", separator: Option[Matcher] = No
           // Do nothing. The nasty vars are already being updated. Nasty vars
         }
 
-        val pos = latestInputState.inputPosition
+        val pos = inputState.inputPosition
         val endpos = if (nodes.isEmpty) pos else nodes.last.endPosition
         val combinedNode = new SimpleMutableContainerTreeNode(name, nodes, pos, endpos)
         Right(

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParser.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParser.scala
@@ -91,7 +91,7 @@ class MatcherDefinitionParser extends CommonTypesParser {
   // $name:[.*]
   private def inlineReference()(implicit matcherName: String, registry: MatcherRegistry): Parser[Matcher] =
     VariableDeclarationToken ~> ident ~ ":" ~ rex ^^ {
-      case newName ~ _ ~ regex => regex.copy(name = newName)
+      case newName ~ _ ~ regex => regex.copy(givenName = Some(newName))
     }
 
   private def matcherExpression(implicit matcherName: String, registry: MatcherRegistry): Parser[Matcher] =

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/primitives.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/primitives.scala
@@ -1,5 +1,6 @@
 package com.atomist.tree.content.text.microgrammar
 
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.SimpleMutableContainerTreeNode
 import com.atomist.tree.content.text.microgrammar.Matcher.MatchPrefixResult
 
@@ -44,13 +45,13 @@ case class Wrap(m: Matcher, name: String)
   extends Matcher {
 
   override def matchPrefixInternal(inputState: InputState): MatchPrefixResult =
-    m.matchPrefix(inputState).right.map(matched =>
-      matched.copy(node = matched.node.map(mn => {
-        val n = SimpleMutableContainerTreeNode.wrap(name, mn)
-        //println(s"New node is $n")
-        n
-      })))
-
+    m.matchPrefix(inputState).right.map {
+      matched =>
+        val wrappedNode = matched.node.map {
+          SimpleMutableContainerTreeNode.wrap(name, _)
+        }
+        matched.copy(node = wrappedNode)
+    }
 }
 
 case class Optional(m: Matcher, name: String = "optional") extends Matcher {

--- a/src/main/scala/com/atomist/tree/treeNode.scala
+++ b/src/main/scala/com/atomist/tree/treeNode.scala
@@ -1,6 +1,7 @@
 package com.atomist.tree
 
 import com.atomist.rug.spi.{ExportFunction, Typed}
+import com.atomist.tree.TreeNode.Significance
 import com.atomist.util.{Visitable, Visitor}
 
 /**
@@ -75,6 +76,20 @@ trait TreeNode extends Visitable {
     */
   def childrenNamed(key: String): Seq[TreeNode]
 
+  /**
+    * Is this tree node here to help other nodes
+    * hang together, or does it have significance
+    * to the user and the outside world?
+    */
+  def significance: Significance = TreeNode.Undeclared
+
+}
+
+object TreeNode {
+  sealed trait Significance
+  case object Noise extends Significance
+  case object Signal extends Significance
+  case object Undeclared extends Significance
 }
 
 /**

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/DismatchReportTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/DismatchReportTest.scala
@@ -14,8 +14,8 @@ class DismatchReportTest extends FlatSpec with Matchers {
 
     withClue(output) {
       output.startsWith(
-        """ [[Tony] was aged [24]]{.} Alice was aged 16. And they are both gone""") should be(true)
-      // Christian suggests this instead, and it is better:
+        """ [[name=Tony] [was aged] [age=24]]{.} Alice was aged 16. And they are both gone""") should be(true)
+      // Christian suggests this instead of {.}, and it is better:
       //    """ [[Tony] was aged [24]]. Alice was aged 16. And they are both gone
       //      |                       ~""".stripMargin) should be(true)
     }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherOperationsTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherOperationsTest.scala
@@ -1,5 +1,6 @@
 package com.atomist.tree.content.text.microgrammar
 
+import com.atomist.tree.TreeNode
 import org.scalatest.{FlatSpec, Matchers}
 
 class MatcherOperationsTest extends FlatSpec with Matchers {
@@ -17,9 +18,10 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
   it should "match literal in partial string" in {
     val l = Literal("thing")
     l.matchPrefix(InputState("thing2")) match {
-      case Right(pm) =>
-        pm should equal(
-          PatternMatch(None, "thing", InputState("thing2", offset = 5), l.toString))
+      case Right(PatternMatch(Some(node), "thing", is, value)) =>
+        node.significance should be(TreeNode.Noise)
+        value should be(l.toString)
+        is.offset should be(5)
     }
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -31,7 +31,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
       s"$RegexpOpenToken[.*]$RegexpCloseToken",
       s"$RegexpOpenToken[.]$RegexpCloseToken")
     for (v <- validLiterals) mgp.parseMatcher("y", v) match {
-      case Regex("y", rex, _) =>
+      case Regex(rex, Some("y"), _) =>
     }
   }
 
@@ -41,7 +41,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
       s"${VariableDeclarationToken}foo:$RegexpOpenToken.*$RegexpCloseToken",
       s"${VariableDeclarationToken}foo:$RegexpOpenToken.$RegexpCloseToken")
     for (v <- validLiterals) mgp.parseMatcher("x", v) match {
-      case Regex("foo", rex, _) =>
+      case Regex(rex, Some("foo"), _) =>
         withClue(s"String [$v] should contain regex [$rex]") {
           v.contains(rex) should be(true)
         }
@@ -156,7 +156,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
   it should "parse strict string literals" in {
     val f = s"""${StrictLiteralOpen}xxxx$StrictLiteralClose"""
     val parsed = mgp.parseMatcher("f", f)
-    parsed.name should be("literal")
+    parsed.name should be(".literal")
     parsed match {
       case Literal("xxxx", _) =>
     }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -15,9 +15,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
     }
   }
 
-  // TODO this is a debatable case. Why wouldn't we just match with a regex or literal string
-  // if there's nothing dynamic in the content? No nodes are created
-  it should "match literal using microgrammar" in pendingUntilFixed {
+  it should "match literal using microgrammar" in {
     val matcher = mgp.parseMatcher("lit", "def foo")
     val mg = new MatcherMicrogrammar(matcher)
     mg.findMatches("def foo bar").size should be(1)
@@ -68,8 +66,10 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
     val matches = mg.findMatches(html)
     matches.size should be(1)
 
-    matches.head.fieldValues.head.value should be ("https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
-    matches.head.fieldValues(1).value should be ("lazy emoji-wrapper")
+    withClue(matches) {
+      matches.head.fieldValues.head.value should be("https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
+      matches.head.fieldValues(1).value should be("lazy emoji-wrapper")
+    }
   }
 
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarPathExpressionTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarPathExpressionTest.scala
@@ -1,0 +1,119 @@
+package com.atomist.tree.content.text.microgrammar.dsl
+
+import com.atomist.project.archive.DefaultAtomistConfig
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.kind.core.ProjectMutableView
+import com.atomist.rug.spi.UsageSpecificTypeRegistry
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
+import com.atomist.tree.TreeNode
+import com.atomist.tree.content.text.microgrammar._
+import com.atomist.tree.pathexpression.{PathExpressionEngine, PathExpressionParser}
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
+
+  it should "Let give 0 matches when I access something that might exist but does not" in {
+
+    val microgrammar =
+      new MatcherMicrogrammar(
+        Literal("a ") ~ Regex("[a-z]+", Some("blah")) ~ Optional(Literal("yo", Some("myWord"))) ~ Literal(".")
+        , "bananagrammar")
+    val pathExpression = "/File()/bananagrammar()/myWord()"
+
+    val result = exercisePathExpression(microgrammar, pathExpression, input)
+
+    result.size should be(0)
+  }
+
+  it should "Let give 0 matches when I access something deep that might exist but does not" in {
+
+    val microgrammar =
+      new MatcherMicrogrammar(
+        Literal("a ") ~ Regex("[a-z]+", Some("blah")) ~ Optional(Literal("yo") ~ Wrap(Rep(Regex("[a-z]+", Some("carrot"))), "banana")) ~ Literal(".")
+        , "bananagrammar")
+    val pathExpression = "/File()/bananagrammar()/banana()/carrot()"
+
+    val result = exercisePathExpression(microgrammar, pathExpression, input)
+
+    result.size should be(0)
+  }
+
+  it should "Fail when I name a node that can't possibly exist" in pendingUntilFixed {
+
+    val microgrammar =
+      new MatcherMicrogrammar(
+        Literal("a ") ~ Regex("[a-z]+", Some("blah"))
+        , "bananagrammar")
+    val pathExpression = "/File()/bananagrammar()/dadvan()"
+
+    val message = exerciseFailingPathExpression(microgrammar, pathExpression, input)
+    message should be("what should it be")
+  }
+
+
+  def exercisePathExpression(microgrammar: Microgrammar, pathExpressionString: String, input: String): List[TreeNode] = {
+
+    val result = exercisePathExpressionInternal(microgrammar, pathExpressionString, input)
+
+    result match {
+      case Left(a) => fail(a)
+      case Right(b) => b
+    }
+  }
+
+  private def exercisePathExpressionInternal(microgrammar: Microgrammar, pathExpressionString: String, input: String) = {
+
+    /* Construct a root node */
+    val as = SimpleFileBasedArtifactSource(StringFileArtifact("banana.txt", input))
+    val pmv = new ProjectMutableView(as /* cheating */ , as, DefaultAtomistConfig)
+
+    /* Parse the path expression */
+    val pathExpression = PathExpressionParser.parseString(pathExpressionString)
+
+    /* Install the microgrammar */
+    val typeRegistryWithMicrogrammar =
+      new UsageSpecificTypeRegistry(DefaultTypeRegistry,
+        Seq(new MicrogrammarTypeProvider(microgrammar)))
+
+    new PathExpressionEngine().evaluate(pmv, pathExpression, typeRegistryWithMicrogrammar)
+  }
+
+  def exerciseFailingPathExpression(microgrammar: Microgrammar, pathExpressionString: String, input: String): String = {
+    val result = exercisePathExpressionInternal(microgrammar, pathExpressionString, input)
+
+    result match {
+      case Left(a) => a
+      case Right(b) => fail("This was supposed to fail")
+    }
+  }
+
+
+  val input: String =
+    """There was a banana. It crossed the street. A car ran over it.
+      |No banana for you.
+      |""".stripMargin
+
+  it should "match an unnamed literal" in {
+
+    val microgrammar = new MatcherMicrogrammar(Literal("banana"), "bananagrammar")
+    val pathExpression = "/File()/bananagrammar()"
+
+    val result = exercisePathExpression(microgrammar, pathExpression, input)
+
+    result.size should be(2)
+  }
+
+  it should "match a named node" in {
+
+    val microgrammar =
+      new MatcherMicrogrammar(
+        Literal("a ") ~ Regex("[a-z]+", Some("blah")) ~ Optional(Literal("yo", Some("myWord"))) ~ Literal(".")
+        , "bananagrammar")
+    val pathExpression = "/File()/bananagrammar()/blah"
+
+    val result = exercisePathExpression(microgrammar, pathExpression, input)
+
+    result.size should be(1)
+  }
+}


### PR DESCRIPTION
Adds support for a mapping strategy from Antlr grammar productions to generated nodes. In some cases, such as language grammars designed from language specs, the names of productions in an Antlr grammar makes sense. In other cases, such as JSON, it may be counter to the user's expectation and we need the ability to map node names and types (tags).