### PR TITLE
Add POM's scope element

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/pom/PomMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/PomMutableView.scala
@@ -245,7 +245,22 @@ trait PomMutableViewMutatingFunctions extends BuildViewMutatingFunctions {
       dependency,
       s"""<dependency><groupId>$groupId</groupId><artifactId>$artifactId</artifactId></dependency>""")
 
-  @ExportFunction(readOnly = false, description = "Add or replace a dependency, providing version")
+  @ExportFunction(readOnly = false, description = "Add or replace a dependency")
+  def addOrReplaceDependency(@ExportFunctionParameterDescription(name = "groupId",
+    description = "The value of the dependency's groupId")
+                             groupId: String,
+                             @ExportFunctionParameterDescription(name = "artifactId",
+                               description = "The value of the dependency's artifactId")
+                             artifactId: String,
+                             @ExportFunctionParameterDescription(name = "scope",
+                               description = "The value of the dependency's scope")
+                             scope: String): Unit =
+    addOrReplaceNode(dependenciesBaseXPath,
+      s"/project/dependencies/dependency/artifactId[text()='$artifactId' and ../groupId[text() = '$groupId']]/..",
+      dependency,
+      s"""<dependency><groupId>$groupId</groupId><artifactId>$artifactId</artifactId><scope>$scope</scope></dependency>""")
+
+  @ExportFunction(readOnly = false, description = "Add or replace a dependency, providing version and scope")
   def addOrReplaceDependencyOfVersion(@ExportFunctionParameterDescription(name = "groupId",
     description = "The value of the dependency's groupId")
                              groupId: String,
@@ -259,6 +274,24 @@ trait PomMutableViewMutatingFunctions extends BuildViewMutatingFunctions {
       s"/project/dependencies/dependency/artifactId[text()='$artifactId' and ../groupId[text() = '$groupId']]/..",
       dependency,
       s"""<dependency><groupId>$groupId</groupId><artifactId>$artifactId</artifactId><version>$version</version></dependency>""")
+
+  @ExportFunction(readOnly = false, description = "Add or replace a dependency, providing version and scope")
+  def addOrReplaceDependencyOfVersion(@ExportFunctionParameterDescription(name = "groupId",
+    description = "The value of the dependency's groupId")
+                                      groupId: String,
+                                      @ExportFunctionParameterDescription(name = "artifactId",
+                                        description = "The value of the dependency's artifactId")
+                                      artifactId: String,
+                                      @ExportFunctionParameterDescription(name = "newVersion",
+                                        description = "The value of the dependency's version to be set")
+                                      version: String,
+                                      @ExportFunctionParameterDescription(name = "scope",
+                                        description = "The value of the dependency's scope to be set")
+                                      scope: String): Unit =
+    addOrReplaceNode(dependenciesBaseXPath,
+      s"/project/dependencies/dependency/artifactId[text()='$artifactId' and ../groupId[text() = '$groupId']]/..",
+      dependency,
+      s"""<dependency><groupId>$groupId</groupId><artifactId>$artifactId</artifactId><version>$version</version><scope>$scope</scope></dependency>""")
 
   @ExportFunction(readOnly = false, description = "Add or replace a dependency's version")
   def addOrReplaceDependencyVersion(@ExportFunctionParameterDescription(name = "groupId",

--- a/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
@@ -345,6 +345,41 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
     validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
   }
 
+  it should "add a dependency with scope" in {
+    val dependencyArtifactId = "atomist-artifact"
+    val dependencyGroupId = "com.atomist"
+    val dependencyScope = "compile"
+
+    validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (false)
+
+    validPomUut.addOrReplaceDependency(dependencyGroupId, dependencyArtifactId, dependencyScope)
+
+    validPomUut.dirty should be (true)
+
+    validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
+
+    validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be ("compile")
+  }
+
+  it should "add a dependency with version and scope" in {
+    val dependencyArtifactId = "atomist-artifact"
+    val dependencyGroupId = "com.atomist"
+    val dependencyVersion = "0.1.0"
+    val dependencyScope = "compile"
+
+    validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (false)
+
+    validPomUut.addOrReplaceDependencyOfVersion(dependencyGroupId, dependencyArtifactId, dependencyVersion, dependencyScope)
+
+    validPomUut.dirty should be (true)
+
+    validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
+
+    validPomUut.dependencyVersion(dependencyGroupId, dependencyArtifactId) should be ("0.1.0")
+
+    validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be ("compile")
+  }
+
   it should "not add a further dependency if the dependency already exists" in {
     val dependencyArtifactId = "spring-boot-starter-web"
     val dependencyGroupId = "org.springframework.boot"


### PR DESCRIPTION
Currently, there is one way to add scope for existing dependencies. Now,
new operators are added to add scope when dependency is added or
updated.