### PR TITLE
Node is no longer optional in PatternMatch

### DIFF
--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Concat.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Concat.scala
@@ -42,12 +42,12 @@ case class Concat(left: Matcher, right: Matcher, name: String = Concat.DefaultCo
             // Both match.
             val mergedTree: PositionedTreeNode =
               new SimpleMutableContainerTreeNode(name,
-                leftMatch.node.toSeq ++ rightMatch.node,
+                Seq(leftMatch.node, rightMatch.node),
                 startPosition = leftMatch.startPosition,
                 endPosition = rightMatch.endPosition,
                 significance = TreeNode.Noise)
             Right(PatternMatch(
-              Some(mergedTree),
+              mergedTree,
               leftMatch.matched + rightMatch.matched,
               rightMatch.resultingInputState,
               this.toString))

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/DismatchReport.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/DismatchReport.scala
@@ -14,9 +14,7 @@ case class DismatchReport(why: String,
   }
 
   def lengthOfClosestMatch: Int = {
-    val priorMatchLen =
-    for { m <- priorMatch
-          n <- m.node } yield n.value.length
+    val priorMatchLen = priorMatch.map(_.node.value.length)
     (Seq(0) ++ causes.map(_.lengthOfClosestMatch) ++ priorMatchLen).max
   }
 
@@ -40,11 +38,7 @@ object DismatchReport {
         }).getOrElse(input)
 
     val whatDidMatch =
-      for {pm <- dr.priorMatch
-           node <- pm.node}
-        yield {
-          printMatching(node, display)
-        }
+      dr.priorMatch.map(pm => printMatching(pm.node, display))
     val lines = whatDidMatch.toSeq ++ Seq(dr.why) ++ dr.causes.flatMap(detailedReportLines(_, display))
 
     lines.map(" " + _)

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Literal.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Literal.scala
@@ -27,7 +27,7 @@ case class Literal(literal: String, named: Option[String] = None) extends Matche
           new MutableTerminalTreeNode(LiteralDefaultName, literal, inputState.inputPosition, significance = TreeNode.Noise)
       }
       Right(PatternMatch(
-        Some(node),
+        node,
         literal,
         is,
         this.toString))
