### PR TITLE
Add typescript test, the Editor

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -24,3 +24,20 @@ executor:
     branch: "update-maven"
     sha: "24b88f7"
 
+---
+kind: "operation"
+client: "rug-cli 0.22.0"
+editor:
+  name: "atomist-rugs.rug-editors.ConvertExistingProjectToRugArchiveWithEditor"
+  group: "atomist-rugs"
+  artifact: "rug-editors"
+  version: "0.6.0"
+  origin:
+    repo: "git@github.com:atomist-rugs/rug-editors"
+    branch: "master"
+    sha: "00b7e7d*"
+  parameters:
+    - "editor_name": "AddTypeScriptTest"
+    - "rug_archive_name": "rug"
+    - "rug_archive_group_id": "atomist"
+

--- a/.atomist/editors/AddTypeScriptTest.rug
+++ b/.atomist/editors/AddTypeScriptTest.rug
@@ -1,0 +1,14 @@
+@description "uses a template to create samplefile.txt"
+@tag "documentation"
+editor AddTypeScriptTest
+
+@displayName "My Value"
+@description "a single parameter to this editor"
+@validInput "free text"
+param my_value: @any
+
+let sampleTemplateTemplate = "AddTypeScriptTestTemplate.vm"
+
+/* Example showing applying a simple template being applied */
+with Project p
+  do merge sampleTemplateTemplate to "samplefile.txt"

--- a/.atomist/editors/AddTypeScriptTest.rug
+++ b/.atomist/editors/AddTypeScriptTest.rug
@@ -2,13 +2,25 @@
 @tag "documentation"
 editor AddTypeScriptTest
 
-@displayName "My Value"
-@description "a single parameter to this editor"
-@validInput "free text"
-param my_value: @any
+@displayName "Class Under Test"
+@validInput "Java fully qualified classname"
+param class_under_test: @any
 
-let sampleTemplateTemplate = "AddTypeScriptTestTemplate.vm"
+let class_name = {
+  var portions = class_under_test.split(".");
+  var after_the_last_dot = portions[portions.length - 1];
+  return after_the_last_dot;
+  }
+
+let ts_file_name = { "src/test/resources/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.ts" }
+let scala_file_name = { "src/test/scala/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.scala" }
 
 /* Example showing applying a simple template being applied */
-with Project p
-  do merge sampleTemplateTemplate to "samplefile.txt"
+with Project p begin
+  do copyEditorBackingFileOrFail "src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts" ts_file_name
+  do copyEditorBackingFileOrFail "src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala" scala_file_name
+  with File when path = ts_file_name
+    do replace "Sample" class_name
+  with File when path = scala_file_name
+    do replace "Sample" class_name
+end

