### PR TITLE
Add correlationId to Message, add JsonBackedTreeNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Implement JsonBackedContainerTreeNode, allows a ContainerTreeNode to 
+    maintain the Json is was generated from
+
+-   Add correlationId to Message, allows handler to define
+    how Messages are correlated
+
 -   Support for @parameter TS class field decorators as per
         https://github.com/atomist/rug/issues/229
 

--- a/src/main/scala/com/atomist/rug/kind/service/SimpleMessageBuilder.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/SimpleMessageBuilder.scala
@@ -1,7 +1,6 @@
 package com.atomist.rug.kind.service
 
 import java.util
-import java.util.Collections
 
 import com.atomist.tree.TreeNode
 
@@ -27,7 +26,8 @@ case class ImmutableMessage(
                              node: TreeNode = null,
                              message: String = null,
                              address: String = null,
-                             actions: java.util.List[Action] = new util.ArrayList[Action]())
+                             actions: java.util.List[Action] = new util.ArrayList[Action](),
+                             correlationId: String = null)
   extends Message {
 
   // We use null for interop and JSON
@@ -58,6 +58,8 @@ case class ImmutableMessage(
 
   def on(channelId: String): Message = address(channelId)
 
+  def withCorrelationId(cId: String): Message = copy(correlationId = cId)
+
 }
 
 object EmptyActionRegistry extends ActionRegistry {
@@ -73,3 +75,4 @@ class ConsoleMessageBuilder(teamId: String, actionRegistry: ActionRegistry)
   m => println(m),
   actionRegistry
 )
+

--- a/src/main/scala/com/atomist/rug/kind/service/message.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/message.scala
@@ -46,6 +46,8 @@ trait Message {
 
   def withActionNamed(a: String): Message
 
+  def withCorrelationId(correlationId: String): Message
+
   def send(): Unit
 
   /**

--- a/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
+++ b/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
@@ -137,3 +137,28 @@ private class WrappingLinkableContainerTreeNode(val wrappedNode: LinkableContain
 
   override def childrenNamed(key: String): Seq[TreeNode] = wrappedNode.childrenNamed(key)
 }
+
+/**
+  * Allows us to return a ContainerTreeNode that encapsulates a json representation
+  * of the object tree.
+  * @param innerNode The ContainerTreeNode that we are encapsulating
+  * @param backingJson the json string that also represents this object tree
+  */
+private class JsonBackedContainerTreeNode(val innerNode: LinkableContainerTreeNode,
+                                          val backingJson: String)
+  extends ContainerTreeNode {
+
+  override def value: String = ???
+
+  override def nodeName: String = innerNode.nodeName
+
+  override def childNodeNames: Set[String] = innerNode.childNodeNames
+
+  override def childNodeTypes: Set[String] = innerNode.childNodeTypes
+
+  override def childrenNamed(key: String): Seq[TreeNode] = innerNode.childrenNamed(key)
+
+  def jsonRepresentation: String = backingJson
+
+  def version: String = version
+}

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handler.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handler.ts
@@ -70,6 +70,8 @@ export interface Message {
 
  withActionNamed(a: string): Message
 
+ withCorrelationId(a: string): Message
+
  address(channelId: string): Message
 
 /**


### PR DESCRIPTION
Some changes required for the CypherTreeMaterializer.

Firstly we need a way of adding a correlationId to a message that can be defined inside the handler.

Secondly we add a new type of ContainerTreeNode where we can hold the JSON map that originally created the TreeNode structure. This allows us to pass the flat JSON representation back when calling send(). This avoids us having to implement a flat JSON serializer and an additional conversion on send().