@@ -44,26 +44,6 @@ object Literal {
   val LiteralDefaultName = ".literal"
 
   implicit def stringToMatcher(s: String): Matcher = Literal(s)
-}
-
-/**
-  * Remainder of the the input
-  */
-case class Remainder(name: String = "remainder") extends Matcher {
-
-  override def matchPrefixInternal(inputState: InputState): MatchPrefixResult = {
-    if (inputState.exhausted)
-      Left(DismatchReport("There is nothing here")) // Why would this stop a match?
-    else {
-      val (matched, is) = inputState.takeAll
-      Right(
-        PatternMatch(None,
-          matched,
-          is, this.toString)
-      )
-    }
-  }
-
 }
 
 /**

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Matcher.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Matcher.scala
@@ -27,10 +27,8 @@ trait Matcher {
   final def matchPrefix(is: InputState): MatchPrefixResult = {
     val matchedOption = matchPrefixInternal(is)
 
-    for {matchFound <- matchedOption.right
-         node <- matchFound.node
-    } {
-      node.asInstanceOf[MutableTreeNode].addType(name)
+    matchedOption.right.foreach { matchFound =>
+      matchFound.node.asInstanceOf[MutableTreeNode].addType(name)
     }
     matchedOption
   }
@@ -97,8 +95,6 @@ object Matcher {
             prettyPrintLines(right))
       case Discard(m, name) =>
         mkSeq(s"Discard($name", prettyPrintLines(m), ")")
-      case Remainder(name) =>
-        Seq(s"Remainder($name)")
       case Wrap(m, name) =>
         mkSeq(s"Wrap($name", prettyPrintLines(m), ")")
       case RestOfLine(name) =>
@@ -132,7 +128,7 @@ trait ConfigurableMatcher extends Matcher {
   * @param resultingInputState resulting InputState
   */
 case class PatternMatch(
-                         node: Option[PositionedTreeNode],
+                         node: PositionedTreeNode,
                          matched: String,
                          resultingInputState: InputState,
                          matcherId: String)

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -30,11 +30,9 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
   private[microgrammar] def outputNode(input: CharSequence)(matchFound: PatternMatch, startOffset: InputPosition = OffsetInputPosition(0)) = {
     val endOffset = startOffset + matchFound.matched.length
     val matchedNode = matchFound.node match {
-      case None =>
-        new MicrogrammarNode(name, name, Seq(), startOffset, endOffset)
-      case Some(one: MutableTerminalTreeNode) =>
+      case one: MutableTerminalTreeNode =>
         new MicrogrammarNode(name, name, Seq(one), startOffset, endOffset)
-      case Some(container: MutableContainerTreeNode) =>
+      case  container: MutableContainerTreeNode =>
         new MicrogrammarNode(name, name, container.childNodes, startOffset, endOffset)
       case _ => ???
     }
@@ -54,7 +52,7 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
           dismatches.append(dismatchReport)
           is = is.advance
         case Right(matchFound) =>
-          listeners.foreach(l => matchFound.node.foreach(l.onMatch))
+          listeners.foreach(l => l.onMatch(matchFound.node))
           val thisStartedAt = OffsetInputPosition(is.offset)
           matches.append(matchFound -> thisStartedAt)
           is = matchFound.resultingInputState

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Regex.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Regex.scala
@@ -21,8 +21,7 @@ case class Regex(regex: String, givenName: Option[String], config: MatcherConfig
       rex.anchored.findPrefixMatchOf(inputState.remainder) match {
         case Some(m) =>
           Right(PatternMatch(
-            Some(
-              new MutableTerminalTreeNode(name, m.matched, inputState.inputPosition, significance = treeNodeSignificance)),
+              new MutableTerminalTreeNode(name, m.matched, inputState.inputPosition, significance = treeNodeSignificance),
             m.matched,
             inputState.take(m.matched.length)._2,
             this.toString))

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Rep.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Rep.scala
@@ -30,21 +30,21 @@ case class Rep(m: Matcher, givenName: Option[String] = None, separator: Option[M
         // We can match zero times. Put in an empty node.
         val pos = inputState.inputPosition
         Right(
-          PatternMatch(node = Some(EmptyContainerTreeNode(name, pos)),
+          PatternMatch(node = EmptyContainerTreeNode(name, pos),
             matched = "", inputState, this.toString))
       case Right(initialMatch) =>
         // We matched once. Let's keep going
         //println(s"Found initial match for $initialMatch")
         var matched = initialMatch.matched
         var latestInputState = initialMatch.resultingInputState
-        var nodes = initialMatch.node.toSeq
+        var nodes = Seq(initialMatch.node)
         //println(s"Trying secondary match $secondaryMatch against [${s.toString.substring(upToOffset)}]")
         while (secondaryMatch.matchPrefix(latestInputState) match {
           case Left(_) => false
           case Right(lastMatch) =>
             //println(s"Made it to secondary match [$lastMatch]")
             matched += lastMatch.matched
-            nodes ++= lastMatch.node.toSeq
+            nodes ++= Seq(lastMatch.node)
             latestInputState = lastMatch.resultingInputState
             true
         }) {
@@ -55,7 +55,7 @@ case class Rep(m: Matcher, givenName: Option[String] = None, separator: Option[M
         val endpos = if (nodes.isEmpty) pos else nodes.last.endPosition
         val combinedNode = new SimpleMutableContainerTreeNode(name, nodes, pos, endpos, treeNodeSignificance)
         Right(
-          PatternMatch(node = Some(combinedNode),
+          PatternMatch(node = combinedNode,
             matched, latestInputState, this.toString)
         )
     }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/matchers/Break.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/matchers/Break.scala
@@ -1,5 +1,6 @@
 package com.atomist.tree.content.text.microgrammar.matchers
 
+import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.MutableTerminalTreeNode
 import com.atomist.tree.content.text.microgrammar.Matcher.MatchPrefixResult
 import com.atomist.tree.content.text.microgrammar.{DismatchReport, InputState, Matcher, PatternMatch}
@@ -32,10 +33,10 @@ case class Break(breakToMatcher: Matcher, named: Option[String] = None)
         case Left(no) =>
           Left(no.andSo("not anywhere in the rest of the input"))
         case Right(terminatingMatch) =>
+          val significance = if (named.isDefined) TreeNode.Signal else TreeNode.Noise
           val (eaten, resultingIs) = inputState.take(terminatingMatch.endPosition.offset - inputState.offset)
           val returnedMatch = PatternMatch(
-            named.map(n =>
-              new MutableTerminalTreeNode(n, eaten, inputState.inputPosition)),
+              new MutableTerminalTreeNode(name, eaten, inputState.inputPosition, significance = significance),
             eaten,
             terminatingMatch.resultingInputState,
             this.toString)

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarTest.scala
@@ -414,8 +414,8 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     }
     val m = ymlKeys.findMatches(input)
     m.size should be(1)
-//    println(TreeNodeUtils.toShorterString(m.head))
-//    println(s"Has ${m.head.fieldValues.size} field values: ${m.head.fieldValues}")
+    //    println(TreeNodeUtils.toShorterString(m.head))
+    //    println(s"Has ${m.head.fieldValues.size} field values: ${m.head.fieldValues}")
     withClue(s"Didn't expect to find match ${TreeNodeUtils.toShorterString(m.head)} with ${m.head.childNodes.size} children and fields=${m.head.fieldValues}\n") {
       val keys = m.head.childrenNamed("key")
       val values = m.head.childrenNamed("value")
@@ -445,13 +445,10 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     printlns.matcher.matchPrefix(InputState(input)) match {
       case Right(pm) =>
         pm.matched should be(p1)
-        pm.node match {
-          case Some(positionedNode) =>
-            val (hatched, _) = PositionedMutableContainerTreeNode.pad(positionedNode, input)
-            p1.contains(hatched.value) should be(true)
-          case _ => fail
-        }
-      case _ => ???
+        val positionedNode = pm.node
+        val (hatched, _) = PositionedMutableContainerTreeNode.pad(positionedNode, input)
+        p1.contains(hatched.value) should be(true)
+      case Left(boo) => fail(DismatchReport.detailedReport(boo, input))
     }
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherOperationsTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherOperationsTest.scala
@@ -10,8 +10,8 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val ls = l.toString
     l.matchPrefix(InputState("thing")) match {
       case Right(PatternMatch(tn, "thing", InputState("thing", _, _), `ls`)) =>
-        tn.get.nodeName should be ("x")
-        tn.get.value should be ("thing")
+        tn.nodeName should be ("x")
+        tn.value should be ("thing")
       case _ => ???
     }
   }
@@ -19,7 +19,7 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
   it should "match literal in partial string" in {
     val l = Literal("thing")
     l.matchPrefix(InputState("thing2")) match {
-      case Right(PatternMatch(Some(node), "thing", is, value)) =>
+      case Right(PatternMatch(node, "thing", is, value)) =>
         node.significance should be(TreeNode.Noise)
         value should be(l.toString)
         is.offset should be(5)

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/RegexTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/RegexTest.scala
@@ -9,7 +9,7 @@ class RegexTest extends FlatSpec with Matchers {
     val l = Regex("[a-zA-Z]+", Some(name))
     l.matchPrefix(InputState("thingxxxY")) match {
       case Right(PatternMatch(tn, "thingxxxY", InputState("thingxxxY", _, _), _)) =>
-        tn.get.nodeName should be (name)
+        tn.nodeName should be (name)
       case _ => ???
     }
   }
@@ -19,7 +19,7 @@ class RegexTest extends FlatSpec with Matchers {
     val l = Regex("[a-zA-Z]+", Some(name))
     l.matchPrefix(InputState("thingxxxY0")) match {
       case Right(PatternMatch(tn, "thingxxxY", InputState("thingxxxY0", _, _), _)) =>
-        tn.get.nodeName should be (name)
+        tn.nodeName should be (name)
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/RepTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/RepTest.scala
@@ -10,7 +10,7 @@ class RepTest extends FlatSpec with Matchers {
     val l = Rep(l1)
     val input = "woieurowieurowieur"
     l.matchPrefix(InputState(input)) match {
-      case Right(PatternMatch(Some(tn), "", InputState(input, _, _), _)) =>
+      case Right(PatternMatch(tn, "", InputState(input, _, _), _)) =>
         tn.nodeName should be (".rep")
       case _ => ???
     }
@@ -20,7 +20,7 @@ class RepTest extends FlatSpec with Matchers {
     val l1 = Literal("thing", Some("thing"))
     val l = Rep(l1)
     l.matchPrefix(InputState("thing2")) match {
-      case Right(PatternMatch(Some(tn: ContainerTreeNode), "thing", InputState(thing2, _, _), _)) =>
+      case Right(PatternMatch(tn: ContainerTreeNode, "thing", InputState(thing2, _, _), _)) =>
         tn.nodeName should be (".rep")
         tn.childNodes.size should be (1)
       case _ => ???
@@ -36,7 +36,7 @@ class RepTest extends FlatSpec with Matchers {
         pe.matched should be ("thingthing")
         pe.resultingInputState.input should be (input)
         pe.resultingInputState.offset should be ("thingthing".length)
-        val tn = pe.node.get.asInstanceOf[ContainerTreeNode]
+        val tn = pe.node.asInstanceOf[ContainerTreeNode]
         tn.nodeName should be (".rep")
         tn.childNodes.size should be (2)
       case _ => ???
@@ -52,7 +52,7 @@ class RepTest extends FlatSpec with Matchers {
         pe.matched should be ("thingthing")
         pe.resultingInputState.input should be (input)
         pe.resultingInputState.offset should be ("thingthing".length)
-        val tn = pe.node.get.asInstanceOf[ContainerTreeNode]
+        val tn = pe.node.asInstanceOf[ContainerTreeNode]
         tn.nodeName should be (namedRep.name)
         tn.childNodes.size should be (2)
       case _ => ???

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/WrapTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/WrapTest.scala
@@ -16,7 +16,7 @@ class WrapTest extends FlatSpec with Matchers {
         pe.matched should be ("thing")
         pe.resultingInputState.input should be (input)
         pe.resultingInputState.offset should be ("thing".length)
-        val tn = pe.node.get.asInstanceOf[ContainerTreeNode]
+        val tn = pe.node.asInstanceOf[ContainerTreeNode]
         tn.nodeName should be ("higherLevel")
         tn.childNodes.size should be (1)
       case _ => ???
@@ -34,7 +34,7 @@ class WrapTest extends FlatSpec with Matchers {
         pe.matched should be ("thingthing")
         pe.resultingInputState.input should be (input)
         pe.resultingInputState.offset should be ("thingthing".length)
-        val tn = pe.node.get.asInstanceOf[PositionedMutableContainerTreeNode]
+        val tn = pe.node.asInstanceOf[PositionedMutableContainerTreeNode]
         tn.nodeName should be (l.name)
 //        println("Before pad: " + TreeNodeUtils.toShortString(tn))
 //        println(tn.childNodes)


### PR DESCRIPTION
Now that any node can be created as Noise, we're free to create them all the time. This simplifies pattern matches a little.