### PR TITLE
Detailed node position and format info can be obtained from PositionedMutableContainerTreeNode

### DIFF
--- a/src/main/scala/com/atomist/tree/content/text/FormatInfo.scala
+++ b/src/main/scala/com/atomist/tree/content/text/FormatInfo.scala
@@ -1,0 +1,78 @@
+package com.atomist.tree.content.text
+
+import com.atomist.util.lang.CodeGenerationHelper
+
+object FormatInfo {
+
+  /**
+    * Given the left input, derive position information.
+    */
+  def contextInfo(leftInput: String): FormatInfo = {
+
+    def findLeadingWhitespace(s: String): String =
+      s.takeWhile(c => c.isWhitespace)
+
+    var lineNumberFrom1 = 1
+    var currentLine = ""
+    var firstIndentedLine: Option[String] = None
+    var offs = 0
+    while (offs < leftInput.length) {
+      leftInput.charAt(offs) match {
+        case '\n' =>
+          lineNumberFrom1 += 1
+          if (firstIndentedLine.isEmpty && findLeadingWhitespace(currentLine).nonEmpty) {
+            firstIndentedLine = Some(currentLine)
+          }
+          currentLine = ""
+        case c =>
+          currentLine += c
+      }
+      offs += 1
+    }
+    val indent: String = firstIndentedLine.map(l => findLeadingWhitespace(l)).getOrElse("")
+    val indentDepth = findLeadingWhitespace(currentLine).length /
+      { if (indent.isEmpty) 1 else indent.length }
+
+    FormatInfo(
+      offs,
+      lineNumberFrom1,
+      currentLine.length + 1,
+      indentDepth,
+      indent)
+  }
+
+}
+
+
+/**
+  * Information about the format in the file
+  *
+  * @param indentDepth indent depth at the beginning of this line. Number of times
+  *                    the indent appears at the beginning of this line
+  * @param indent      indent used in the file.
+  */
+case class FormatInfo(
+                       offset: Int,
+                       lineNumberFrom1: Int,
+                       columnNumberFrom1: Int,
+                       indentDepth: Int,
+                       indent: String
+                     )
+  extends InputPosition {
+
+  private val codeGenerationHelper = new CodeGenerationHelper(indent)
+
+  /**
+    * Add content indented on next line. Tabs will be used as additional indents.
+    * @param content content to add
+    * @return indented content, including line break
+    */
+  def indented(content: String): String = {
+    val expanded = content.replaceAll("\\t", indent)
+    "\n" + codeGenerationHelper.indented(expanded, indentDepth)
+  }
+
+  def usesTabs: Boolean = indent.contains("\t")
+
+  override def show: String = toString
+}

--- a/src/main/scala/com/atomist/tree/content/text/InputPosition.scala
+++ b/src/main/scala/com/atomist/tree/content/text/InputPosition.scala
@@ -36,14 +36,6 @@ trait InputPosition {
   def show: String
 }
 
-case class OffsetInputPosition(offset: Int) extends InputPosition {
-
-  require(offset >= 0, s"Offset must be >= 0, had $offset")
-
-  override def show: String = s"offset=$offset"
-
-  override def toString: String = show
-}
 
 case class LineHoldingOffsetInputPosition(input: String, offset: Int) extends InputPosition {
 
@@ -52,11 +44,4 @@ case class LineHoldingOffsetInputPosition(input: String, offset: Int) extends In
   override def show: String = s"${input.take(offset)}  HERE [${input.drop(offset)}] : offset=$offset"
 
   override def toString: String = show
-}
-
-object OffsetInputPosition {
-
-  def startOf(s: String) = LineHoldingOffsetInputPosition(s, 0)
-
-  def endOf(s: String) = LineHoldingOffsetInputPosition(s, s.length)
 }

