### PR TITLE
Exposing format info from text views

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/dynamic/ContainerTreeNodeView.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/ContainerTreeNodeView.scala
@@ -7,15 +7,12 @@ import com.atomist.tree.{ContainerTreeNode, MutableTreeNode, TreeNode}
 /**
   * Allows select (with/from) navigation over any structured data that can
   * be put into our TreeNode tree structure
-  *
-  * @param originalBackingObject
-  * @param parent
-  * @tparam O
   */
 class ContainerTreeNodeView[O <: ContainerTreeNode](
                                                      originalBackingObject: O,
                                                      parent: MutableView[_])
-  extends ViewSupport[O](originalBackingObject, parent) {
+  extends ViewSupport[O](originalBackingObject, parent)
+    with FormatInfoProvider {
 
   override def nodeName: String = currentBackingObject.nodeName
 
@@ -25,6 +22,8 @@ class ContainerTreeNodeView[O <: ContainerTreeNode](
   override def value: String = currentBackingObject.value
 
   override def dirty: Boolean = false
+
+  override protected def focusNode: TreeNode = currentBackingObject
 
   @ExportFunction(readOnly = true, description = "Return the value of the given key")
   def valueOf(@ExportFunctionParameterDescription(name = "name",
@@ -44,10 +43,10 @@ class ContainerTreeNodeView[O <: ContainerTreeNode](
 
   override def childrenNamed(fieldName: String): Seq[MutableView[_]] =
     currentBackingObject.childrenNamed(fieldName) collect {
-    case mctn: MutableContainerTreeNode => new MutableContainerMutableView(mctn, this)
-    case o: ContainerTreeNode => viewFrom(o)
-    case sv: MutableTerminalTreeNode => new ScalarValueView(sv, this)
-  }
+      case mctn: MutableContainerTreeNode => new MutableContainerMutableView(mctn, this)
+      case o: ContainerTreeNode => viewFrom(o)
+      case sv: MutableTerminalTreeNode => new ScalarValueView(sv, this)
+    }
 
   /**
     * Subclasses can override this if they want to return mutable views
@@ -66,11 +65,14 @@ class ScalarValueView(
                        originalBackingObject: MutableTerminalTreeNode,
                        parent: MutableView[_])
   extends ViewSupport[MutableTerminalTreeNode](originalBackingObject, parent)
-    with MutableTreeNode {
+    with MutableTreeNode
+    with FormatInfoProvider {
 
   override def dirty: Boolean = originalBackingObject.dirty
 
   addTypes(currentBackingObject.nodeTags ++ Set("MutableTerminal"))
+
+  override protected def focusNode: TreeNode = currentBackingObject
 
   override def nodeName: String = originalBackingObject.nodeName
 

--- a/src/main/scala/com/atomist/rug/kind/dynamic/mutableContainerTreeNodeMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/dynamic/mutableContainerTreeNodeMutableView.scala
@@ -24,10 +24,7 @@ class MutableContainerTypeProvider extends TypeProvider(classOf[MutableContainer
 }
 
 /**
-  * Fronts any view with hierarchy
-  *
-  * @param originalBackingObject
-  * @param parent
+  * Fronts any mutable view
   */
 class MutableContainerMutableView(
                                    originalBackingObject: MutableContainerTreeNode,

--- a/src/main/scala/com/atomist/rug/kind/grammar/RawNodeUnderFileMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/RawNodeUnderFileMutableView.scala
@@ -30,7 +30,7 @@ abstract class RawNodeUnderFileMutableView(topLevelNode: MutableContainerTreeNod
   override def nodeTags: Set[String] = Set(Typed.typeToTypeName(getClass))
 
   /**
-    *
+    * Convenient method to operate on nodes selected by a path expression
     * @param pexpr Path expression under this node
     * @param f     function on TreeNode
     */

--- a/src/main/scala/com/atomist/rug/spi/ViewSupport.scala
+++ b/src/main/scala/com/atomist/rug/spi/ViewSupport.scala
@@ -3,7 +3,7 @@ package com.atomist.rug.spi
 import com.atomist.rug.kind.core.{ChangeCounting, FileArtifactBackedMutableView}
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.tree.TreeNode
-import com.atomist.tree.content.text.PositionedMutableContainerTreeNode
+import com.atomist.tree.content.text.{MutableContainerTreeNode, PositionedMutableContainerTreeNode}
 
 import scala.collection.mutable.ListBuffer
 
@@ -29,7 +29,7 @@ abstract class ViewSupport[T](val originalBackingObject: T, val parent: MutableV
 
   // Implementation of FormatInfoProvider relevant if subclasses choose to
   // implement that trait
-  protected def rootNode: Option[PositionedMutableContainerTreeNode] = {
+  protected def rootNode: Option[MutableContainerTreeNode] = {
     def highestNodeWithinFile(mv: MutableView[_]): Option[MutableView[_]] = {
       //println(s"Looking at node $mv with parent ${mv.parent}")
       if (mv.parent == null) None // We failed

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -204,7 +204,7 @@ case class InterfaceGenerationConfig(
 
   val imports: String =
     """
-      |import {TreeNode,PathExpressionEngine} from '../tree/PathExpression'
+      |import {TreeNode,FormatInfo,PathExpressionEngine} from '../tree/PathExpression'
       |import {ProjectContext} from '../operations/ProjectEditor' """
       .stripMargin
 

--- a/src/main/scala/com/atomist/tree/content/text/FormatInfo.scala
+++ b/src/main/scala/com/atomist/tree/content/text/FormatInfo.scala
@@ -7,7 +7,7 @@ object FormatInfo {
   /**
     * Given the left input, derive position information.
     */
-  def contextInfo(leftInput: String): FormatInfo = {
+  def contextInfo(leftInput: String): PointFormatInfo = {
 
     def findLeadingWhitespace(s: String): String =
       s.takeWhile(c => c.isWhitespace)
@@ -33,7 +33,7 @@ object FormatInfo {
     val indentDepth = findLeadingWhitespace(currentLine).length /
       { if (indent.isEmpty) 1 else indent.length }
 
-    FormatInfo(
+    PointFormatInfo(
       offs,
       lineNumberFrom1,
       currentLine.length + 1,
@@ -45,13 +45,21 @@ object FormatInfo {
 
 
 /**
-  * Information about the format in the file
+  * Information about the format of a node within a file
+  */
+case class FormatInfo(
+                     start: PointFormatInfo,
+                     end: PointFormatInfo
+                     )
+
+/**
+  * Information about the format in the file at a particular point
   *
   * @param indentDepth indent depth at the beginning of this line. Number of times
   *                    the indent appears at the beginning of this line
   * @param indent      indent used in the file.
   */
-case class FormatInfo(
+case class PointFormatInfo(
                        offset: Int,
                        lineNumberFrom1: Int,
                        columnNumberFrom1: Int,

--- a/src/main/scala/com/atomist/tree/content/text/FormatInfoProvider.scala
+++ b/src/main/scala/com/atomist/tree/content/text/FormatInfoProvider.scala
@@ -1,0 +1,31 @@
+package com.atomist.tree.content.text
+
+import com.atomist.rug.spi.ExportFunction
+import com.atomist.tree.TreeNode
+
+/**
+  * Extended by classes that can expose their position
+  */
+trait FormatInfoProvider {
+
+  @ExportFunction(readOnly = true,
+    description = "Return the format info for the start of this structure in the file or null if not available")
+  final def formatInfoStart: FormatInfo =
+    rootNode.flatMap(r => r.formatInfoStart(focusNode)).orNull
+
+  @ExportFunction(readOnly = true,
+    description = "Return the format info for the end of this structure in the file or null if not available")
+  final def formatInfoEnd: FormatInfo =
+    rootNode.flatMap(r => r.formatInfoEnd(focusNode)).orNull
+
+  /**
+    * Focus node
+    */
+  protected def focusNode: TreeNode
+
+  /**
+    * Root container
+    */
+  protected def rootNode: Option[PositionedMutableContainerTreeNode]
+
+}

--- a/src/main/scala/com/atomist/tree/content/text/FormatInfoProvider.scala
+++ b/src/main/scala/com/atomist/tree/content/text/FormatInfoProvider.scala
@@ -26,6 +26,6 @@ trait FormatInfoProvider {
   /**
     * Root container
     */
-  protected def rootNode: Option[PositionedMutableContainerTreeNode]
+  protected def rootNode: Option[MutableContainerTreeNode]
 
 }

--- a/src/main/scala/com/atomist/tree/content/text/FormatInfoProvider.scala
+++ b/src/main/scala/com/atomist/tree/content/text/FormatInfoProvider.scala
@@ -10,13 +10,8 @@ trait FormatInfoProvider {
 
   @ExportFunction(readOnly = true,
     description = "Return the format info for the start of this structure in the file or null if not available")
-  final def formatInfoStart: FormatInfo =
-    rootNode.flatMap(r => r.formatInfoStart(focusNode)).orNull
-
-  @ExportFunction(readOnly = true,
-    description = "Return the format info for the end of this structure in the file or null if not available")
-  final def formatInfoEnd: FormatInfo =
-    rootNode.flatMap(r => r.formatInfoEnd(focusNode)).orNull
+  final def formatInfo: FormatInfo =
+    rootNode.flatMap(r => r.formatInfo(focusNode)).orNull
 
   /**
     * Focus node

--- a/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
@@ -25,36 +25,23 @@ trait MutableContainerTreeNode
     }).nonEmpty
 
   /**
-    * Return formatInfo for the start of this child node. We can obtain
+    * Return formatInfo for the child node. We can obtain
     * line and column and formatting information.
     *
     * @param child child of this node
     * @return Some if the child is found
     */
-  def formatInfoStart(child: TreeNode): Option[FormatInfo] =
-    formatInfoFor(child, start = true)
-
-  /**
-    * Return formatInfo for the end of this child node. We can obtain
-    * line and column and formatting information.
-    *
-    * @param child child of this node
-    * @return Some if the child is found
-    */
-  def formatInfoEnd(child: TreeNode): Option[FormatInfo] =
-    formatInfoFor(child, start = false)
-
-  protected def formatInfoFor(child: TreeNode, start: Boolean): Option[FormatInfo] = {
+  def formatInfo(child: TreeNode): Option[FormatInfo] =
     if (!fieldValues.contains(child))
       None
     else {
       // Build string to the left
-      val leftFields = fieldValues.takeWhile(f => f != child) ++ (if (start) Nil else Seq(child))
+      val leftFields = fieldValues.takeWhile(f => f != child)
       val stringToLeft = leftFields.map(_.value).mkString("")
-      val fi = FormatInfo.contextInfo(stringToLeft)
+      val leftPoint = FormatInfo.contextInfo(stringToLeft)
+      val rightPoint = FormatInfo.contextInfo(stringToLeft + child.value)
       //println(s"Found $fi from left string [$stringToLeft] with start=$start")
-      Some(fi)
+      Some(FormatInfo(leftPoint, rightPoint))
     }
-  }
 
 }

--- a/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
@@ -24,4 +24,37 @@ trait MutableContainerTreeNode
       case u: MutableTreeNode if u.dirty => u
     }).nonEmpty
 
+  /**
+    * Return formatInfo for the start of this child node. We can obtain
+    * line and column and formatting information.
+    *
+    * @param child child of this node
+    * @return Some if the child is found
+    */
+  def formatInfoStart(child: TreeNode): Option[FormatInfo] =
+    formatInfoFor(child, start = true)
+
+  /**
+    * Return formatInfo for the end of this child node. We can obtain
+    * line and column and formatting information.
+    *
+    * @param child child of this node
+    * @return Some if the child is found
+    */
+  def formatInfoEnd(child: TreeNode): Option[FormatInfo] =
+    formatInfoFor(child, start = false)
+
+  protected def formatInfoFor(child: TreeNode, start: Boolean): Option[FormatInfo] = {
+    if (!fieldValues.contains(child))
+      None
+    else {
+      // Build string to the left
+      val leftFields = fieldValues.takeWhile(f => f != child) ++ (if (start) Nil else Seq(child))
+      val stringToLeft = leftFields.map(_.value).mkString("")
+      val fi = FormatInfo.contextInfo(stringToLeft)
+      //println(s"Found $fi from left string [$stringToLeft] with start=$start")
+      Some(fi)
+    }
+  }
+
 }

--- a/src/main/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNode.scala
@@ -33,7 +33,15 @@ abstract class PositionedMutableContainerTreeNode(val nodeName: String)
 
   override def childNodeNames: Set[String] = childNodes.map(f => f.nodeName).toSet
 
-  // TODO is this right
+  override protected def formatInfoFor(child: TreeNode, start: Boolean): Option[FormatInfo] = {
+    if (!_padded)
+      throw new IllegalStateException(s"Call pad before trying to get format info from $this")
+    else
+      super.formatInfoFor(child, start)
+  }
+
+
+    // TODO is this right
   override def childNodeTypes: Set[String] = childNodeNames
 
   override def childrenNamed(key: String): Seq[TreeNode] = fieldValues.filter(n => n.nodeName == key)
@@ -78,41 +86,6 @@ abstract class PositionedMutableContainerTreeNode(val nodeName: String)
     else {
       //println(s"Not collapsing ${n.nodeName}:${n.nodeTags}")
       Seq(n)
-    }
-  }
-
-  /**
-    * Return formatInfo for the start of this child node. We can obtain
-    * line and column and formatting information.
-    *
-    * @param child child of this node
-    * @return Some if the child is found
-    */
-  def formatInfoStart(child: TreeNode): Option[FormatInfo] =
-    formatInfoFor(child, start = true)
-
-  /**
-    * Return formatInfo for the end of this child node. We can obtain
-    * line and column and formatting information.
-    *
-    * @param child child of this node
-    * @return Some if the child is found
-    */
-  def formatInfoEnd(child: TreeNode): Option[FormatInfo] =
-    formatInfoFor(child, start = false)
-
-  private def formatInfoFor(child: TreeNode, start: Boolean): Option[FormatInfo] = {
-    if (!_padded)
-      throw new IllegalStateException(s"Call pad before trying to get format info from $this")
-    if (!_fieldValues.contains(child))
-      None
-    else {
-      // Build string to the left
-      val leftFields = _fieldValues.takeWhile(f => f != child) ++ (if (start) Nil else Seq(child))
-      val stringToLeft = leftFields.map(_.value).mkString("")
-      val fi = FormatInfo.contextInfo(stringToLeft)
-      //println(s"Found $fi from left string [$stringToLeft] with start=$start")
-      Some(fi)
     }
   }
 

--- a/src/main/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNode.scala
@@ -33,11 +33,11 @@ abstract class PositionedMutableContainerTreeNode(val nodeName: String)
 
   override def childNodeNames: Set[String] = childNodes.map(f => f.nodeName).toSet
 
-  override protected def formatInfoFor(child: TreeNode, start: Boolean): Option[FormatInfo] = {
+  override def formatInfo(child: TreeNode): Option[FormatInfo] = {
     if (!_padded)
       throw new IllegalStateException(s"Call pad before trying to get format info from $this")
     else
-      super.formatInfoFor(child, start)
+      super.formatInfo(child)
   }
 
 

--- a/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
@@ -13,7 +13,7 @@ class TypeScriptGenerationHelper(indent: String = "    ")
   /**
     * Convert the block to a JsDoc style comment.
     */
-  def toJsDoc(block: String) = {
+  def toJsDoc(block: String): String = {
     s"""
        |/**
        |   ${indented(block, 1)}
@@ -44,6 +44,7 @@ class TypeScriptGenerationHelper(indent: String = "    ")
       case "FileArtifactMutableView" => "File"   // TODO this is nasty
       case "scala.collection.immutable.Set<java.lang.String>" => "string[]" // Nasty
       case `pathExpressionEngineClassName` => "PathExpressionEngine"
+      case "class com.atomist.tree.content.text.FormatInfo" => "FormatInfo"
       case x => throw new UnsupportedOperationException(s"Unsupported type [$jt]")
     }
   }

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -19,6 +19,11 @@ class PathExpression<R,N> {
 }
 
 interface FormatInfo {
+    start: PointFormatInfo
+    end: PointFormatInfo
+}
+
+interface PointFormatInfo {
 
    offset: number
    lineNumberFrom1: number
@@ -44,9 +49,7 @@ interface TreeNode {
 
   children(): TreeNode[]
 
-  formatInfoStart(): FormatInfo
-
-  formatInfoEnd(): FormatInfo
+  formatInfo(): FormatInfo
 
 }
 
@@ -111,6 +114,7 @@ export {PathExpression}
 export {PathExpressionEngine}
 export {TreeNode}
 export {FormatInfo}
+export {PointFormatInfo}
 export {TypeProvider}
 export {DynamicType}
 export {Microgrammar}

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -18,9 +18,20 @@ class PathExpression<R,N> {
 
 }
 
+interface FormatInfo {
+
+   offset: number
+   lineNumberFrom1: number
+   columnNumberFrom1: number
+   indentDepth: number
+   indent: String
+}
+
+
 /**
  * Operations common to all tree nodes.
  */
+ // TODO differentiate text nodes
 interface TreeNode {
 
   nodeName(): string
@@ -32,6 +43,10 @@ interface TreeNode {
   update(newValue: string)
 
   children(): TreeNode[]
+
+  formatInfoStart(): FormatInfo
+
+  formatInfoEnd(): FormatInfo
 
 }
 
@@ -95,6 +110,7 @@ export {Match}
 export {PathExpression}
 export {PathExpressionEngine}
 export {TreeNode}
+export {FormatInfo}
 export {TypeProvider}
 export {DynamicType}
 export {Microgrammar}

--- a/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeTest.scala
@@ -6,7 +6,7 @@ import com.atomist.rug.kind.dynamic.MutableContainerMutableView
 import com.atomist.source.{EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.ConsoleMatchListener
-import com.atomist.tree.pathexpression.{ExpressionEngine, PathExpression, PathExpressionEngine, PathExpressionParser}
+import com.atomist.tree.pathexpression.{ExpressionEngine, PathExpressionEngine, PathExpressionParser}
 import org.scalatest.{FlatSpec, Matchers}
 
 object CSharpFileTypeTest {

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
@@ -29,6 +29,7 @@ class TypeScriptInterfaceGeneratorTest extends FlatSpec with Matchers {
             |interface ProjectContext {}
             |interface PathExpressionEngine {}
             |interface TreeNode {}
+            |interface FormatInfo {}
           """.stripMargin))
     }
 

--- a/src/test/scala/com/atomist/tree/content/text/FormatInfoTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/FormatInfoTest.scala
@@ -44,7 +44,7 @@ class FormatInfoTest extends FlatSpec with Matchers {
     fi.usesTabs should be (true)
   }
 
-  private def testIndent(indent: String): FormatInfo = {
+  private def testIndent(indent: String): PointFormatInfo = {
     val input =
       s"""
         |public class Foobar {

--- a/src/test/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNodeTest.scala
@@ -30,7 +30,7 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
 
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
 
-    an[IllegalStateException] should be thrownBy soo.formatInfoStart(f1)
+    an[IllegalStateException] should be thrownBy soo.formatInfo(f1)
   }
 
   it should "find format info for child node" in {
@@ -44,17 +44,12 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
     soo.pad(line)
 
-    soo.formatInfoStart(f1) match {
+    soo.formatInfo(f1) match {
       case Some(fi) =>
-        fi.offset should be(f1.startPosition.offset)
-        fi.lineNumberFrom1 should be(1)
-      case _ => ???
-    }
-
-    soo.formatInfoEnd(f1) match {
-      case Some(fi) =>
-        fi.offset should be(f1.endPosition.offset)
-        fi.lineNumberFrom1 should be(1)
+        fi.start.offset should be(f1.startPosition.offset)
+        fi.start.lineNumberFrom1 should be(1)
+        fi.end.offset should be(f1.endPosition.offset)
+        fi.end.lineNumberFrom1 should be(1)
       case _ => ???
     }
   }
@@ -70,7 +65,7 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1), startOf(line), endOf(line))
     soo.pad(line)
 
-    soo.formatInfoStart(f2) should be(empty)
+    soo.formatInfo(f2) should be(empty)
   }
 
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarUsageInPathExpressionTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarUsageInPathExpressionTest.scala
@@ -4,12 +4,11 @@ import com.atomist.parse.java.ParsingTargets
 import com.atomist.project.archive.DefaultAtomistConfig
 import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.core.ProjectMutableView
-import com.atomist.rug.kind.dynamic.MutableContainerMutableView
 import com.atomist.rug.spi.UsageSpecificTypeRegistry
 import com.atomist.source.EmptyArtifactSource
-import com.atomist.tree.{MutableTreeNode, TreeNode}
-import com.atomist.tree.content.text.microgrammar.{MatcherMicrogrammar, Microgrammar, MicrogrammarTypeProvider}
+import com.atomist.tree.content.text.microgrammar.{MatcherMicrogrammar, MicrogrammarTypeProvider}
 import com.atomist.tree.pathexpression.{ExpressionEngine, PathExpressionEngine}
+import com.atomist.tree.{MutableTreeNode, TreeNode}
 import org.scalatest.{FlatSpec, Matchers}
 
 /**

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
@@ -59,6 +59,38 @@ class TypeScriptMicrogrammarTest extends FlatSpec with Matchers {
       |export let editor = new MgEditor()
       | """.stripMargin
 
+  val RequiresFormatInfo: String =
+    """import {Project} from '@atomist/rug/model/Core'
+      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+      |import {PathExpression,TreeNode,Microgrammar} from '@atomist/rug/tree/PathExpression'
+      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+      |import {Match} from '@atomist/rug/tree/PathExpression'
+      |import {Parameter} from '@atomist/rug/operations/RugOperation'
+      |
+      |class MgEditor implements ProjectEditor {
+      |    name: string = "Constructed"
+      |    description: string = "Uses 2 microgrammars"
+      |
+      |    edit(project: Project) {
+      |      let mg1 = new Microgrammar('mv1', `$mv1:§[a-zA-Z0-9_\\.]+§</modelVersion>`)
+      |      let mg2 = new Microgrammar('modelVersion', `<modelVersion>$:mv1`)
+      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg1).addType(mg2)
+      |
+      |      eng.with<TreeNode>(project, "/*[@name='pom.xml']/modelVersion()/mv1()", n => {
+      |        if (n.value() != "4.0.0") project.fail("" + n.value())
+      |        n.update('Foo bar')
+      |        let fi = n.formatInfoStart()
+      |        if (fi == null)
+      |         throw new Error("FormatInfo was null")
+      |        if (fi.lineNumberFrom1 < 10)
+      |         throw new Error(`I don't like ${fi}`)
+      |        //console.log(fi)
+      |      })
+      |    }
+      |  }
+      |export let editor = new MgEditor()
+      | """.stripMargin
+
   val NavigatesNestedUsingPathExpression: String =
     """import {Project} from '@atomist/rug/model/Core'
       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
@@ -116,9 +148,14 @@ class TypeScriptMicrogrammarTest extends FlatSpec with Matchers {
     originalPomContent.replace("<modelVersion>4.0.0</modelVersion>", "<modelVersion>Foo bar</modelVersion>") should be(editedPomContent)
   }
 
-  it should "run use microgrammar defined in TypeScript in 2 consts" in {
+  it should "use microgrammar defined in TypeScript in 2 consts" in {
     invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       ModifiesWithSimpleMicrogrammarSplitInto2))
+  }
+
+  it should "use editor requiring FormatInfo" in {
+    invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
+      RequiresFormatInfo))
   }
 
   it should "navigate nested using path expression" in {

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
@@ -79,10 +79,10 @@ class TypeScriptMicrogrammarTest extends FlatSpec with Matchers {
       |      eng.with<TreeNode>(project, "/*[@name='pom.xml']/modelVersion()/mv1()", n => {
       |        if (n.value() != "4.0.0") project.fail("" + n.value())
       |        n.update('Foo bar')
-      |        let fi = n.formatInfoStart()
+      |        let fi = n.formatInfo()
       |        if (fi == null)
       |         throw new Error("FormatInfo was null")
-      |        if (fi.lineNumberFrom1 < 10)
+      |        if (fi.start.lineNumberFrom1 < 10)
       |         throw new Error(`I don't like ${fi}`)
       |        //console.log(fi)
       |      })


### PR DESCRIPTION
Make it possible to get format info (line, column and indentation info) from any view backed in a positioned tree node structure. Useful for reviewers and adding content respecting existing formatting.