### PR TITLE
JavaScript property navigation for Antlr-backed nodes

### DIFF
--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -4,7 +4,6 @@ import com.atomist.rug.RugRuntimeException
 import com.atomist.rug.command.DefaultCommandRegistry
 import com.atomist.rug.spi._
 import com.atomist.tree.{ContainerTreeNode, TreeNode}
-import com.atomist.tree.content.text.microgrammar.MicrogrammarNode
 import com.atomist.util.lang.JavaScriptArray
 import jdk.nashorn.api.scripting.AbstractJSObject
 
@@ -40,7 +39,7 @@ class jsSafeCommittingProxy(types: Set[Typed],
         op => name.equals(op.name))
 
       if (possibleOps.isEmpty && commandRegistry.findByNodeAndName(node, name).isEmpty) {
-        if (node.nodeTags.contains(MicrogrammarNode.MicrogrammarNodeType)) {
+        if (node.nodeTags.contains(TreeNode.Dynamic)) {
           // Navigation on a node
           new FixedReturnProxy(name, node)
         }

--- a/src/main/scala/com/atomist/tree/TerminalTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/TerminalTreeNode.scala
@@ -1,0 +1,18 @@
+package com.atomist.tree
+
+import com.atomist.util.Visitor
+
+/**
+  * Convenient supertrait for terminal TreeNodes. Contains a simple string value.
+  */
+trait TerminalTreeNode extends TreeNode {
+
+  final override def accept(v: Visitor, depth: Int): Unit = v.visit(this, depth)
+
+  final override def childNodeNames: Set[String] = Set()
+
+  final override def childNodeTypes: Set[String] = Set()
+
+  final override def childrenNamed(key: String): Seq[TreeNode] = Nil
+
+}

--- a/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/MutableContainerTreeNode.scala
@@ -31,17 +31,29 @@ trait MutableContainerTreeNode
     * @param child child of this node
     * @return Some if the child is found
     */
-  def formatInfo(child: TreeNode): Option[FormatInfo] =
-    if (!fieldValues.contains(child))
+  def formatInfo(child: TreeNode): Option[FormatInfo] = {
+    def descs(f: MutableContainerTreeNode): Seq[TreeNode] = {
+      f +: f.fieldValues.flatMap {
+        case d: MutableContainerTreeNode => descs(d)
+        case n => Seq(n)
+      }
+    }
+
+    val descendants = descs(this)
+
+    if (!descendants.contains(child))
       None
     else {
       // Build string to the left
-      val leftFields = fieldValues.takeWhile(f => f != child)
-      val stringToLeft = leftFields.map(_.value).mkString("")
+      val leftFields = descendants.takeWhile(f => f != child)
+      val stringToLeft = leftFields
+        .filter(_.childNodes.isEmpty)
+        .map(_.value).mkString("")
       val leftPoint = FormatInfo.contextInfo(stringToLeft)
       val rightPoint = FormatInfo.contextInfo(stringToLeft + child.value)
       //println(s"Found $fi from left string [$stringToLeft] with start=$start")
       Some(FormatInfo(leftPoint, rightPoint))
     }
+  }
 
 }

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -3,7 +3,6 @@ package com.atomist.tree.content.text.grammar.antlr
 import com.atomist.tree.TreeNode.Significance
 import com.atomist.tree.content.text._
 import com.atomist.tree.content.text.grammar.MatchListener
-import com.atomist.tree.content.text.microgrammar.MicrogrammarNode
 import com.atomist.tree.{ContainerTreeNode, SimpleTerminalTreeNode, TreeNode}
 import com.typesafe.scalalogging.LazyLogging
 import org.antlr.v4.runtime.tree.{ErrorNode, TerminalNode}

--- a/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
+++ b/src/main/scala/com/atomist/tree/content/text/grammar/antlr/ModelBuildingListener.scala
@@ -3,6 +3,7 @@ package com.atomist.tree.content.text.grammar.antlr
 import com.atomist.tree.TreeNode.Significance
 import com.atomist.tree.content.text._
 import com.atomist.tree.content.text.grammar.MatchListener
+import com.atomist.tree.content.text.microgrammar.MicrogrammarNode
 import com.atomist.tree.{ContainerTreeNode, SimpleTerminalTreeNode, TreeNode}
 import com.typesafe.scalalogging.LazyLogging
 import org.antlr.v4.runtime.tree.{ErrorNode, TerminalNode}
@@ -107,7 +108,8 @@ class ModelBuildingListener(
       startPos,
       endPos,
       namingStrategy.significance(rule, deduped),
-      namingStrategy.tagsForContainer(rule, deduped))
+      // Mark it as a dynamic node
+      namingStrategy.tagsForContainer(rule, deduped) ++ Set(TreeNode.Dynamic))
   }
 
   // Remove duplicate fields. The ones with lower case can replace the ones with upper case

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -75,13 +75,5 @@ private class MicrogrammarNode(name: String,
     name: String, fields, startPosition, endPosition, significance = TreeNode.Signal) {
 
   addType(typ)
-  addType(MicrogrammarNode.MicrogrammarNodeType)
-}
-
-object MicrogrammarNode {
-
-  /**
-    * Node type added for all microgrammar nodes
-    */
-  val MicrogrammarNodeType = "microgrammar"
+  addType(TreeNode.Dynamic)
 }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammar.scala
