### PR TITLE
Lower cases ScalaMetaTreeNode productions. Allow JS calls on ScalaMetaTreeNode-backed objects

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/scala/ScalaMetaTreeBackedTreeNode.scala
+++ b/src/main/scala/com/atomist/rug/kind/scala/ScalaMetaTreeBackedTreeNode.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.kind.scala
 
 import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.{InputPosition, OffsetInputPosition, PositionedTreeNode}
+import com.atomist.util.lang.JavaHelpers
 
 import scala.meta._
 
@@ -21,8 +22,10 @@ private[scala] class ScalaMetaTreeBackedTreeNode(smTree: Tree)
     // class names with ` that are illegal Java class names according to java.Class
     // (but what would it know)
     val fqn = smTree.getClass.getName
-    fqn.drop(fqn.lastIndexOf("$") + 1).replace("Impl", "")
+    JavaHelpers.lowerize(fqn.drop(fqn.lastIndexOf("$") + 1).replace("Impl", ""))
   }
+
+  override def nodeTags: Set[String] = super.nodeTags ++ Set(TreeNode.Dynamic)
 
   override def startPosition: InputPosition = OffsetInputPosition(smTree.pos.start.offset)
 

--- a/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/SimpleMutableContainerTreeNode.scala
@@ -94,7 +94,10 @@ object SimpleMutableContainerTreeNode {
       case ptn: PositionedTreeNode =>
         makeMutable(ptn)
     }
-    new SimpleMutableContainerTreeNode(ptn.nodeName, kids, ptn.startPosition, ptn.endPosition, significance = TreeNode.Signal)
+    new SimpleMutableContainerTreeNode(ptn.nodeName, kids,
+      ptn.startPosition, ptn.endPosition,
+      significance = TreeNode.Signal,
+      additionalTypes = ptn.nodeTags)
   }
 
 }

