### PR TITLE
Antlr naming

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
@@ -6,6 +6,7 @@ import com.atomist.rug.kind.grammar.{AntlrRawFileType, RawNodeUnderFileMutableVi
 import com.atomist.rug.spi.{ExportFunction, ExportFunctionParameterDescription}
 import com.atomist.source.FileArtifact
 import com.atomist.tree.content.text.MutableContainerTreeNode
+import com.atomist.tree.content.text.grammar.antlr.FromGrammarNamingStrategy
 import com.atomist.tree.pathexpression.{PathExpression, PathExpressionParser}
 
 object CSharpFileType {
@@ -15,6 +16,7 @@ object CSharpFileType {
 
 class CSharpFileType
   extends AntlrRawFileType(topLevelProduction = "compilation_unit",
+    FromGrammarNamingStrategy,
     "classpath:grammars/antlr/CSharpLexer.g4",
     "classpath:grammars/antlr/CSharpParser.g4"
   ) {

--- a/src/main/scala/com/atomist/rug/kind/grammar/AntlrRawFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/AntlrRawFileType.scala
@@ -12,7 +12,7 @@ import com.atomist.source.{ArtifactSource, FileArtifact}
 import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.grammar.MatchListener
-import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.tree.content.text.grammar.antlr.{AntlrGrammar, AstNodeNamingStrategy}
 import com.atomist.util.Utils.withCloseable
 import org.apache.commons.io.IOUtils
 import org.springframework.core.io.DefaultResourceLoader
@@ -27,6 +27,7 @@ import scala.collection.JavaConverters._
   */
 abstract class AntlrRawFileType(
                                  topLevelProduction: String,
+                                 namingStrategy: AstNodeNamingStrategy,
                                  grammars: String*
                                )
   extends Type(DefaultEvaluator)
@@ -39,7 +40,7 @@ abstract class AntlrRawFileType(
     resources.map(r => withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8)))
   }
 
-  private lazy val antlrGrammar = new AntlrGrammar(topLevelProduction, g4s: _*)
+  private lazy val antlrGrammar = new AntlrGrammar(topLevelProduction, namingStrategy, g4s: _*)
 
   final override def resolvesFromNodeTypes = Set("Project", "File")
 

--- a/src/main/scala/com/atomist/rug/kind/javascript/JavaScriptParser.scala
+++ b/src/main/scala/com/atomist/rug/kind/javascript/JavaScriptParser.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.kind.javascript
 
 import java.nio.charset.StandardCharsets
 
-import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.tree.content.text.grammar.antlr.{AntlrGrammar, FromGrammarNamingStrategy}
 import com.atomist.tree.content.text.grammar.{MatchListener, Parser}
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.TreeNodeOperations._
@@ -21,7 +21,7 @@ class JavaScriptParser extends Parser {
     withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8))
   }
 
-  private lazy val jsGrammar = new AntlrGrammar("program", g4)
+  private lazy val jsGrammar = new AntlrGrammar("program", FromGrammarNamingStrategy, g4)
 
   override def parse(input: String, ml: Option[MatchListener] = None): Option[MutableContainerTreeNode] = {
     jsGrammar.parse(input, ml)

--- a/src/main/scala/com/atomist/rug/kind/json/JsonParser.scala
+++ b/src/main/scala/com/atomist/rug/kind/json/JsonParser.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.kind.json
 
 import java.nio.charset.StandardCharsets
 
-import com.atomist.tree.content.text.grammar.antlr.AntlrGrammar
+import com.atomist.tree.content.text.grammar.antlr.{AntlrGrammar, FromGrammarNamingStrategy}
 import com.atomist.tree.content.text.grammar.{MatchListener, Parser}
 import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.content.text.TreeNodeOperations._
@@ -21,7 +21,7 @@ class JsonParser extends Parser {
     withCloseable(r.getInputStream)(is => IOUtils.toString(is, StandardCharsets.UTF_8))
   }
 
-  private lazy val jsGrammar = new AntlrGrammar("json", g4)
+  private lazy val jsGrammar = new AntlrGrammar("json", FromGrammarNamingStrategy, g4)
 
   override def parse(input: String, ml: Option[MatchListener] = None): Option[MutableContainerTreeNode] = {
     jsGrammar.parse(input, ml).map(raw => {

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.kind.python3
 
 import com.atomist.rug.kind.grammar.AntlrRawFileType
 import com.atomist.source.FileArtifact
+import com.atomist.tree.content.text.grammar.antlr.FromGrammarNamingStrategy
 
 object PythonFileType {
 
@@ -10,7 +11,9 @@ object PythonFileType {
 }
 
 class PythonFileType
-  extends AntlrRawFileType("file_input", "classpath:grammars/antlr/Python3.g4") {
+  extends AntlrRawFileType("file_input",
+    FromGrammarNamingStrategy,
+    "classpath:grammars/antlr/Python3.g4") {
 
   import PythonFileType._
 

--- a/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
@@ -8,9 +8,11 @@ class SimpleMutableContainerTreeNode(
                                       val initialFieldValues: Seq[TreeNode],
                                       val startPosition: InputPosition,
                                       val endPosition: InputPosition,
-                                      override val significance: Significance = TreeNode.Noise
-                                    )
+                                      override val significance: Significance = TreeNode.Noise,
+                                      val additionalTypes: Set[String] = Set())
   extends AbstractMutableContainerTreeNode(name) {
+
+  additionalTypes.foreach(addType(_))
 
   initialFieldValues.foreach(insertFieldCheckingPosition)
 

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AntlrGrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/AntlrGrammar.scala
@@ -14,6 +14,7 @@ import org.snt.inmemantlr.GenericParser
   */
 class AntlrGrammar(
                     production: String,
+                    namingStrategy: AstNodeNamingStrategy,
                     grammars: String*)
   extends AbstractInMemAntlrGrammar
     with Parser {
@@ -26,7 +27,7 @@ class AntlrGrammar(
 
   override def parse(input: String, ml: Option[MatchListener]): Option[MutableContainerTreeNode] = {
     logger.debug(s"Using grammars:\n$grammars")
-    val l = new ModelBuildingListener(production, ml)
+    val l = new ModelBuildingListener(production, ml, namingStrategy)
     try {
       val parser = config.parser
       parser.setListener(l)

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -65,9 +65,6 @@ class ModelBuildingListener(
     val endPos = // position(rc.stop) + rc.getStop.getText.size
       OffsetInputPosition(rc.getStop.getStopIndex + 1)
 
-    // Create an empty model node that we'll fill
-    val tn = new SimpleMutableContainerTreeNode(rule, Nil, startPos, endPos)
-    tn.addType(rule)
 
     // We only want methods on the generated class itself
     val valueMethods = rc.getClass
@@ -103,11 +100,7 @@ class ModelBuildingListener(
     }
 
     val deduped = deduplicate(fieldsToAdd)
-    for {
-      f <- deduped
-    }
-      tn.insertFieldCheckingPosition(f)
-    tn
+    new SimpleMutableContainerTreeNode(rule, deduped, startPos, endPos, Set(rule))
   }
 
   // Remove duplicate fields. The ones with lower case can replace the ones with upper case


### PR DESCRIPTION
Adds ability to map Antlr node names and types as per `AntlrGrammar` strategy. Useful to map Antlr production names to user-intelligible values. 