### PR TITLE
Class level decorator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Added support for @editor, @generator, @executor, @reviewer and @tags class decorators in TS
+
 -   Added `ScalaFileType` backed by ScalaMeta
 
 -   Fix: Elm parser failed on files with two multiline comments

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingExecutor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingExecutor.scala
@@ -14,8 +14,6 @@ class JavaScriptInvokingExecutor(
   extends JavaScriptInvokingProjectOperation(jsc, jsVar, rugAs)
     with Executor {
 
-  override val name: String = jsVar.getMember("name").asInstanceOf[String]
-
   override def execute(serviceSource: ServiceSource, poa: ProjectOperationArguments): Unit = {
     val smv = new ServicesMutableView(rugAs, serviceSource)
     val wsmv = new jsSafeCommittingProxy(new ServicesType, smv)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectEditor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectEditor.scala
@@ -20,8 +20,6 @@ class JavaScriptInvokingProjectEditor(
   extends JavaScriptInvokingProjectOperation(jsc, jsVar, rugAs)
     with ProjectEditorSupport {
 
-  override val name: String = jsVar.getMember("name").asInstanceOf[String]
-
   override def applicability(as: ArtifactSource): Applicability = Applicability.OK
 
   override protected def modifyInternal(

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectGenerator.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectGenerator.scala
@@ -23,8 +23,6 @@ class JavaScriptInvokingProjectGenerator(
   extends JavaScriptInvokingProjectOperation(jsc, jsVar, rugAs)
     with ProjectGenerator {
 
-  override val name: String = jsVar.getMember("name").asInstanceOf[String]
-
   @throws(classOf[InvalidParametersException])
   override def generate(projectName: String, poa: ProjectOperationArguments): ArtifactSource = {
     validateParameters(poa)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectReviewer.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectReviewer.scala
@@ -18,8 +18,6 @@ class JavaScriptInvokingProjectReviewer(
   extends JavaScriptInvokingProjectOperation(jsc, jsVar, rugAs)
     with ProjectReviewer {
 
-  override val name: String = jsVar.getMember("name").asInstanceOf[String]
-
   override def review(targetProject: ArtifactSource, poa: ProjectOperationArguments): ReviewResult = {
     val (response, elapsedTime) = time {
       val pmv = new ProjectMutableView(rugAs,

--- a/src/main/typescript/node_modules/@atomist/rug/operations/ProjectEditor.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/ProjectEditor.ts
@@ -14,5 +14,5 @@ export interface ProjectEditor extends RugOperation {
   /**
    * Edit the project given the parameters.
    */
-  edit(project: Project, params: {}): void
+  edit(project: Project, params?: {}): void
 }

--- a/src/main/typescript/node_modules/@atomist/rug/operations/ProjectGenerator.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/ProjectGenerator.ts
@@ -6,8 +6,7 @@ import {RugOperation} from "./RugOperation"
  * Top level interface for all project generators
  */
 interface ProjectGenerator extends RugOperation {
-    
-    populate(emptyProject: Project, args: {})
+    populate(emptyProject: Project, params?: {})
 }
 
 export {ProjectGenerator}

--- a/src/main/typescript/node_modules/@atomist/rug/operations/ProjectReviewer.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/ProjectReviewer.ts
@@ -1,4 +1,4 @@
-import {RugOperation, ReviewResult, Parameter} from "./RugOperation"
+import {RugOperation, ReviewResult} from "./RugOperation"
 import {Project} from "../model/Core"
 import {ProjectContext} from "./ProjectEditor"
 
@@ -6,6 +6,5 @@ import {ProjectContext} from "./ProjectEditor"
  * Review the given project with given parameters
  */
 export interface ProjectReviewer extends RugOperation {
-
-  review(project: Project, params: {}): ReviewResult
+  review(project: Project, params?: {}): ReviewResult
 }

--- a/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
@@ -97,12 +97,10 @@ class ReviewResult {
       public comments: ReviewComment[]) {}
 }
 
-
-
 //used by annotation functions
 
 function set_metadata(obj: any, key: string, value: any){
-  Object.defineProperty(obj, key, {value: value, writable: false, enumerable: false})
+  Object.defineProperty(obj, key, {value: value, writable: false, enumerable: true})
 }
 
 
@@ -123,15 +121,45 @@ function get_metadata(obj: any, key: string){
 */
 function parameter(details: BaseParameter) {
   return function (target: any, propertyKey: string) {
-    var params = get_metadata(target, "parameters");
+    var params = get_metadata(target, "__parameters");
     if(params == null){
       params = []
     }
     details["name"] = propertyKey
     details["decorated"] = true
     params.push(details);
-    set_metadata(target, "parameters", params);
+    set_metadata(target, "__parameters", params);
   }
 }
 
-export {RugOperation, Parameter, Pattern, Result, Status, ReviewResult, ReviewComment, Severity, BaseParameter, parameter}
+/**
+* Decorator for editors. Use this intead of implementing the editor interface.
+*/
+
+function ruglike(kind: string) {
+  return function (name: string, description: string) {
+    return function(ctr: Function) {
+      if (typeof ctr.prototype[kind] !== "function") {
+        throw new Error(`${kind} must be function that takes a Project as its first argument.`)
+      }
+      ctr.prototype["__name"] = name;
+      ctr.prototype["__description"] = description
+    }
+  }
+}
+
+let generator = ruglike("populate")
+let reviewer = ruglike("review")
+let editor = ruglike("edit")
+
+/**
+* Decorator for tags. Sets tags on the class
+*/
+
+function tags(...tags: string[]) {
+  return function(target: any) {
+    target.prototype["__tags"] = tags
+  }
+}
+
+export {RugOperation, Parameter, Pattern, Result, Status, ReviewResult, ReviewComment, Severity, BaseParameter, parameter, editor, generator, reviewer, tags}

--- a/src/main/typescript/node_modules/@atomist/rug/tree/TreeHelper.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/TreeHelper.ts
@@ -1,11 +1,10 @@
-
 import {TreeNode,ParentAwareTreeNode} from "./PathExpression"
 
 /**
  * Helper functions for working with TreeNodes in simple
  * case where we don't need a path expression.
  */
-export class TreeHelper {
+class TreeHelper {
 
     /**
      * Return an ancestor meeting the given criteria
@@ -23,7 +22,7 @@ export class TreeHelper {
         else if (parent.parent()) { // Essentially an instanceof, which we can't do on an interface
             return this.findAncestor(parent as ParentAwareTreeNode, nodeTest) as N
         }
-        else 
+        else
             return null
     }
 
@@ -32,9 +31,10 @@ export class TreeHelper {
      */
     findAncestorWithTag<N extends TreeNode>(n: ParentAwareTreeNode, tag: String): N {
         let r = this.findAncestor<N>(
-            n, 
+            n,
             n => n.nodeTags().contains(tag))
-        //console.log(`findAncestorWithTag returning ${r.nodeName()}`)
         return r
     }
 }
+
+export {TreeHelper}

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinderTest.scala
@@ -12,30 +12,28 @@ class JavaScriptOperationFinderTest  extends FlatSpec with Matchers {
   val SimpleProjectEditorWithParametersArray: String =
     s"""
        |import {Project} from '@atomist/rug/model/Core'
-       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
        |import {File} from '@atomist/rug/model/Core'
-       |import {Parameter} from '@atomist/rug/operations/RugOperation'
+       |import {parameter, editor} from '@atomist/rug/operations/RugOperation'
        |
-       |class SimpleEditor implements ProjectEditor {
-       |    name: string = "Simple"
-       |    description: string = "A nice little editor"
-       |    parameters: Parameter[] = [{name: "content", description: "Content", pattern: "^.*$$", maxLength: 100}]
-       |    edit(project: Project, {content} : {content: string}) {
-       |    }
+       |@editor("Simple", "A nice little editor")
+       |class SimpleEditor{
+       |
+       |    @parameter({pattern: "^.*$$", description: "foo bar"})
+       |    content: string
+       |
+       |    edit(project: Project) {}
        |  }
-       |export let editor = new SimpleEditor()
+       |export let myeditor = new SimpleEditor()
     """.stripMargin
 
   val SimpleProjectEditorWithAnnotatedParameters: String =
     s"""
        |import {Project} from '@atomist/rug/model/Core'
-       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
        |import {File} from '@atomist/rug/model/Core'
-       |import {parameter} from '@atomist/rug/operations/RugOperation'
+       |import {parameter, editor} from '@atomist/rug/operations/RugOperation'
        |
-       |class SimpleEditor implements ProjectEditor {
-       |    name: string = "Simple"
-       |    description: string = "A nice little editor"
+       |@editor("Simple", "A nice little editor")
+       |class SimpleEditor {
        |
        |    @parameter({pattern: "^.*$$", description: "foo bar"})
        |    content: string = "Test String";
@@ -55,7 +53,7 @@ class JavaScriptOperationFinderTest  extends FlatSpec with Matchers {
        |       }
        |    }
        |  }
-       |export let editor = new SimpleEditor()
+       |export let myeditor = new SimpleEditor()
     """.stripMargin
 
   it should "find an editor with a parameters list" in {

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
@@ -20,35 +20,33 @@ object TypeScriptRugEditorTest {
   val SimpleEditorWithoutParameters =
     """
       |import {Project} from '@atomist/rug/model/Core';
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor';
+      |import {editor} from '@atomist/rug/operations/RugOperation'
       |
-      |class SimpleEditor implements ProjectEditor {
-      |    name: string = "Simple";
-      |    description: string = "My simple editor";
+      |@editor("Simple", "My simple editor")
+      |class SimpleEditor {
       |    edit(project: Project): void {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
       |    }
       |}
-      |export let editor = new SimpleEditor();
+      |export let myeditor = new SimpleEditor();
     """.stripMargin
 
   val SimpleEditorWithBasicParameter =
     s"""
       |import {Project} from '@atomist/rug/model/Core'
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-      |import {parameter} from '@atomist/rug/operations/RugOperation'
+      |import {editor, parameter} from '@atomist/rug/operations/RugOperation'
       |
-      |class SimpleEditor implements ProjectEditor {
-      |    name: string = "Simple"
-      |    description: string = "My simple editor"
+      |@editor("Simple", "My simple editor")
+      |class SimpleEditor {
       |
       |    @parameter({description: "Content", pattern: "$ContentPattern"})
       |    content: string
+      |
       |    edit(project: Project)  {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God")
       |    }
       |}
-      |export let editor = new SimpleEditor()
+      |export let myeditor = new SimpleEditor()
     """.stripMargin
 
   val SimpleLetStyleEditorWithoutParameters =
@@ -61,76 +59,70 @@ object TypeScriptRugEditorTest {
       |    description: "My simple editor",
       |    edit(project: Project) {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
-      |
-      |        // `Edited Project now containing ${project.fileCount()} files: \n`)
       |    }
       |}
     """.stripMargin
 
   val SimpleEditor =
     """
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
       |import {Project} from '@atomist/rug/model/Core'
+      |import {editor} from '@atomist/rug/operations/RugOperation'
       |
-      |class SimpleEditor implements ProjectEditor {
-      |    name: string = "Simple"
-      |    description: string = "My simple editor"
+      |@editor("Simple", "My simple editor")
+      |class SimpleEditor {
       |    edit(project: Project) {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
       |    }
       |}
       |
-      |export let editor = new SimpleEditor()
+      |export let myeditor = new SimpleEditor()
     """.stripMargin
 
   val SimpleEditorInvokingOtherEditor =
     """
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
       |import {Project} from '@atomist/rug/model/Core'
+      |import {editor} from '@atomist/rug/operations/RugOperation'
       |
-      |class SimpleEditor implements ProjectEditor {
-      |    name: string = "Simple"
-      |    description: string = "My simple editor"
+      |@editor("Simple", "My simple editor")
+      |class SimpleEditor {
       |    edit(project: Project) {
       |        project.editWith("other", { otherParam: "Anders Hjelsberg is God" });
       |    }
       |}
-      |export let editor = new SimpleEditor()
+      |export let myeditor = new SimpleEditor()
 
     """.stripMargin
 
   val SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters =
     s"""
        |import {Project} from '@atomist/rug/model/Core'
-       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
        |import {File} from '@atomist/rug/model/Core'
-       |import {parameter} from '@atomist/rug/operations/RugOperation'
+       |import {editor, parameter, tags} from '@atomist/rug/operations/RugOperation'
        |
-       |class SimpleEditor implements ProjectEditor {
-       |    name: string = "Simple"
-       |    description: string = "My simple editor"
-       |    tags: string[] = ["java", "maven"]
+       |@editor("Simple", "My simple editor")
+       |@tags("java", "maven")
+       |class SimpleEditor {
        |
        |    @parameter({description: "Content", displayName: "content", pattern: "$ContentPattern", maxLength: 100, tags: ["foo","bar"]})
        |    content: string
-       |
        |
        |    edit(project: Project) {
        |      project.editWith("other", { otherParam: "Anders Hjelsberg is God" })
        |    }
        |  }
-       |export let editor = new SimpleEditor()
+       |export let myeditor = new SimpleEditor()
     """.stripMargin
 
   val SimpleGenerator =
     """
-      |import {ProjectGenerator} from '@atomist/rug/operations/ProjectGenerator'
       |import {Project} from '@atomist/rug/model/Core'
+      |import {generator, parameter} from '@atomist/rug/operations/RugOperation'
       |
-      |class SimpleGenerator implements ProjectGenerator {
-      |     description: string = "My simple Generator"
-      |     name: string = "SimpleGenerator"
-      |     content: string = ""
+      |@generator("SimpleGenerator","My simple Generator")
+      |class SimpleGenerator{
+      |
+      |     content: string = "woot"
+      |
       |     populate(project: Project) {
       |        let len: number = this.content.length;
       |        if(project.name() != "woot"){
@@ -145,15 +137,11 @@ object TypeScriptRugEditorTest {
   val SimpleEditorTaggedAndMeta =
     s"""
        |import {Project} from '@atomist/rug/model/Core'
-       |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-       |import {parameter} from '@atomist/rug/operations/RugOperation'
-       |import {File} from '@atomist/rug/model/Core'
+       |import {parameter, tags, editor} from '@atomist/rug/operations/RugOperation'
        |
-       |class SimpleEditor implements ProjectEditor {
-       |
-       |    name: string = "Simple"
-       |    description: string = "A nice little editor"
-       |    tags: string[] = ["java", "maven"]
+       |@editor("Simple","A nice little editor")
+       |@tags("java", "maven")
+       |class SimpleEditor {
        |
        |    @parameter({description: "Content", displayName: "content", pattern: "$ContentPattern", maxLength: 100, displayable: false})
        |    content: string = "Anders is ?"
@@ -181,14 +169,14 @@ object TypeScriptRugEditorTest {
 
   val SimpleEditorWithRelativeDependency =
     """
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+      |import {editor} from '@atomist/rug/operations/RugOperation'
       |import {Project} from '@atomist/rug/model/Core'
       |
       |import {Bar} from './Foo'
       |
-      |class SimpleEditor implements ProjectEditor {
-      |    name: string = "Simple"
-      |    description: string = "My simple editor"
+      |@editor("Simple","My simple editor")
+      |class SimpleEditor {
+      |
       |    edit(project: Project) {
       |        let bar: Bar = new Bar();
       |        bar.doWork()
@@ -196,43 +184,39 @@ object TypeScriptRugEditorTest {
       |    }
       |}
       |
-      |export let editor = new SimpleEditor()
+      |export let myeditor = new SimpleEditor()
     """.stripMargin
 
     val EditorInjectedWithPathExpressionObject: String =
-      """import {Project} from '@atomist/rug/model/Core'
-        |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-        |import {PathExpression} from '@atomist/rug/tree/PathExpression'
-        |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-        |import {Match} from '@atomist/rug/tree/PathExpression'
-        |import {File} from '@atomist/rug/model/Core'
-        |import {parameter} from '@atomist/rug/operations/RugOperation'
+
+      """import {Project,File} from '@atomist/rug/model/Core'
+        |import {Match, PathExpression, PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+        |import {parameter, editor,tags} from '@atomist/rug/operations/RugOperation'
         |
         |class PomFile extends PathExpression<Project,File> {
         |
         |    constructor() { super(`/File()[@name='pom.xml']`) }
         |}
         |
-        |class ConstructedEditor implements ProjectEditor {
-        |
-        |    name: string = "Constructed"
-        |    description: string = "A nice little editor"
-        |    tags: string[] = ["java", "maven"]
+        |@tags("java", "maven")
+        |@editor("Constructed", "A nice little editor")
+        |class ConstructedEditor {
         |
         |    @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
-        |    packageName: string;
+        |    packageName: string
+        |
         |    edit(project: Project) {
         |
         |      let eng: PathExpressionEngine = project.context().pathExpressionEngine();
         |      let m = eng.evaluate<Project,File>(project, new PomFile())
         |
-        |      var t: string = `param=${this.packageName},filecount=${m.root().fileCount()}`
+        |      let t: string = `param=${this.packageName},filecount=${m.root().fileCount()}`
         |      for (let n of m.matches()) {
         |        t += `Matched file=${n.path()}`;
         |        n.append("randomness")
         |        }
         |
-        |        var s: string = ""
+        |        let s: string = ""
         |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
         |        for (let f of project.files())
         |            s = s + `File [${f.path()}] containing [${f.content()}]\n`
@@ -240,26 +224,21 @@ object TypeScriptRugEditorTest {
         |        `${t}\n\nEdited Project containing ${project.fileCount()} files: \n${s}`)
         |    }
         |  }
-        |  export let editor = new ConstructedEditor()
+        |  export let myeditor = new ConstructedEditor()
         | """.stripMargin
 
   val EditorInjectedWithPathExpression: String =
-    """import {Project} from '@atomist/rug/model/Core'
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-      |import {PathExpression} from '@atomist/rug/tree/PathExpression'
-      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-      |import {Match} from '@atomist/rug/tree/PathExpression'
-      |import {File} from '@atomist/rug/model/Core'
-      |import {parameter} from '@atomist/rug/operations/RugOperation'
+
+    """import {Project, File} from '@atomist/rug/model/Core'
+      |import {Match, PathExpression, PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+      |import {editor, parameter, tags} from '@atomist/rug/operations/RugOperation'
       |
-      |class ConstructedEditor implements ProjectEditor {
-      |
-      |    name: string = "Constructed"
-      |    description: string = "A nice little editor"
-      |    tags: string[] = ["java", "maven"]
+      |@tags("java", "maven")
+      |@editor("Constructed", "A nice little editor")
+      |class ConstructedEditor {
       |
       |    @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
-      |    packageName: string;
+      |    packageName: string
       |
       |    edit(project: Project) {
       |
@@ -280,29 +259,29 @@ object TypeScriptRugEditorTest {
       |            s = s + `File [${f.path()}] containing [${f.content()}]\n`
       |    }
       |  }
-      |  export let editor = new ConstructedEditor()
+      |  export let myeditor = new ConstructedEditor()
       | """.stripMargin
 
   val EditorInjectedWithPathExpressionUsingWith: String =
     """import {Project} from '@atomist/rug/model/Core'
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
       |import {PathExpression} from '@atomist/rug/tree/PathExpression'
       |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
       |import {Match} from '@atomist/rug/tree/PathExpression'
       |import {File} from '@atomist/rug/model/Core'
-      |import {Result,Status, Parameter} from '@atomist/rug/operations/RugOperation'
+      |import {editor,parameter,tags} from '@atomist/rug/operations/RugOperation'
       |
-      |class ConstructedEditor implements ProjectEditor {
       |
-      |    name: string = "Constructed"
-      |    description: string = "A nice little editor"
-      |    tags: string[] = ["java", "maven"]
-      |    parameters: Parameter[] = [{name: "packageName", description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100}]
+      |@tags("java", "maven")
+      |@editor("Constructed", "A nice little editor")
+      |class ConstructedEditor {
       |
-      |    edit(project: Project, {packageName } : {packageName: string}) {
+      |    @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
+      |    packageName: string
+      |
+      |    edit(project: Project) {
       |      let eng: PathExpressionEngine = project.context().pathExpressionEngine();
       |      project.files().filter(t => false)
-      |      var t: string = `param=${packageName},filecount=${project.fileCount()}`
+      |      var t: string = `param=${this.packageName},filecount=${project.fileCount()}`
       |
       |      eng.with<File>(project, "/*[@name='pom.xml']", n => {
       |        t += `Matched file=${n.path()}`;
@@ -319,36 +298,35 @@ object TypeScriptRugEditorTest {
       |    }
       |  }
       |
-      |  export let editor = new ConstructedEditor()
+      |  export let myeditor = new ConstructedEditor()
       | """.stripMargin
 
   val EditorInjectedWithPathExpressionUsingWithTypeJump: String =
-    """import {Project} from '@atomist/rug/model/Core'
-      |import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-      |import {PathExpression} from '@atomist/rug/tree/PathExpression'
-      |import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-      |import {Match} from '@atomist/rug/tree/PathExpression'
-      |import {File} from '@atomist/rug/model/Core'
-      |import {Result,Status, Parameter} from '@atomist/rug/operations/RugOperation'
+
+    """import {Match, PathExpression, PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+      |import {Project, File} from '@atomist/rug/model/Core'
+      |import {editor, parameter, tags} from '@atomist/rug/operations/RugOperation'
       |
-      |class ConstructedEditor implements ProjectEditor {
-      |    name: string = "Constructed"
-      |    description: string = "A nice little editor"
-      |    tags: string[] = ["java", "maven"]
       |
-      |    parameters: Parameter[] = [{name: "packageName", description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100}]
-      |    edit(project: Project, {packageName } : { packageName: string}) {
+      |@tags("java", "maven")
+      |@editor("Constructed", "A nice little editor")
+      |class ConstructedEditor {
+      |
+      |    @parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
+      |    packageName: string
+      |
+      |    edit(project: Project) {
       |
       |      let eng: PathExpressionEngine = project.context().pathExpressionEngine();
       |
-      |      var t: string = `param=${packageName},filecount=${project.fileCount()}`
+      |      let t: string = `param=${this.packageName},filecount=${project.fileCount()}`
       |
       |      eng.with<File>(project, "/File()", n => {
       |        t += `Matched file=${n.path()}`;
       |        n.append("randomness")
       |      })
       |
-      |        var s: string = ""
+      |        let s: string = ""
       |
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
       |        for (let f of project.files())
@@ -357,7 +335,7 @@ object TypeScriptRugEditorTest {
       |        //`${t}\n\nEdited Project containing ${project.fileCount()} files: \n${s}`)
       |    }
       |  }
-      |  export let editor = new ConstructedEditor()
+      |  export let myeditor = new ConstructedEditor()
       | """.stripMargin
 
 }


### PR DESCRIPTION
Annotations take precedence over equivalent interface fields to avoid any confusion about which are used.
e.g.

```typescript
import {Project} from '@atomist/rug/model/Core'
import {File} from '@atomist/rug/model/Core'
import {editor, parameter, tags} from '@atomist/rug/operations/RugOperation'

@editor("Simple", "My simple editor")
@tags("java", "maven")
class SimpleEditor {

    @parameter({description: "Content", displayName: "content", pattern: "$ContentPattern", maxLength: 100, tags: ["foo","bar"]})
    content: string

    edit(project: Project) {
      project.editWith("other", { otherParam: "Anders Hjelsberg is God" })
    }
  }
export let myeditor = new SimpleEditor()
```