### PR TITLE
Use additional ScalaTest features in kind.elm

### DIFF
--- a/src/test/scala/com/atomist/rug/kind/elm/ElmCaseManipulationTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmCaseManipulationTest.scala
@@ -7,10 +7,11 @@ import com.atomist.rug.InterpreterRugPipeline.DefaultRugArchive
 import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.OptionValues._
 
 class ElmCaseManipulationTest extends FlatSpec with Matchers {
 
-  val bodyAppenderUnderUpdateFunction: String =
+  private val bodyAppenderUnderUpdateFunction: String =
     """
       |editor AddClause
       |
@@ -23,7 +24,7 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
       |
     """.stripMargin
 
-  val bodyAppenderMatchingOnCaseExpression: String =
+  private val bodyAppenderMatchingOnCaseExpression: String =
     """
       |editor AddClause
       |
@@ -35,7 +36,7 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
       |
     """.stripMargin
 
-  val clauseAdderMatchingExpression: String =
+  private val clauseAdderMatchingExpression: String =
     """
       |editor AddClause
       |
@@ -62,9 +63,9 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
   private def appendToCase(rugProg: String) {
     val todoSource = StringFileArtifact("Main.elm", ElmParserTest.FullProgram)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), rugProg)
-    val f = r.findFile("Main.elm").get
+    val f = r.findFile("Main.elm").value
     val content = f.content
-    content.contains("! []") should be(true)
+    content should include("! []")
   }
 
   private def addClauseToCase(rugProg: String) {
@@ -75,11 +76,13 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
       "expr" -> expr,
       "rhs" -> rhs
     ))
-    val f = r.findFile("Main.elm").get
+    val f = r.findFile("Main.elm").value
     val content = f.content
-    content.contains(expr) should be (true)
-    content.contains(rhs) should be (true)
-
+    content should (
+      include(expr)
+        and
+        include(rhs)
+      )
   }
 
   private def elmExecute(elmProject: ArtifactSource, program: String,

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmExtractModuleTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmExtractModuleTest.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.kind.elm
 
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.OptionValues._
 import com.atomist.util.Utils.StringImprovements
 
 class ElmExtractModuleTest extends FlatSpec with Matchers {
@@ -42,10 +43,13 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", ElmExtractModuleTest.OriginalMain)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), prog, Map("new_module_name" -> module))
 
-    val content = r.findFile("RandomGif.elm").get.content
+    val content = r.findFile("RandomGif.elm").value.content
     val expectedHeader = "module RandomGif exposing (Model, init, Msg, update, view, subscriptions)"
-    content.contains(expectedHeader) should be(true)
-    content.contains("main") should be(false)
+    content should (
+      include(expectedHeader)
+        and
+        not include("main")
+      )
   }
   it should "replace the init function" in {
     val prog =
@@ -81,8 +85,8 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", ElmExtractModuleTest.OriginalMain)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), prog, Map("new_module_name" -> module))
 
-    val content = r.findFile("Main.elm").get.content
-    content.contains("( randomGifModel, randomGifCommands )") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include("( randomGifModel, randomGifCommands )")
   }
 
   it should "replace a type alias Model" in {
@@ -110,8 +114,8 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", ElmExtractModuleTest.OriginalMain)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), prog, Map("new_module_name" -> module))
 
-    val content = r.findFile("Main.elm").get.content
-    content.contains(elm) should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(elm)
   }
 
   it should "replace the subscriptions body" in {
@@ -133,6 +137,8 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
         |    with type.alias when name = "Model"
         |      do replaceBody new_body
         |""".stripMargin
+
+    pending
   }
 
   it should "replace the Msg" in {
@@ -158,8 +164,8 @@ class ElmExtractModuleTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", ElmExtractModuleTest.OriginalMain)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), prog, Map("new_module_name" -> module))
 
-    val content = r.findFile("Main.elm").get.content
-    content.contains(elm.toSystem) should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(elm.toSystem)
   }
 }
 

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTextInputTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTextInputTest.scala
@@ -1,11 +1,8 @@
 package com.atomist.rug.kind.elm
 