--- a/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
@@ -24,16 +24,30 @@ class UpgradeScalaTestAssertions implements ProjectEditor {
                 TermName:[be]
                 Lit:[2]
       */
-      let oldAssertion = `/src/test/scala//ScalaFile()//TermApplyInfix[/TermName[@value='should']]`
+      let oldAssertion = `/src/test/scala//ScalaFile()//termApplyInfix[/termName[@value='should']]`
 
-      eng.with<TextTreeNode>(project, oldAssertion, shouldTerm => {
-        //console.log(`The catch clause was '${cc.value()} at ${cc.formatInfo()}'`)
-        
-        // let c2 = cc as any // We need to do this to get to the children
-        // let classType = c2.class_type()
-        console.log(shouldTerm.value())
+      eng.with<any>(project, oldAssertion, shouldTerm => {
+
+        console.log("b4 select")
+
+        let termSelect = shouldTerm.termSelect()
+
+        console.log("after select")
+        let termApply = shouldTerm.termApply()
+        if (termApply != null) {
+          console.log(`after apply, termApply value = ${termApply.value()}`)
+        }
+        if (termApply != null && termApply.termName().value() == "be") {
+
+          console.log(shouldTerm.value())
+        }
+        else {
+          console.log(`after apply, termApply is null`)
+        }
+
       })
-    }
+}
+
 }
 
 export let editor = new UpgradeScalaTestAssertions()

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeTest.scala
@@ -59,7 +59,7 @@ class ScalaFileTypeTest extends FlatSpec with Matchers {
     scalas.size should be(1)
     val scalaFileNode = scalas.get.head.asInstanceOf[MutableContainerMutableView]
 
-    val expr = "//TermTryWithCases/Case//TypeName[@value='ThePlaneHasFlownIntoTheMountain']"
+    val expr = "//termTryWithCases/case//typeName[@value='ThePlaneHasFlownIntoTheMountain']"
       ee.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
         case Right(nodes) if nodes.nonEmpty =>
           nodes.size should be(1)
@@ -78,7 +78,7 @@ class ScalaFileTypeTest extends FlatSpec with Matchers {
 
     val newException = "MicturationException"
 
-    val expr = "//TermTryWithCases/Case//TypeName[@value='ThePlaneHasFlownIntoTheMountain']"
+    val expr = "//termTryWithCases/case//typeName[@value='ThePlaneHasFlownIntoTheMountain']"
     ee.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
         nodes.size should be(1)
@@ -105,7 +105,7 @@ class ScalaFileTypeTest extends FlatSpec with Matchers {
 
     val newException = "MicturationException"
 
-    val expr = "//Case//TypeName[@value='ThePlaneHasFlownIntoTheMountain']"
+    val expr = "//case//typeName[@value='ThePlaneHasFlownIntoTheMountain']"
     ee.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
         nodes.size should be(2)
@@ -135,7 +135,7 @@ class ScalaFileTypeTest extends FlatSpec with Matchers {
     val newException = "MicturationException"
     //println(TreeNodeUtils.toShorterString(scalaFileNode))
 
-    val expr = "//TermTryWithCases/Case[//TypeName[@value='ThePlaneHasFlownIntoTheMountain']]"
+    val expr = "//termTryWithCases/case[//typeName[@value='ThePlaneHasFlownIntoTheMountain']]"
     ee.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
         nodes.size should be(1)

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeUsageTest.scala
@@ -1,16 +1,11 @@
 package com.atomist.rug.kind.scala
 
 import com.atomist.project.edit.SuccessfulModification
-import com.atomist.rug.kind.DefaultTypeRegistry
-import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.kind.grammar.AbstractTypeUnderFileTest
-import com.atomist.source.EmptyArtifactSource
-import com.atomist.tree.utils.TreeNodeUtils
 
 class ScalaFileTypeUsageTest extends AbstractTypeUnderFileTest {
 
   import ScalaFileTypeTest._
-  import com.atomist.tree.pathexpression.PathExpressionParser._
 
   override val typeBeingTested = new ScalaFileType
 
@@ -18,19 +13,10 @@ class ScalaFileTypeUsageTest extends AbstractTypeUnderFileTest {
 
   it should "upgrade ScalaTest assertions" in pendingUntilFixed {
 
-    import TreeNodeUtils._
-
-//    val pmv = new ProjectMutableView(EmptyArtifactSource(), ScalaTestSources )
-//    expressionEngine.evaluate(pmv, "/src/test/scala//ScalaFile()", DefaultTypeRegistry) match {
-//      case Right(nodes) =>
-//        println(toShorterString(nodes.head, NameAndContentStringifier))
-//      case _ => ???
-//    }
-
     modify("UpgradeScalaTestAssertions.ts", ScalaTestSources) match {
       case sm: SuccessfulModification =>
-        //val theFile = sm.result.findFile("src/exception.cs").get
-        //theFile.content should be (Exceptions.replace("IndexOutOfRangeException", newExceptionType))
+        val theFile = sm.result.findFile(ScalaTestSources.allFiles.head.path).get
+        theFile.content.contains("====") should be (true)
       case wtf => fail(s"Expected SuccessfulModification, not $wtf")
     }
   }

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaMetaBackedTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaMetaBackedTreeNodeTest.scala
@@ -28,7 +28,7 @@ class ScalaMetaBackedTreeNodeTest extends FlatSpec with Matchers {
       """
     val str: Parsed[Source] = source.parse[Source]
     val tn = new ScalaMetaTreeBackedTreeNode(str.get)
-    ee.evaluate(tn, "//TermParam[/TypeName[@value='String']]/TermName", DefaultTypeRegistry) match {
+    ee.evaluate(tn, "//termParam[/typeName[@value='String']]/termName", DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
         nodes.size should be(1)
         nodes.head.value should be("bar")
@@ -42,7 +42,7 @@ class ScalaMetaBackedTreeNodeTest extends FlatSpec with Matchers {
       """
     val str: Parsed[Source] = source.parse[Source]
     val tn = new ScalaMetaTreeBackedTreeNode(str.get)
-    ee.evaluate(tn, "//TermParam[/TypeName[@value='String']]/TermName", DefaultTypeRegistry) match {
+    ee.evaluate(tn, "//termParam[/typeName[@value='String']]/termName", DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
         nodes.size should be(1)
         val tn: PositionedTreeNode = nodes.head.asInstanceOf[PositionedTreeNode]


### PR DESCRIPTION
Makes `makeMutable` TreeNode utility operation preserve tags.

Also improves pending test for ScalaFileType