### PR TITLE
Update from deprecated @generator annotation in test Rug

### DIFF
--- a/src/test/resources/elm-start-static-page/.atomist/editors/NewStaticPage.rug
+++ b/src/test/resources/elm-start-static-page/.atomist/editors/NewStaticPage.rug
@@ -1,8 +1,7 @@
 
 @tag "elm"
 @description "Creates a new static Elm program"
-@generator "StaticPage"
-editor NewStaticPage
+generator NewStaticPage
 
 @maxLength 21
 @description "Name of your new project."


### PR DESCRIPTION
Stop this warning,

  Generator 'NewStaticPage' uses deprecated @generator annotation.
  Please remove the @generator annotation and change the 'editor' keyword to 'generator'.