--- a/src/main/scala/com/atomist/tree/content/text/OffsetInputPosition.scala
+++ b/src/main/scala/com/atomist/tree/content/text/OffsetInputPosition.scala
@@ -1,0 +1,17 @@
+package com.atomist.tree.content.text
+
+case class OffsetInputPosition(offset: Int) extends InputPosition {
+
+  require(offset >= 0, s"Offset must be >= 0, had $offset")
+
+  override def show: String = s"offset=$offset"
+
+  override def toString: String = show
+}
+
+object OffsetInputPosition {
+
+  def startOf(s: String) = LineHoldingOffsetInputPosition(s, 0)
+
+  def endOf(s: String) = LineHoldingOffsetInputPosition(s, s.length)
+}

--- a/src/main/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNode.scala
@@ -37,8 +37,43 @@ abstract class PositionedMutableContainerTreeNode(val nodeName: String)
   override def pad(initialSource: String, topLevel: Boolean = false): Unit = if (!_padded) {
     val (hatched, _) = PositionedMutableContainerTreeNode.pad(this, initialSource, topLevel)
     _fieldValues = ListBuffer.empty[TreeNode]
-    _fieldValues.append(hatched.childNodes:_*)
+    _fieldValues.append(hatched.childNodes: _*)
     _padded = true
+  }
+
+  /**
+    * Return formatInfo for the start of this child node. We can obtain
+    * line and column and formatting information.
+    *
+    * @param child child of this node
+    * @return Some if the child is found
+    */
+  def formatInfoStart(child: TreeNode): Option[FormatInfo] =
+    formatInfoFor(child, start = true)
+
+  /**
+    * Return formatInfo for the end of this child node. We can obtain
+    * line and column and formatting information.
+    *
+    * @param child child of this node
+    * @return Some if the child is found
+    */
+  def formatInfoEnd(child: TreeNode): Option[FormatInfo] =
+    formatInfoFor(child, start = false)
+
+  private def formatInfoFor(child: TreeNode, start: Boolean): Option[FormatInfo] = {
+    if (!_padded)
+      throw new IllegalStateException(s"Call pad before trying to get format info from $this")
+    if (!fieldValues.contains(child))
+      None
+    else {
+      // Build string to the left
+      val leftFields = fieldValues.takeWhile(f => f != child) ++ (if (start) Nil else Seq(child))
+      val stringToLeft = leftFields.map(_.value).mkString("")
+      val fi = FormatInfo.contextInfo(stringToLeft)
+      //println(s"Found $fi from left string [$stringToLeft] with start=$start")
+      Some(fi)
+    }
   }
 
   /**
@@ -147,86 +182,87 @@ object PositionedMutableContainerTreeNode {
   def pad(pupae: PositionedTreeNode, initialSource: String, topLevel: Boolean = false): (MutableTreeNode, Report) = {
 
     var report: Seq[String] = Seq()
+
     def say(s: String) = report = s +: report
 
-      // Number of characters of fields to show in padding field names
-      val show = 40
+    // Number of characters of fields to show in padding field names
+    val show = 40
 
-      def padding(from: Int, to: Int): TreeNode = {
-        //      require(from >= 0 && from < initialSource.size, s"from for padding must be 0-${initialSource.size}, had $from")
-        //      require(to >= 0 && to < initialSource.size, s"from for padding must be 0-${initialSource.size}, $to")
+    def padding(from: Int, to: Int): TreeNode = {
+      //      require(from >= 0 && from < initialSource.size, s"from for padding must be 0-${initialSource.size}, had $from")
+      //      require(to >= 0 && to < initialSource.size, s"from for padding must be 0-${initialSource.size}, $to")
 
-        val content = initialSource.substring(from, to)
-        val name = s"$from-$to[${
-          val pcontent = TreeNodeUtils.inlineReturns(content)
-          if (pcontent.length > show) s"${pcontent.take(show)}..." else pcontent
-        }]"
-        val pad = PaddingTreeNode(name, content)
-        pad
-      }
+      val content = initialSource.substring(from, to)
+      val name = s"$from-$to[${
+        val pcontent = TreeNodeUtils.inlineReturns(content)
+        if (pcontent.length > show) s"${pcontent.take(show)}..." else pcontent
+      }]"
+      val pad = PaddingTreeNode(name, content)
+      pad
+    }
 
-      val fieldResults = ListBuffer.empty[TreeNode]
-      if (pupae.startPosition == null)
-        throw new IllegalStateException(s"startPosition not set in $pupae.nodeName: class $this")
+    val fieldResults = ListBuffer.empty[TreeNode]
+    if (pupae.startPosition == null)
+      throw new IllegalStateException(s"startPosition not set in $pupae.nodeName: class $this")
 
-      // There may be content before the first production that we want to account if we are a top level production
-      if (topLevel && pupae.startPosition.offset > 0) {
-        fieldResults.append(padding(0, pupae.startPosition.offset))
-      }
+    // There may be content before the first production that we want to account if we are a top level production
+    if (topLevel && pupae.startPosition.offset > 0) {
+      fieldResults.append(padding(0, pupae.startPosition.offset))
+    }
 
-      say(s"Processing ${pupae.childNodes.length} children")
-      var lastEndOffset = pupae.startPosition.offset
-      for {
-        fv <- pupae.childNodes
-      } {
-        fv match {
-          case sm: PositionedTreeNode if sm.initialized =>
-            // This condition isn't pretty, is it? No. I suspect we are not testing the right conditions.
-            // Perhaps we mean "if this node isn't a bunch of whitespace" (that's a thing in Python)
-            // but that whitespace appears to be appended to the previous node maybe? because if we add those
-            // whitespace nodes here it gets doubled.
-            if (sm.startPosition.offset >= lastEndOffset || sm.isInstanceOf[PositionedMutableContainerTreeNode]) {
-              try {
-                sm.pad(initialSource)
-              }
-              catch {
-                case iex: IllegalArgumentException =>
-                  throw new IllegalArgumentException(s"Cannot find position when processing $this and trying to pad $sm", iex)
-              }
-              val smoffset = sm.startPosition.offset
-              if (smoffset > lastEndOffset) fieldResults.append(padding(lastEndOffset, smoffset))
-              lastEndOffset = sm.endPosition.offset
-              fieldResults.append(sm)
+    say(s"Processing ${pupae.childNodes.length} children")
+    var lastEndOffset = pupae.startPosition.offset
+    for {
+      fv <- pupae.childNodes
+    } {
+      fv match {
+        case sm: PositionedTreeNode if sm.initialized =>
+          // This condition isn't pretty, is it? No. I suspect we are not testing the right conditions.
+          // Perhaps we mean "if this node isn't a bunch of whitespace" (that's a thing in Python)
+          // but that whitespace appears to be appended to the previous node maybe? because if we add those
+          // whitespace nodes here it gets doubled.
+          if (sm.startPosition.offset >= lastEndOffset || sm.isInstanceOf[PositionedMutableContainerTreeNode]) {
+            try {
+              sm.pad(initialSource)
             }
-            else {
-              say(s"Skipping this mutable terminal tree node. ${sm.startPosition} and lastEndOffset is ${lastEndOffset}")
+            catch {
+              case iex: IllegalArgumentException =>
+                throw new IllegalArgumentException(s"Cannot find position when processing $this and trying to pad $sm", iex)
             }
-          case mttn: PositionedTreeNode =>
-            // This one is not actually positioned now is it
-            ???
-          case f: TreeNode if "".equals(f.value) =>
-            // It's harmless. Keep it as it may be queried. It won't be updateable
-            // Because we probably don't know where it lives.
-            fieldResults.append(f)
-            say(s"Keeping empty node $f")
-          case other =>
-            say(s"Ignoring node: $other")
-          // Ignore it. Let padding do its work
-        }
+            val smoffset = sm.startPosition.offset
+            if (smoffset > lastEndOffset) fieldResults.append(padding(lastEndOffset, smoffset))
+            lastEndOffset = sm.endPosition.offset
+            fieldResults.append(sm)
+          }
+          else {
+            say(s"Skipping this mutable terminal tree node. ${sm.startPosition} and lastEndOffset is ${lastEndOffset}")
+          }
+        case mttn: PositionedTreeNode =>
+          // This one is not actually positioned now is it
+          ???
+        case f: TreeNode if "".equals(f.value) =>
+          // It's harmless. Keep it as it may be queried. It won't be updateable
+          // Because we probably don't know where it lives.
+          fieldResults.append(f)
+          say(s"Keeping empty node $f")
+        case other =>
+          say(s"Ignoring node: $other")
+        // Ignore it. Let padding do its work
       }
-      // Put in trailing padding if necessary
-      if (pupae.endPosition.offset > lastEndOffset) {
-        fieldResults.append(padding(lastEndOffset, pupae.endPosition.offset))
-      }
+    }
+    // Put in trailing padding if necessary
+    if (pupae.endPosition.offset > lastEndOffset) {
+      fieldResults.append(padding(lastEndOffset, pupae.endPosition.offset))
+    }
 
-      // If it's a top level element, make sure we account for the entire file
-      if (topLevel) {
-        val content = initialSource.substring(pupae.endPosition.offset)
-        if (content.nonEmpty) {
-          val pn = PaddingTreeNode("End", content)
-          fieldResults.append(pn)
-        }
+    // If it's a top level element, make sure we account for the entire file
+    if (topLevel) {
+      val content = initialSource.substring(pupae.endPosition.offset)
+      if (content.nonEmpty) {
+        val pn = PaddingTreeNode("End", content)
+        fieldResults.append(pn)
       }
+    }
     (new MutableButNotPositionedContainerTreeNode(pupae.nodeName, fieldResults), report)
   }
 }
@@ -244,13 +280,14 @@ object PositionedMutableContainerTreeNode {
   * and MutableTreeNode are conflated, and the pad method actually updates the instance.
   *
   * As of its creation, it will only be used for tests.
+  *
   * @param name
   * @param initialFieldValues
   */
 class MutableButNotPositionedContainerTreeNode(
-                                       name: String,
-                                       val initialFieldValues: Seq[TreeNode]
-                                     )
+                                                name: String,
+                                                val initialFieldValues: Seq[TreeNode]
+                                              )
   extends PositionedMutableContainerTreeNode(name) {
 
   initialFieldValues.foreach(insertFieldCheckingPosition)

--- a/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
@@ -12,7 +12,7 @@ class SimpleMutableContainerTreeNode(
                                       val additionalTypes: Set[String] = Set())
   extends PositionedMutableContainerTreeNode(name) {
 
-  additionalTypes.foreach(addType(_))
+  additionalTypes.foreach(addType)
 
   initialFieldValues.foreach(insertFieldCheckingPosition)
 

--- a/src/test/scala/com/atomist/tree/content/text/FormatInfoTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/FormatInfoTest.scala
@@ -1,0 +1,112 @@
+package com.atomist.tree.content.text
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class FormatInfoTest extends FlatSpec with Matchers {
+
+  import FormatInfo.contextInfo
+
+  it should "find position at start of file" in {
+    val fi = contextInfo("")
+    fi.offset should be (0)
+    fi.columnNumberFrom1 should be (1)
+    fi.lineNumberFrom1 should be (1)
+    fi.indentDepth should be (0)
+  }
+
+  it should "find position within first line of file" in {
+    val input = "The quick brown"
+    val fi = contextInfo(input)
+    fi.columnNumberFrom1 should be (input.length + 1)
+    fi.lineNumberFrom1 should be (1)
+    fi.indentDepth should be (0)
+  }
+
+  it should "find position in second line of file" in {
+    val input = "The\n "
+    val fi = contextInfo(input)
+    fi.columnNumberFrom1 should be (2)
+    fi.lineNumberFrom1 should be (2)
+    fi.indentDepth should be (1)
+  }
+
+  it should "recognize indent depth of 4 with spaces" in
+    testIndent("    ")
+
+  it should "recognize indent depth of 3 with spaces" in {
+    val fi = testIndent("   ")
+    fi.usesTabs should be (false)
+
+  }
+
+  it should "recognize indent depth of 1 with tabs" in {
+    val fi = testIndent("\t")
+    fi.usesTabs should be (true)
+  }
+
+  private def testIndent(indent: String): FormatInfo = {
+    val input =
+      s"""
+        |public class Foobar {
+        |${indent}int i;
+        |
+        |${indent}void doSomething() {
+        |${indent}${indent}doIt();""".stripMargin
+    val fi = contextInfo(input)
+    fi.columnNumberFrom1 should be (2 * indent.length + 8)
+    fi.lineNumberFrom1 should be (6)
+    fi.indentDepth should be (2)
+    fi.indent should be (indent)
+    fi
+  }
+
+  it should "add indented content with 4 spaces" in
+    testAddContent("    ", "Whatever")
+
+  it should "add indented content with tab" in
+    testAddContent("\t", "Whatever")
+
+  private def testAddContent(indent: String, content: String): String = {
+    val input =
+      s"""
+         |public class Foobar {
+         |${indent}int i;
+         |
+        |${indent}void doSomething() {
+         |${indent}${indent}doIt();""".stripMargin
+    val fi = contextInfo(input)
+    fi.indent should be (indent)
+    fi.indentDepth should be (2)
+    val indented = fi.indented(content)
+    indented.take(indent.length + 1) should equal ("\n" + indent)
+    val r = input + fi.indented(content)
+    r should equal(input + "\n" + indent + indent + content)
+    r
+  }
+
+  it should "add multi line content" in {
+    val indent = "   "
+    val content =
+      s"""public Thing {
+        |\tdoIt();""".stripMargin
+    val input =
+      s"""
+         |public class Foobar {
+         |${indent}int i;
+         |
+         |${indent}void doSomething() {
+         |${indent}${indent}doIt();""".stripMargin
+    val fi = contextInfo(input)
+    fi.indent should be (indent)
+    fi.indentDepth should be (2)
+    val indented = fi.indented(content)
+    indented.contains("\t") should be (false)
+    indented.take(indent.length + 1) should equal ("\n" + indent)
+    val r = input + fi.indented(content)
+    r.contains("\t") should be (false)
+    r should equal(input + "\n" +
+      indent + indent + "public Thing {\n" + indent + indent + indent + "doIt();")
+    r
+  }
+
+}

--- a/src/test/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNodeTest.scala
@@ -1,0 +1,59 @@
+package com.atomist.tree.content.text
+
+import com.atomist.tree.content.text.OffsetInputPosition.{endOf, startOf}
+import org.scalatest.{FlatSpec, Matchers}
+
+class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
+
+  it should "refuse to find format info for child node without pad" in {
+    val inputA = "foo"
+    val inputB = "bar"
+    val line = inputA + inputB
+
+    val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
+    val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
+
+    val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
+
+    an[IllegalStateException] should be thrownBy soo.formatInfoStart(f1)
+  }
+
+  it should "find format info for child node" in {
+    val inputA = "foo"
+    val inputB = "bar"
+    val line = inputA + inputB
+
+    val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
+    val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
+
+    val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
+    soo.pad(line)
+
+    soo.formatInfoStart(f1) match {
+      case Some(fi) =>
+        fi.offset should be(f1.startPosition.offset)
+        fi.lineNumberFrom1 should be(1)
+    }
+
+    soo.formatInfoEnd(f1) match {
+      case Some(fi) =>
+        fi.offset should be(f1.endPosition.offset)
+        fi.lineNumberFrom1 should be(1)
+    }
+  }
+
+  it should "not find format info for non child node" in {
+    val inputA = "foo"
+    val inputB = "bar"
+    val line = inputA
+
+    val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
+    val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
+
+    val soo = new SimpleMutableContainerTreeNode("x", Seq(f1), startOf(line), endOf(line))
+    soo.pad(line)
+
+    soo.formatInfoStart(f2) should be(empty)
+  }
+
+}


### PR DESCRIPTION
Adds the ability to construct a `FormatInfo` object from a direct child field of a `PositionedMutableContainerTreeNode`. This can be used to:

- Return line and column information for the node for reviewers and diagnostics
- Obtain information about the indentation style of the file (tabs vs space; indent depth)
- Format strings to add to the file **while preserving the existing formatting**.

This functionality should help to edit many types of file preserving structure.

Resolves #238.