--- a/.atomist/editors/AddTypeScriptTest.rug
+++ b/.atomist/editors/AddTypeScriptTest.rug
@@ -14,16 +14,21 @@ let class_name = {
 
 let package = { class_under_test.replace(/\.[^.]*$/, "") }
 
-let ts_file_name = { "src/test/resources/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.ts" }
-let scala_file_name = { "src/test/scala/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.scala" }
+let sample_ts_under_resources = "com/atomist/rug/ts/SampleTypeScriptTest.ts"
+let sample_ts_file_path = { "src/test/resources/" + sample_ts_under_resources }
+
+let ts_under_resources = { class_under_test.replace(/\./g, '/') + "TypeScriptTest.ts" }
+let ts_file_path = { "src/test/resources/" + ts_under_resources }
+let scala_file_path = { "src/test/scala/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.scala" }
 
 /* Example showing applying a simple template being applied */
 with Project p begin
-  do copyEditorBackingFileOrFail "src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts" ts_file_name
-  do copyEditorBackingFileOrFail "src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala" scala_file_name
-  with File when path = ts_file_name
+  do copyEditorBackingFileOrFail sample_ts_file_path ts_file_path
+  do copyEditorBackingFileOrFail "src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala" scala_file_path
+  with File when path = ts_file_path
     do replace "Sample" class_name
-  with File when path = scala_file_name begin
+  with File when path = scala_file_path begin
+    do replace sample_ts_under_resources ts_under_resources
     do replace "package com.atomist.rug.ts" { "package " + package }
     do replace "Sample" class_name
   end

--- a/.atomist/editors/AddTypeScriptTest.rug
+++ b/.atomist/editors/AddTypeScriptTest.rug
@@ -12,6 +12,8 @@ let class_name = {
   return after_the_last_dot;
   }
 
+let package = { class_under_test.replace(/\.[^.]*$/, "") }
+
 let ts_file_name = { "src/test/resources/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.ts" }
 let scala_file_name = { "src/test/scala/" + class_under_test.replace(/\./g, '/') + "TypeScriptTest.scala" }
 
@@ -21,6 +23,8 @@ with Project p begin
   do copyEditorBackingFileOrFail "src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala" scala_file_name
   with File when path = ts_file_name
     do replace "Sample" class_name
-  with File when path = scala_file_name
+  with File when path = scala_file_name begin
+    do replace "package com.atomist.rug.ts" { "package " + package }
     do replace "Sample" class_name
+  end
 end

--- a/.atomist/manifest.yml
+++ b/.atomist/manifest.yml
@@ -1,0 +1,6 @@
+group: atomist
+artifact: rug
+version: "0.1.0"
+requires: "[0.8.0,1.0.0)"
+dependencies:
+extensions:

--- a/.atomist/templates/AddTypeScriptTestTemplate.vm
+++ b/.atomist/templates/AddTypeScriptTestTemplate.vm
@@ -1,0 +1,8 @@
+Shows resolving a parameter to an editor as a variable in the template:
+
+$my_value
+
+See the Apache Velocity Project [User Guide][guide] for more
+information on using Velocity templates.
+
+[guide]: http://velocity.apache.org/engine/1.7/user-guide.html

--- a/.atomist/tests/AddTypeScriptTest.rt
+++ b/.atomist/tests/AddTypeScriptTest.rt
@@ -1,0 +1,20 @@
+scenario AddTypeScriptTest should do something amazing for developers
+
+let my_value = "Hey there new Atomista"
+
+let sample_output_file = "samplefile.txt"
+
+given
+  /* Selects the current project and its source files
+     as an initial point for then applying your editor
+  */
+  ArchiveRoot
+
+when
+  /* Run your editor */
+  AddTypeScriptTest
+
+then
+  /* Assert Something important that your editor did */
+  fileExists sample_output_file
+    and fileContains sample_output_file my_value

--- a/.atomist/tests/AddTypeScriptTest.rt
+++ b/.atomist/tests/AddTypeScriptTest.rt
@@ -1,8 +1,8 @@
 scenario AddTypeScriptTest should do something amazing for developers
 
-let my_value = "Hey there new Atomista"
 
-let sample_output_file = "samplefile.txt"
+let output_ts = "src/test/resources/com/atomist/rug/kind/scala/SomeClassHereTypeScriptTest.ts"
+let output_scala = "src/test/scala/com/atomist/rug/kind/scala/SomeClassHereTypeScriptTest.scala"
 
 given
   /* Selects the current project and its source files
@@ -12,9 +12,11 @@ given
 
 when
   /* Run your editor */
-  AddTypeScriptTest
+  AddTypeScriptTest class_under_test="com.atomist.rug.kind.scala.SomeClassHere"
 
 then
-  /* Assert Something important that your editor did */
-  fileExists sample_output_file
-    and fileContains sample_output_file my_value
+  fileExists output_ts
+    and fileContains output_ts "class SomeClassHereTypeScriptTest implements ProjectEditor"
+    and fileExists output_scala
+    and fileContains output_scala "class SomeClassHereTypeScriptTest extends FlatSpec with Matchers"
+

--- a/.atomist/tests/AddTypeScriptTest.rt
+++ b/.atomist/tests/AddTypeScriptTest.rt
@@ -13,7 +13,7 @@ given
 when
   /* Run your editor */
   AddTypeScriptTest class_under_test="com.atomist.rug.kind.scala.SomeClassHere"
-
+Tes
 then
   fileExists output_ts
     and fileContains output_ts "class SomeClassHereTypeScriptTest implements ProjectEditor"

--- a/.atomist/tests/AddTypeScriptTest.rt
+++ b/.atomist/tests/AddTypeScriptTest.rt
@@ -22,4 +22,5 @@ then
     and dump output_scala
     and fileContains output_scala "class SomeClassHereTypeScriptTest extends FlatSpec with Matchers"
     and fileContains output_scala "package com.atomist.rug.kind.scala"
+    and fileContains output_scala "com/atomist/rug/kind/scala/SomeClassHereTypeScriptTest.ts"
 

--- a/.atomist/tests/AddTypeScriptTest.rt
+++ b/.atomist/tests/AddTypeScriptTest.rt
@@ -13,10 +13,13 @@ given
 when
   /* Run your editor */
   AddTypeScriptTest class_under_test="com.atomist.rug.kind.scala.SomeClassHere"
-Tes
+
 then
   fileExists output_ts
-    and fileContains output_ts "class SomeClassHereTypeScriptTest implements ProjectEditor"
+    and fileContains output_ts "class SomeClassHereTypeScriptTest"
+    and fileContains output_ts "Uses SomeClassHere from TypeScript"
     and fileExists output_scala
+    and dump output_scala
     and fileContains output_scala "class SomeClassHereTypeScriptTest extends FlatSpec with Matchers"
+    and fileContains output_scala "package com.atomist.rug.kind.scala"
 

--- a/src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts
@@ -1,0 +1,20 @@
+import {Project} from '@atomist/rug/model/Core'
+import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
+import {PathExpression,TreeNode,Microgrammar} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from '@atomist/rug/operations/RugOperation'
+
+class SampleTypeScriptTest implements ProjectEditor {
+    name: string = "Constructed";
+    description: string = "Uses single microgrammar";
+
+    edit(project: Project) {
+
+        let pom = project.findFile('pom.xml');
+
+        pom.replace('dependency', 'dependenciesAreForBirds');
+
+    }
+}
+export let editor = new SampleTypeScriptTest();

--- a/src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts
@@ -1,13 +1,9 @@
 import {Project} from '@atomist/rug/model/Core'
 import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-import {PathExpression,TreeNode,Microgrammar} from '@atomist/rug/tree/PathExpression'
-import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-import {Match} from '@atomist/rug/tree/PathExpression'
-import {Parameter} from '@atomist/rug/operations/RugOperation'
+import {Editor} from '@atomist/rug/operations/Decorators'
 
-class SampleTypeScriptTest implements ProjectEditor {
-    name: string = "Constructed";
-    description: string = "Uses single microgrammar";
+@Editor("SampleTypeScriptTest", "Uses Sample from TypeScript")
+class SampleTypeScriptTest {
 
     edit(project: Project) {
 

--- a/src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala
@@ -1,0 +1,42 @@
+package com.atomist.rug.ts
+
+import com.atomist.parse.java.ParsingTargets
+import com.atomist.project.SimpleProjectOperationArguments
+import com.atomist.project.edit.SuccessfulModification
+import com.atomist.rug.runtime.js.{JavaScriptInvokingProjectEditor, JavaScriptOperationFinder}
+import com.atomist.source.file.ClassPathArtifactSource
+import org.scalatest.{FlatSpec, Matchers}
+
+class SampleTypeScriptTest extends FlatSpec with Matchers {
+
+  it should "use Sample from TypeScript" in {
+
+    val tsEditorResource = "com/atomist/rug/ts/SampleTypeScriptTest.ts"
+    val parameters = SimpleProjectOperationArguments.Empty
+    val target = ParsingTargets.NewStartSpringIoProject
+    val fileThatWillBeModified = "pom.xml"
+
+
+    // construct the Rug archive
+    val artifactSourceWithEditor = ClassPathArtifactSource.toArtifactSource(tsEditorResource).withPathAbove(".atomist/editors")
+    val artifactSourceWithRugNpmModule = TypeScriptBuilder.compileWithModel(artifactSourceWithEditor)
+    println(s"rug archive: ${artifactSourceWithEditor}")
+
+    // get the operation out of the artifact source
+    val projectEditor = JavaScriptOperationFinder.fromJavaScriptArchive(artifactSourceWithRugNpmModule).head.asInstanceOf[JavaScriptInvokingProjectEditor]
+
+    // apply the operation
+    projectEditor.modify(target, parameters) match {
+      case sm: SuccessfulModification =>
+        val contents = sm.result.findFile(fileThatWillBeModified).get.content
+        withClue(s"contents of $fileThatWillBeModified are:<$contents>") {
+          // check the results
+          contents.contains("dependenciesAreForBirds") should be(true)
+        }
+
+      case boo => fail(s"Modification was not successful: $boo")
+    }
+
+  }
+
+}

--- a/src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala
@@ -21,7 +21,7 @@ class SampleTypeScriptTest extends FlatSpec with Matchers {
     // construct the Rug archive
     val artifactSourceWithEditor = ClassPathArtifactSource.toArtifactSource(tsEditorResource).withPathAbove(".atomist/editors")
     val artifactSourceWithRugNpmModule = TypeScriptBuilder.compileWithModel(artifactSourceWithEditor)
-    println(s"rug archive: ${artifactSourceWithEditor}")
+    println(s"rug archive: $artifactSourceWithEditor")
 
     // get the operation out of the artifact source
     val projectEditor = JavaScriptOperationFinder.fromJavaScriptArchive(artifactSourceWithRugNpmModule).head.asInstanceOf[JavaScriptInvokingProjectEditor]

--- a/src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/rug/ts/SampleTypeScriptTest.scala
@@ -6,6 +6,7 @@ import com.atomist.project.edit.SuccessfulModification
 import com.atomist.rug.runtime.js.{JavaScriptInvokingProjectEditor, JavaScriptOperationFinder}
 import com.atomist.source.file.ClassPathArtifactSource
 import org.scalatest.{FlatSpec, Matchers}
+import com.atomist.rug.ts.TypeScriptBuilder
 
 class SampleTypeScriptTest extends FlatSpec with Matchers {
 


### PR DESCRIPTION
I found myself asking yet again, "How can I add a test for this, that uses it in TypeScript?" and I didn't want to add yet another hard-coded test to TypeScriptMicrogrammarTest. I wanted a TypeScript file in resources, and a Scala test to use it. One that is as clear as I can make it about how this works.

Now we can add tests individually for functionalities, and someday this will be useful in language extensions repositories. For now, this editor is only useful in Rug, so it makes sense for it to live here.