@@ -31,9 +31,9 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
     val endOffset = startOffset + matchFound.matched.length
     val matchedNode = matchFound.node match {
       case one: MutableTerminalTreeNode =>
-        new MicrogrammarNode(name, name, Seq(one), startOffset, endOffset)
+        new SimpleMutableContainerTreeNode(name, Seq(one), startOffset, endOffset, TreeNode.Signal, Set(name, TreeNode.Dynamic))
       case  container: MutableContainerTreeNode =>
-        new MicrogrammarNode(name, name, container.childNodes, startOffset, endOffset)
+        new SimpleMutableContainerTreeNode(name, container.childNodes, startOffset, endOffset, TreeNode.Signal, Set(name, TreeNode.Dynamic))
       case _ => ???
     }
     matchedNode.pad(input.toString)
@@ -64,16 +64,4 @@ class MatcherMicrogrammar(val matcher: Matcher, val name: String = "MySpecialMic
 
   override def toString: String = s"MatcherMicrogrammar wrapping [$matcher]"
 
-}
-
-private class MicrogrammarNode(name: String,
-                               typ: String,
-                               fields: Seq[TreeNode],
-                               startPosition: InputPosition,
-                               endPosition: InputPosition)
-  extends SimpleMutableContainerTreeNode(
-    name: String, fields, startPosition, endPosition, significance = TreeNode.Signal) {
-
-  addType(typ)
-  addType(TreeNode.Dynamic)
 }

--- a/src/main/scala/com/atomist/tree/treeNode.scala
+++ b/src/main/scala/com/atomist/tree/treeNode.scala
@@ -91,28 +91,19 @@ trait TreeNode extends Visitable {
 }
 
 object TreeNode {
+
   sealed trait Significance
   case object Noise extends Significance
   case object Signal extends Significance
   case object Undeclared extends Significance
+
+  /**
+    * Tag added to all dynamically created nodes, such as those backed by microgrammars or Antlr
+    */
+  val Dynamic: String = "-dynamic"
 }
 
 /**
   * Tag interface for TreeNodes that are intended to contain other TreeNodes.
   */
 trait ContainerTreeNode extends TreeNode
-
-/**
-  * Convenient supertrait for terminal TreeNodes. Contains a simple string value.
-  */
-trait TerminalTreeNode extends TreeNode {
-
-  final override def accept(v: Visitor, depth: Int): Unit = v.visit(this, depth)
-
-  final override def childNodeNames: Set[String] = Set()
-
-  final override def childNodeTypes: Set[String] = Set()
-
-  final override def childrenNamed(key: String): Seq[TreeNode] = Nil
-
-}

--- a/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
@@ -23,10 +23,12 @@ class ChangeException implements ProjectEditor {
 
       let count = 0
       eng.with<any>(project, catchClause, cc => {
-        console.log(`The catch clause was '${cc.value()}'`)
+        //console.log(`The catch clause was '${cc.value()} at ${cc.formatInfo()}'`)
+        if (cc.formatInfo() == null) 
+          throw new Error(`Format info was null for ${cc.nodeName()}`)
+        if (cc.formatInfo().start().lineNumberFrom1() < 5 || cc.formatInfo().start().lineNumberFrom1() > 100) 
+          throw new Error(`Format info values are wacky in ${cc.formatInfo()}`)
         let classType = cc.class_type()
-          //cc.children.filter(c => c.nodeName == "class_identifier")
-          console.log(`n=${classType}`)
         classType.update(this.newException)
         count++
       })

--- a/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
@@ -1,0 +1,39 @@
+import {Project,File} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {parameter} from '@atomist/rug/operations/RugOperation'
+
+class ChangeException implements ProjectEditor {
+    name: string = "ChangeException"
+    description: string = "Changes exception"
+
+    @parameter({pattern: "^.*$$", description: "New package"})
+    newException: string
+
+    edit(project: Project) {
+      let eng: PathExpressionEngine = project.context().pathExpressionEngine()
+
+      /*
+        specific_catch_clause
+	      : CATCH OPEN_PARENS class_type identifier? CLOSE_PARENS exception_filter? block
+      */
+      let catchClause = `/src//CSharpFile()//specific_catch_clause[//class_type[@value='IndexOutOfRangeException']]`
+
+      let count = 0
+      eng.with<any>(project, catchClause, cc => {
+        console.log(`The catch clause was '${cc.value()}'`)
+        let classType = cc.class_type()
+          //cc.children.filter(c => c.nodeName == "class_identifier")
+          console.log(`n=${classType}`)
+        classType.update(this.newException)
+        count++
+      })
+
+      if (count == 0)
+       throw new Error("No C# files with exceptions found. Sad.")
+    }
+}
+
+export let editor = new ChangeException()

--- a/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeUsageTest.scala
@@ -62,7 +62,7 @@ class CSharpFileTypeUsageTest extends AntlrRawFileTypeTest {
       case sm: SuccessfulModification =>
         val theFile = sm.result.findFile("src/exception.cs").get
         theFile.content should be (Exceptions.replace("IndexOutOfRangeException", newExceptionType))
-      case _ => ???
+      case wtf => fail(s"Expected SuccessModification, not $wtf")
     }
   }
 

