### PR TITLE
Allow YAML files with multiple documents, but ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--   Implement JsonBackedContainerTreeNode, allows a ContainerTreeNode to 
+-   Implement JsonBackedContainerTreeNode, allows a ContainerTreeNode to
     maintain the Json is was generated from
 
 -   Add correlationId to Message, allows handler to define
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Yml type can now be instantiated from ProjectMutableView,
     DirectoryMutableView, and FileMutableView,
     https://github.com/atomist/rug/issues/250
+
+-   Handle YAML files with multiple documents, but only first is
+    parsed and addressable.
 
 ### Changed
 

--- a/src/main/scala/com/atomist/rug/kind/yml/YmlMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/yml/YmlMutableView.scala
@@ -63,8 +63,8 @@ private[yml] class YmlModel(val yml: String) {
 
   val y = new Yaml()
 
-  val map: scala.collection.mutable.Map[String, Object] = y.load(new StringReader(yml)) match {
-    case map: java.util.Map[String @unchecked, Object @unchecked] => map.asScala
+  val map: scala.collection.mutable.Map[String, Object] = y.loadAll(new StringReader(yml)).asScala.headOption match {
+    case Some(map: java.util.Map[String @unchecked, Object @unchecked]) => map.asScala
     case _ => throw new IllegalStateException(s"Unrecognized result parsing yml '$yml'")
   }
 

--- a/src/main/scala/com/atomist/rug/kind/yml/YmlType.scala
+++ b/src/main/scala/com/atomist/rug/kind/yml/YmlType.scala
@@ -24,7 +24,10 @@ class YmlType(
 
   def this() = this(DefaultEvaluator)
 
-  override def description = "YML file"
+  override def description =
+    """
+      |YAML file.  If the file contains multiple YAML documents, only the first is parsed and addressable.
+    """.stripMargin
 
   override def viewManifest: Manifest[YmlMutableView] = manifest[YmlMutableView]
 

--- a/src/test/scala/com/atomist/rug/kind/yml/YmlMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/yml/YmlMutableViewTest.scala
@@ -65,16 +65,14 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
   it should "find key in simple yml" in {
     val simpleYml =
       """
-    name:
-      test1
-
-    description:
-      A template of profound illustrative power.
-      """
+         |name:
+         |  test1
+         |
+         |description:
+         |  A template of profound illustrative power.
+      """.stripMargin
     val yv = new YmlMutableView(StringFileArtifact("info.yml", simpleYml),
       new ProjectMutableView(EmptyArtifactSource(""), as))
-    //    val ic = SimpleFunctionInvocationContext("p", yv, as, null, Map(),
-    //      SimpleProjectOperationArguments.Empty, Nil)
     yv.valueOf("name") should be("test1")
   }
 
@@ -163,5 +161,20 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
     yv.content.contains(firstComment)
     yv.content.contains(secondComment)
     yv.content.contains(thirdComment)
+  }
+
+  it should "find first key in multiple document yml" in {
+    val doubleYml =
+      """
+        |---
+        |name: test1
+        |description: A template of profound illustrative power.
+        |---
+        |name: test2
+        |description: Ignored less powerful template.
+      """.stripMargin
+    val yv = new YmlMutableView(StringFileArtifact("info.yml", doubleYml),
+      new ProjectMutableView(EmptyArtifactSource(""), as))
+    yv.valueOf("name") should be("test1")
   }
 }


### PR DESCRIPTION
Previously the YAML parser would fail on a YAML file with multiple
documents.  The code will now only parse and operate on the first,
ignoring the rest.