-import com.atomist.project.SimpleProjectOperationArguments
-import com.atomist.project.edit.{ProjectEditor, SuccessfulModification}
-import com.atomist.rug.DefaultRugPipeline
-import com.atomist.rug.kind.DefaultTypeRegistry
-import com.atomist.source.{ArtifactSource, FileArtifact, SimpleFileBasedArtifactSource, StringFileArtifact}
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.OptionValues._
 
 class ElmTextInputTest extends FlatSpec with Matchers {
 
@@ -71,7 +68,7 @@ class ElmTextInputTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val r = elmExecute(r3, prog4)
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
 
     // TODO should really bring this back, but there appears to be an ordering thing and
     // I'm not sure you've implemented all necessary edits
@@ -89,7 +86,9 @@ class ElmTextInputTest extends FlatSpec with Matchers {
         "field_type" -> "String",
         "initial_value" -> "cats"))
 
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
+
+    pending
   }
 }
 
@@ -263,25 +262,4 @@ object ElmTextInputTest {
       |      with case when matchAsString = match
       |        do addClause new_pattern body
       |""".stripMargin
-
-  def elmExecuteWithOtherEditorsDefined(elmProject: ArtifactSource, program: String,
-                 params: Map[String, String] = Map()): ArtifactSource = {
-    val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
-
-    val files: Seq[FileArtifact] = Seq(
-      new StringFileArtifact("AddToModel.rug", "AddToModel.rug", AddToModel),
-      new StringFileArtifact("AddToMessage.rug", "AddToMessage.rug", AddToModel)
-    )
-    val as = new SimpleFileBasedArtifactSource("whatever", files)
-    val rugAs = new SimpleFileBasedArtifactSource("", StringFileArtifact("editor/LineCommenter.rug", program))
-    val eds = runtime.create(rugAs,None)
-    val pe = eds.head.asInstanceOf[ProjectEditor]
-
-    val r = pe.modify(elmProject, SimpleProjectOperationArguments("", params))
-    r match {
-      case sm: SuccessfulModification =>
-        sm.result
-      case _ => ???
-    }
-  }
 }

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTypeScriptEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTypeScriptEditorTest.scala
@@ -23,13 +23,14 @@ class ElmTypeScriptEditorTest extends FlatSpec with Matchers {
     maybeReadme.isDefined should be(true)
     val readme : String = maybeReadme.get.content
 
-    withClue(s"README content----------\n$readme\n----------\n") {
-      readme.contains( s"# $projectName") should be(true)
-      readme.contains(s"${System.lineSeparator()}${description}${System.lineSeparator()}") should be(true)
-    }
+    readme should (
+      include( s"# $projectName")
+        and
+        include(s"${System.lineSeparator()}${description}${System.lineSeparator()}")
+    )
   }
 
-  def singleFileArtifactSource(projectName: String): SimpleFileBasedArtifactSource = {
+  private def singleFileArtifactSource(projectName: String): SimpleFileBasedArtifactSource = {
     new SimpleFileBasedArtifactSource(
       projectName,
       StringFileArtifact(

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTypeUsageTest.scala
@@ -8,8 +8,8 @@ import com.atomist.rug.kind.elm.ElmTypeUsageTest.TestDidNotModifyException
 import com.atomist.rug.ts.{RugTranspiler, TypeScriptBuilder}
 import com.atomist.rug.{CompilerChainPipeline, DefaultRugPipeline, RugPipeline}
 import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
-import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.OptionValues._
 
 class ElmTypeUsageTest extends FlatSpec with Matchers {
 
@@ -188,9 +188,9 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     ),
       runtime = runtime)
 
-    val newTodoContent = result.findFile(s"$newModuleName.elm").get.content
+    val newTodoContent = result.findFile(s"$newModuleName.elm").value.content
     newTodoContent.trim should equal("module Foobar exposing (..)")
-    val newUsesTodoContent = result.findFile(usesTodoSource.path).get.content
+    val newUsesTodoContent = result.findFile(usesTodoSource.path).value.content
     newUsesTodoContent.trim should equal(makeUsesTodoSource(newModuleName).content.trim)
   }
 
@@ -229,8 +229,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
         .stripMargin)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val cont = r.findFile("Todo.elm").get.content
-    cont.contains(newImportStatement) should be(true)
+    val cont = r.findFile("Todo.elm").value.content
+    cont should include(newImportStatement)
     // TODO had to add 4 returns here. Maybe 3 is correct?
     cont should be(todoSource.content + s"${System.lineSeparator()}${System.lineSeparator()}${System.lineSeparator()}${System.lineSeparator()}" + newImportStatement)
   }
@@ -252,8 +252,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
         .stripMargin)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Todo.elm").get.content
-    content.contains(newImportStatement) should be(true)
+    val content = r.findFile("Todo.elm").value.content
+    content should include(newImportStatement)
     content should be(todoSource.content + newImportStatement + System.lineSeparator())
   }
 
@@ -309,13 +309,13 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(newImportStatement) should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(newImportStatement)
   }
 
   it should "add a whole declaration" in {
-    val pattern = "SeeThis string"
-    val expression = "model"
+//    val pattern = "SeeThis string"
+//    val expression = "model"
     val prog =
       s"""
          |editor AddFunction
@@ -340,8 +340,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
         |        , more
         |        , bar
         |        ]""".stripMargin))
-    val content = r.findFile("Main.elm").get.content
-    content.contains(addThisCode) should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(addThisCode)
   }
 
   it should "rename a function" in {
@@ -367,7 +367,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     val todoSource = StringFileArtifact("Main.elm", input)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
     content.trim should equal(output.trim)
   }
 
@@ -394,7 +394,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     val todoSource = StringFileArtifact("Main.elm", input)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
     content.trim should equal(output.trim)
   }
 
@@ -432,8 +432,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog,
       Map("field_type" -> fieldType, "initial_value" -> initialValue.toString))
-    val content = r.findFile("Main.elm").get.content
-    content.contains(s"""$newField = \"$initialValue\"""") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(s"""$newField = \"$initialValue\"""")
   }
 
   /*
@@ -464,7 +464,9 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
+
+    pending
   }
 
   it should "rename function" in {
@@ -481,8 +483,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(newFunctionName) should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(newFunctionName)
     //content should be(todoSource.content + newImportStatement)
   }
 
@@ -500,8 +502,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(newTypeAliasName) should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(newTypeAliasName)
     //content should be(todoSource.content + newImportStatement)
   }
 
@@ -522,8 +524,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(s"$newIdentifier : $newType") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(s"$newIdentifier : $newType")
   }
 
   it should "add to empty record type" in {
@@ -547,8 +549,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
         |""".stripMargin)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(s"{ $newIdentifier : $newType }") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(s"{ $newIdentifier : $newType }")
   }
 
   it should "add to record value at top of function" in {
@@ -571,8 +573,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
         |""".stripMargin)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(s"$newField = $initialValue") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(s"$newField = $initialValue")
   }
 
   it should "add to record value deep in function" in {
@@ -595,8 +597,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
         |""".stripMargin)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(s"$newField = $initialValue") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(s"$newField = $initialValue")
   }
 
   it should "add a constructor to a union type" in {
@@ -613,8 +615,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.contains(s"| $newConstructor") should be(true) // assumes it's at the end or in the middle
+    val content = r.findFile("Main.elm").value.content
+    content should include(s"| $newConstructor") // assumes it's at the end or in the middle
   }
 
   it should "add function" in {
@@ -628,7 +630,9 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
+
+    pending
   }
 
   it should "replace the body of this function" in {
@@ -655,8 +659,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog, Map("module" -> "Main"))
-    val content = r.findFile("Main.elm").get.content
-    content.contains(", subscriptions = subscriptions2") should be(true)
+    val content = r.findFile("Main.elm").value.content
+    content should include(", subscriptions = subscriptions2")
   }
 
   it should "replace the body of case clauses" in {
@@ -676,8 +680,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       ElmParserTest.FullProgram)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Main.elm").get.content
-    content.split(toAppend).length should equal(5)
+    val content = r.findFile("Main.elm").value.content
+    content.split(toAppend) should have length(5)
   }
 
   it should "let me switch on the type of a function" in {
@@ -704,17 +708,23 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
 
       val advancedProgramShouldAlterThis = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog,
         Map("new_pattern" -> "Hello", "body" -> "model"))
-      val content = advancedProgramShouldAlterThis.findFile("Main.elm").get.content
-      content.contains("Hello ->") should be(true)
-      content.contains("model ! []") should be(true)
+      val content = advancedProgramShouldAlterThis.findFile("Main.elm").value.content
+      content should(
+        include("Hello ->")
+          and
+          include("model ! []")
+        )
     }
 
     {
       val basicProgramShouldNotAlterThis = elmExecute(new SimpleFileBasedArtifactSource("", StringFileArtifact("Main.elm", ElmParserTest.BeginnerProgram)), prog,
         Map("new_pattern" -> "Hello", "body" -> "model"))
-      val content = basicProgramShouldNotAlterThis.findFile("Main.elm").get.content
-      content.contains("Hello ->") should be(true)
-      content.contains("model ! []") should be(false)
+      val content = basicProgramShouldNotAlterThis.findFile("Main.elm").value.content
+      content should(
+        include("Hello ->")
+          and
+          not include("model ! []")
+        )
     }
 
     {
@@ -723,9 +733,12 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
 
       val advancedProgramShouldPassASpecialBody = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog,
         Map("new_pattern" -> "Hello", "body" -> "(model, Cmd.none)"))
-      val content = advancedProgramShouldPassASpecialBody.findFile("Main.elm").get.content
-      content.contains("Hello ->") should be(true)
-      content.contains("model ! []") should be(false)
+      val content = advancedProgramShouldPassASpecialBody.findFile("Main.elm").value.content
+      content should(
+        include("Hello ->")
+        and
+          not include ("model ! []")
+      )
     }
   }
 
@@ -762,8 +775,8 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       elm)
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
-    val content = r.findFile("Foo.elm").get.content
-    content.contains("chuck = 10000000") should be(true)
+    val content = r.findFile("Foo.elm").value.content
+    content should include("chuck = 10000000")
   }
 }
 

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmUpgradeProgramTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmUpgradeProgramTest.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.kind.elm
 
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.OptionValues._
 
 class ElmUpgradeProgramTest extends FlatSpec with Matchers {
 
@@ -26,7 +27,7 @@ class ElmUpgradeProgramTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", elm)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), editor)
 
-    r.findFile("Main.elm").get.content.lines.find(_.contains("import Foo")).head should equal("import Foo exposing (fooFunction)")
+    r.findFile("Main.elm").value.content.lines.find(_.contains("import Foo")).headOption.value should equal("import Foo exposing (fooFunction)")
 
   }
 
@@ -50,7 +51,7 @@ class ElmUpgradeProgramTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", elm)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), editor)
 
-    r.findFile("Carrot.elm").get.content.contains("module Carrot") should be(true)
+    r.findFile("Carrot.elm").value.content should include("module Carrot")
   }
 
   it should "find a module that exposes all things and defines this one" in {
@@ -72,7 +73,7 @@ class ElmUpgradeProgramTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", elm)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), editor)
 
-    r.findFile("Carrot.elm").get.content.contains("module Carrot") should be(true)
+    r.findFile("Carrot.elm").value.content should include("module Carrot")
   }
 
   it should "find not a module that does not expose the thing" in {
@@ -183,11 +184,12 @@ class ElmUpgradeProgramTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val r = elmExecute(r3, prog4)
-    val content = r.findFile("Main.elm").get.content
+    val content = r.findFile("Main.elm").value.content
 
     // TODO should really bring this back, but there appears to be an ordering thing and
     // I'm not sure you've implemented all necessary edits
     //content should equal(ElmParserTest.AdvancedProgram)
+    pending
   }
 
 }

--- a/src/test/scala/com/atomist/rug/kind/elm/PredicateTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/PredicateTest.scala
@@ -4,6 +4,7 @@ import com.atomist.rug.DefaultRugPipeline
 import com.atomist.rug.kind.elm.ElmTypeUsageTest.TestDidNotModifyException
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.OptionValues._
 
 class PositivePredicateTest extends FlatSpec with Matchers {
 
@@ -43,7 +44,7 @@ class PositivePredicateTest extends FlatSpec with Matchers {
     val result = elmExecute(elmProject, editor, Map[String, String](),
       runtime = new DefaultRugPipeline())
 
-    val carrotContent = result.findFile(s"Banana.elm").get.content
+    val carrotContent = result.findFile(s"Banana.elm").value.content
     // TODO: remove the trims! this finds the newline problem
     carrotContent.trim should equal(expected.trim)
   }
@@ -56,7 +57,7 @@ class PositivePredicateTest extends FlatSpec with Matchers {
     val result = elmExecute(elmProject, editor, Map[String, String](),
       runtime = new DefaultRugPipeline())
 
-    val carrotContent = result.findFile(s"Banana.elm").get.content
+    val carrotContent = result.findFile(s"Banana.elm").value.content
     // TODO: remove the trims! this finds the newline problem
     carrotContent should equal(expected)
   }


### PR DESCRIPTION
 - Import `OptionValues._` to allow `.value` on an Option instead of `.get` for
   an improved error message when `None`

 - Make some methods private - apparently this reduces compile times

 - Swap `<string>.contains(<x>) should be (true)` for `<string> should include(<x>)`
    - Less code
    - Includes string in assertion error avoiding need to add `println` or `withClue`
      later

  - Collapse multiple include assertions on same string into one` should(..)`

  - Add pending in cases where an assertion appears to be missing

  - Removed some unused code, commented others.