--- a/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeUsageTest.scala
@@ -1,6 +1,6 @@
 package com.atomist.rug.kind.csharp
 
-import com.atomist.project.edit.NoModificationNeeded
+import com.atomist.project.edit.{NoModificationNeeded, SuccessfulModification}
 import com.atomist.rug.kind.grammar.AntlrRawFileTypeTest
 
 class CSharpFileTypeUsageTest extends AntlrRawFileTypeTest {
@@ -38,7 +38,7 @@ class CSharpFileTypeUsageTest extends AntlrRawFileTypeTest {
   }
 
   it should "not add using if it's already present" in {
-    val r = modify("AddUsingUsingMethod.ts", HelloWorldSources,
+    modify("AddUsingUsingMethod.ts", HelloWorldSources,
       Map("packageName" -> "System")) match {
       case nmn: NoModificationNeeded =>
       case _ => ???
@@ -54,5 +54,16 @@ class CSharpFileTypeUsageTest extends AntlrRawFileTypeTest {
   }
 
   it should "add using if no using present" is pending
+
+  it should "change exception" in {
+    val newExceptionType = "ThePlaneHasFlownIntoTheMountainException"
+    modify("ChangeException.ts", ExceptionProject,
+      Map("newException" -> newExceptionType)) match {
+      case sm: SuccessfulModification =>
+        val theFile = sm.result.findFile("src/exception.cs").get
+        theFile.content should be (Exceptions.replace("IndexOutOfRangeException", newExceptionType))
+      case _ => ???
+    }
+  }
 
 }

--- a/src/test/scala/com/atomist/rug/kind/grammar/SimpleMutableContainerTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/grammar/SimpleMutableContainerTreeNodeTest.scala
@@ -115,6 +115,32 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     updated should equal(expected)
   }
 
+  it should "find format info from nested node" in {
+    val inputA = "foo"
+    val inputB = "bar"
+    val inputC = "Lisbon"
+    val inputD = "Alentejo"
+    val unmatchedContent = "this is incorrect"
+    val bollocks2 = "(more bollocks)"
+    val line = inputA + unmatchedContent + inputB + inputC + bollocks2 + inputD
+
+    val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
+    val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length))
+
+    val ff1 = new MutableTerminalTreeNode("c1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
+    val ff2 = new MutableTerminalTreeNode("c2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + bollocks2.length))
+
+    val f3 = new SimpleMutableContainerTreeNode("c", Seq(ff1, ff2), ff1.startPosition, endOf(line))
+
+    val soo = SimpleMutableContainerTreeNode.wholeInput("x", Seq(f1, f2, f3), line)
+
+    soo.formatInfo(SimpleTerminalTreeNode("x", "y")) should be (empty)
+
+    soo.formatInfo(f1).get.start.offset should equal (f1.startPosition.offset)
+    soo.formatInfo(f2).get.start.offset should equal (f2.startPosition.offset)
+    soo.formatInfo(ff1).get.start.offset should equal (ff1.startPosition.offset)
+  }
+
   it should "allow add in nested match" in
     handleLine("")
 


### PR DESCRIPTION
Introduces a Dynamic tag for TreeNodes, which is shared between Antlr and the microgrammar support, where an `MicrogrammarNode` annotation was previously used.

Added additional path-expression based test for C# file type to illustrate this.

Deleted `MicrogrammarNode` class and object, as they are no longer needed.

Fixed issue where `FormatInfo` was only obtainable for direct children of a file's root node.