### PR TITLE
Better js safe committing proxy

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/scala/ScalaMetaTreeBackedTreeNode.scala
+++ b/src/main/scala/com/atomist/rug/kind/scala/ScalaMetaTreeBackedTreeNode.scala
@@ -33,13 +33,13 @@ private[scala] class ScalaMetaTreeBackedTreeNode(smTree: Tree)
 
   override def value: String = smTree.syntax
 
-  def childNodeNames: Set[String] = children.map(_.nodeName).toSet
+  def childNodeNames: Set[String] = wrappedChildren.map(_.nodeName).toSet
 
   override def childNodeTypes: Set[String] = childNodes.flatMap(n => n.nodeTags).toSet
 
-  def children: Seq[TreeNode] = smTree.children.map(new ScalaMetaTreeBackedTreeNode(_))
+  private def wrappedChildren: Seq[TreeNode] = smTree.children.map(new ScalaMetaTreeBackedTreeNode(_))
 
-  override def childrenNamed(key: String): Seq[TreeNode] = children.filter(_.nodeName == key)
+  override def childrenNamed(key: String): Seq[TreeNode] = wrappedChildren.filter(_.nodeName == key)
 
   override def toString: String = s"$nodeName:${nodeTags.mkString(",")}:[$value]"
 

--- a/src/main/scala/com/atomist/rug/kind/service/ServicesMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/ServicesMutableView.scala
@@ -32,8 +32,6 @@ class ServicesMutableView(rugAs: ArtifactSource,
 
   override def nodeName: String = "services"
 
-  override def nodeTags: Set[String] = Set("services")
-
   override val childNodeNames: Set[String] = Set("service")
 
   override def childrenNamed(fieldName: String): Seq[MutableView[_]] = fieldName match {

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
@@ -56,7 +56,7 @@ class JavaScriptEventHandler(
       case Right(matches) =>
         val cm = jsContextMatch(
           targetNode,
-          pexe.wrap(matches),
+          jsPathExpressionEngine.wrap(matches),
           s2,
           teamId = e.teamId)
         invokeHandlerFunction(e, cm)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingExecutor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingExecutor.scala
@@ -16,7 +16,7 @@ class JavaScriptInvokingExecutor(
 
   override def execute(serviceSource: ServiceSource, poa: ProjectOperationArguments): Unit = {
     val smv = new ServicesMutableView(rugAs, serviceSource)
-    val wsmv = new jsSafeCommittingProxy(new ServicesType, smv)
+    val wsmv = new jsSafeCommittingProxy(smv)
     invokeMemberWithParameters("execute", wsmv, addDefaultParameterValues(poa))
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperation.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperation.scala
@@ -69,8 +69,6 @@ abstract class JavaScriptInvokingProjectOperation(
 
   /**
     * Convenience method that will try __name first for decorated things
-    * @param name
-    * @return
     */
   protected def getMember(name: String, someVar: ScriptObjectMirror = jsVar) : AnyRef = {
     val decorated = s"__$name"
@@ -94,11 +92,10 @@ abstract class JavaScriptInvokingProjectOperation(
 
     // Translate parameters if necessary
     val processedArgs = args.collect {
-      case poa: ProjectOperationArguments => {
+      case poa: ProjectOperationArguments =>
         val params = poa.parameterValues.map(p => p.getName -> p.getValue).toMap.asJava
         setParamsIfDecorated(clone,params)
         params
-      }
       case x => x
     }
 
@@ -107,8 +104,6 @@ abstract class JavaScriptInvokingProjectOperation(
 
   /**
     * Separate for test
-    * @param jsVar
-    * @return
     */
   private[js] def cloneVar (jsVar: ScriptObjectMirror) : ScriptObjectMirror = {
     val bindings = new SimpleBindings()
@@ -122,8 +117,6 @@ abstract class JavaScriptInvokingProjectOperation(
   }
   /**
     * Make sure we only set fields if they've been decorated with @parameter
-    * @param clone
-    * @param params
     */
   private def setParamsIfDecorated(clone: ScriptObjectMirror, params: java.util.Map[String, AnyRef]): Unit = {
     val decoratedParamNames: Set[String] = clone.get("__parameters") match {
@@ -135,11 +128,10 @@ abstract class JavaScriptInvokingProjectOperation(
       case _ => Set()
     }
     params.asScala.foreach {
-      case (k: String, v: AnyRef) => {
+      case (k: String, v: AnyRef) =>
         if(decoratedParamNames.contains(k)){
           clone.put(k,v)
         }
-      }
     }
   }
 
@@ -162,11 +154,10 @@ abstract class JavaScriptInvokingProjectOperation(
     */
   protected def readParametersFromMetadata: Seq[Parameter] = {
       getMember("parameters") match {
-      case ps: ScriptObjectMirror if !ps.isEmpty => {
+      case ps: ScriptObjectMirror if !ps.isEmpty =>
         ps.asScala.collect {
           case (_, details: ScriptObjectMirror) => parameterVarToParameter(jsVar, details)
         }.toSeq
-      }
       case _ => Seq()
     }
   }
@@ -228,6 +219,6 @@ abstract class JavaScriptInvokingProjectOperation(
     * @return proxy TypeScript callers can use
     */
   protected def wrapProject(pmv: ProjectMutableView): jsSafeCommittingProxy = {
-    new jsSafeCommittingProxy(projectType, pmv)
+    new jsSafeCommittingProxy(pmv)
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandler.scala
@@ -46,7 +46,7 @@ class NamedJavaScriptEventHandler(pathExpressionStr: String,
       case Right(matches) =>
         val cm = jsContextMatch(
           targetNode,
-          ctx.pathExpressionEngine.wrap(matches),
+          jsPathExpressionEngine.wrap(matches),
           s2,
           teamId = e.teamId)
         dispatch(invokeHandlerFunction(e, cm))

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -191,11 +191,8 @@ class jsPathExpressionEngine(
   def wrap(nodes: Seq[TreeNode]): java.util.List[Object] = {
     val cr: CommandRegistry = DefaultCommandRegistry
 
-    def nodeTypes(node: TreeNode): Set[Typed] =
-      node.nodeTags.flatMap(t => typeRegistry.findByName(t))
-
     def proxify(n: TreeNode): Object = n match {
-      case _ => new jsSafeCommittingProxy(nodeTypes(n), n, cr)
+      case _ => new jsSafeCommittingProxy(n, cr)
     }
 
     new JavaScriptArray(

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -50,6 +50,8 @@ class jsPathExpressionEngine(
                               typeRegistry: TypeRegistry = DefaultTypeRegistry,
                               private var matcherRegistry: MatcherRegistry = EmptyMatcherRegistry) {
 
+  import jsPathExpressionEngine._
+
   /**
     * Return a customized version of this path expression engine for use in a specific
     * context, with its own microgrammar types
@@ -181,6 +183,12 @@ class jsPathExpressionEngine(
     }
   }
 
+}
+
+object jsPathExpressionEngine {
+
+  val matcherParser = new MatcherDefinitionParser
+
   /**
     * Wrap the given sequence of nodes so they can be accessed from
     * TypeScript. Intended for use from Scala, not TypeScript.
@@ -188,21 +196,14 @@ class jsPathExpressionEngine(
     * @param nodes sequence to wrap
     * @return TypeScript and JavaScript-friendly list
     */
-  def wrap(nodes: Seq[TreeNode]): java.util.List[Object] = {
-    val cr: CommandRegistry = DefaultCommandRegistry
-
-    def proxify(n: TreeNode): Object = n match {
-      case _ => new jsSafeCommittingProxy(n, cr)
-    }
-
+  def wrap(nodes: Seq[TreeNode], cr: CommandRegistry = DefaultCommandRegistry): java.util.List[Object] = {
     new JavaScriptArray(
-      nodes.map(n => proxify(n))
+      nodes.map(n => wrapOne(n))
         .asJava)
   }
-}
 
-object jsPathExpressionEngine {
-
-  val matcherParser = new MatcherDefinitionParser
+  def wrapOne(n: TreeNode, cr: CommandRegistry = DefaultCommandRegistry): Object = n match {
+    case _ => new jsSafeCommittingProxy(n, cr)
+  }
 
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -2,6 +2,7 @@ package com.atomist.rug.runtime.js.interop
 
 import com.atomist.rug.RugRuntimeException
 import com.atomist.rug.command.DefaultCommandRegistry
+import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.spi._
 import com.atomist.tree.{ContainerTreeNode, TreeNode}
 import com.atomist.util.lang.JavaScriptArray
@@ -13,56 +14,57 @@ import jdk.nashorn.api.scripting.AbstractJSObject
   * object and vetoes invocation otherwise and (b) calls the commit() method of the node if found on all invocations of a
   * method that isn't read-only
   *
-  * @param types Rug types we are fronting. This is a union type.
   * @param node  node we are fronting
   */
-class jsSafeCommittingProxy(types: Set[Typed],
+class jsSafeCommittingProxy(
                             val node: TreeNode,
-                            commandRegistry: CommandRegistry)
+                            commandRegistry: CommandRegistry = DefaultCommandRegistry,
+                            typeRegistry: TypeRegistry = DefaultTypeRegistry)
   extends AbstractJSObject {
-
-  def this(t: Typed, node: TreeNode, commandRegistry: CommandRegistry = DefaultCommandRegistry) =
-    this(Set(t), node, commandRegistry)
 
   override def toString: String = s"SafeCommittingProxy around $node"
 
-  private val typ = UnionType(types)
+  private val nodeTypes: Set[Typed] =
+    node.nodeTags.flatMap(t => typeRegistry.findByName(t))
+
+  private val typ: Typed = UnionType(nodeTypes)
 
   import jsSafeCommittingProxy.MagicJavaScriptMethods
 
-  override def getMember(name: String): AnyRef = typ.typeInformation match {
-    case _ if MagicJavaScriptMethods.contains(name) =>
+  override def getMember(name: String): AnyRef = {
+    if (MagicJavaScriptMethods.contains(name))
       super.getMember(name)
+    else typ.typeInformation match {
+      case st: StaticTypeInformation =>
+        val possibleOps = st.operations.filter(
+          op => name.equals(op.name))
 
-    case st: StaticTypeInformation =>
-      val possibleOps = st.operations.filter(
-        op => name.equals(op.name))
-
-      if (possibleOps.isEmpty && commandRegistry.findByNodeAndName(node, name).isEmpty) {
-        if (node.nodeTags.contains(TreeNode.Dynamic)) {
-          // Navigation on a node
-          new FunctionProxyToNodeNavigationMethods(name, node)
+        if (possibleOps.isEmpty && commandRegistry.findByNodeAndName(node, name).isEmpty) {
+          if (node.nodeTags.contains(TreeNode.Dynamic)) {
+            // Navigation on a node
+            new FunctionProxyToNodeNavigationMethods(name, node)
+          }
+          else node match {
+            case sobtn: ScriptObjectBackedTreeNode =>
+              sobtn.invoke(name)
+            case _ => throw new RugRuntimeException(null,
+              s"Attempt to invoke method [$name] on type [${typ.description}]: No exported method with that name: Found ${st.operations.map(_.name)}")
+          }
         }
-        else node match {
-          case sobtn: ScriptObjectBackedTreeNode =>
-            sobtn.invoke(name)
-          case _ => throw new RugRuntimeException(null,
-            s"Attempt to invoke method [$name] on type [${typ.description}]: No exported method with that name: Found ${st.operations.map(_.name)}")
-        }
-      }
-      else
-        new FunctionProxyToReflectiveInvocationOnUnderlyingNode(name, possibleOps)
+        else
+          new FunctionProxyToReflectiveInvocationOnUnderlyingJVMNode(name, possibleOps)
 
-    case _ =>
-      // No static type information
-      throw new IllegalStateException(s"No static type information is available for type [${typ.description}]: Probably an internal error")
+      case _ =>
+        // No static type information
+        throw new IllegalStateException(s"No static type information is available for type [${typ.description}]: Probably an internal error")
+    }
   }
 
   /**
     * Nashorn proxy for a method invocation that delegates to the
-    * underlying node using reflecti
+    * underlying node using reflection
     */
-  private class FunctionProxyToReflectiveInvocationOnUnderlyingNode(name: String, possibleOps: Seq[TypeOperation])
+  private class FunctionProxyToReflectiveInvocationOnUnderlyingJVMNode(name: String, possibleOps: Seq[TypeOperation])
     extends AbstractJSObject {
 
     override def isFunction: Boolean = true

--- a/src/main/scala/com/atomist/tree/treeNode.scala
+++ b/src/main/scala/com/atomist/tree/treeNode.scala
@@ -58,6 +58,15 @@ trait TreeNode extends Visitable {
     childNodeNames.toSeq.flatMap(name => childrenNamed(name))
 
   /**
+    * Convenience method for Java callers and JavaScript
+    */
+  @ExportFunction(readOnly = true, description = "Children")
+  def children: java.util.List[TreeNode] = {
+    import scala.collection.JavaConverters._
+    childNodes.asJava
+  }
+
+  /**
     * Return the names of children of this node
     *
     * @return the names of children. There may be multiple children

--- a/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
@@ -40,6 +40,7 @@ class TypeScriptGenerationHelper(indent: String = "    ")
       case "java.util.List<com.atomist.rug.kind.core.FileArtifactBackedMutableView>" => "File[]"
       case "java.util.List<com.atomist.rug.kind.java.support.PackageInfo>" => "any[]"//TODO
       case "java.util.List<com.atomist.rug.kind.service.ServiceMutableView>" => "any[]"
+      case "java.util.List<com.atomist.tree.TreeNode>" => "any[]"
       case "List" => "any[]" // TODO improve this
       case "FileArtifactMutableView" => "File"   // TODO this is nasty
       case "scala.collection.immutable.Set<java.lang.String>" => "string[]" // Nasty

--- a/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
@@ -27,23 +27,14 @@ class UpgradeScalaTestAssertions implements ProjectEditor {
 
       eng.with<any>(project, oldAssertion, shouldTerm => {
 
-        console.log("b4 select")
-
         let termSelect = shouldTerm.termSelect()
 
-        console.log("after select")
         let termApply = shouldTerm.termApply()
-        if (termApply != null) {
-          console.log(`after apply, termApply value = ${termApply.value()}`)
+        if (termApply != null && ["be", "equal"].indexOf(termApply.termName().value()) > -1) {
+          let newValue = `assert(${termSelect.value()} === ${termApply.children()[1].value()})`
+          console.log(`It's a 'be': ${shouldTerm.value()}, replace all with ${newValue}`)
+          shouldTerm.update(newValue)
         }
-        if (termApply != null && termApply.termName().value() == "be") {
-
-          console.log(shouldTerm.value())
-        }
-        else {
-          console.log(`after apply, termApply is null`)
-        }
-
       })
 }
 

--- a/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
@@ -3,7 +3,6 @@ import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
 import {PathExpression,TextTreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
 import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
 import {Match} from '@atomist/rug/tree/PathExpression'
-import {parameter} from '@atomist/rug/operations/RugOperation'
 
 class UpgradeScalaTestAssertions implements ProjectEditor {
     name: string = "UpgradeScalaTestAssertions"

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeUsageTest.scala
@@ -3,6 +3,9 @@ package com.atomist.rug.kind.scala
 import com.atomist.project.edit.SuccessfulModification
 import com.atomist.rug.kind.grammar.AbstractTypeUnderFileTest
 
+/**
+  * Tests for realistic Scala scenarios
+  */
 class ScalaFileTypeUsageTest extends AbstractTypeUnderFileTest {
 
   import ScalaFileTypeTest._
@@ -10,6 +13,8 @@ class ScalaFileTypeUsageTest extends AbstractTypeUnderFileTest {
   override val typeBeingTested = new ScalaFileType
 
   it should "change exception catch ???" is pending
+
+  it should "change a.equals(b)" is pending
 
   it should "upgrade ScalaTest assertions" in pendingUntilFixed {
 

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeUsageTest.scala
@@ -16,12 +16,13 @@ class ScalaFileTypeUsageTest extends AbstractTypeUnderFileTest {
 
   it should "change a.equals(b)" is pending
 
-  it should "upgrade ScalaTest assertions" in pendingUntilFixed {
+  it should "upgrade ScalaTest assertions" in {
 
     modify("UpgradeScalaTestAssertions.ts", ScalaTestSources) match {
       case sm: SuccessfulModification =>
         val theFile = sm.result.findFile(ScalaTestSources.allFiles.head.path).get
-        theFile.content.contains("====") should be (true)
+        //println(theFile.content)
+        theFile.content.contains("===") should be (true)
       case wtf => fail(s"Expected SuccessfulModification, not $wtf")
     }
   }

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
@@ -13,30 +13,26 @@ import org.scalatest.{FlatSpec, Matchers}
 class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
 
   it should "not allow invocation of non export function" in {
-    val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-
-    val sc = new jsSafeCommittingProxy(typed, fmv)
+    val sc = new jsSafeCommittingProxy(fmv)
     intercept[RugRuntimeException] {
       sc.getMember("bla")
     }
   }
 
   it should "not allow invocation of export function" in {
-    val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    val sc = new jsSafeCommittingProxy(typed, fmv)
+    val sc = new jsSafeCommittingProxy(fmv)
      sc.getMember("setContent")
   }
 
   it should "not allow invocation of registered command function" in {
-    val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
     val fc = new FakeCommand
-    val sc = new jsSafeCommittingProxy(typed, fmv, new FakeCommandRegistry(fc))
+    val sc = new jsSafeCommittingProxy(fmv, new FakeCommandRegistry(fc))
     val ajs: AbstractJSObject = sc.getMember("execute").asInstanceOf[AbstractJSObject]
     val afc = ajs.call(fmv, null)
     fc.fmv should be(fmv)
@@ -44,10 +40,9 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
   }
 
   it should "fail for unregistered command function" in {
-    val typed = new FileType()
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    val sc = new jsSafeCommittingProxy(typed, fmv, new FakeCommandRegistry)
+    val sc = new jsSafeCommittingProxy(fmv, new FakeCommandRegistry)
     intercept[RugRuntimeException] {
       sc.getMember("delete")
     }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
@@ -128,15 +128,18 @@ class TypeScriptMicrogrammarTest extends FlatSpec with Matchers {
       |
       |class MgEditor implements ProjectEditor {
       |    name: string = "Constructed"
-      |    description: string = "Uses single microgrammar"
+      |    description: string = "Uses 2 microgrammars"
       |
       |    edit(project: Project) {
-      |      let mg = new Microgrammar('method', `public $type:§[A-Za-z0-9]+§`)
-      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg)
+      |      let mg1 = new Microgrammar('mv1', `$mv1:§[a-zA-Z0-9_\\.]+§</modelVersion>`)
+      |      let mg2 = new Microgrammar('modelVersion', `<modelVersion>$:mv1`)
+      |      let eng: PathExpressionEngine = project.context().pathExpressionEngine().addType(mg1).addType(mg2)
       |
-      |      eng.with<TextTreeNode>(project, "//File()/method()/type()", n => {
-      |        let s = `Type is ${n}`
-      |        n.update(n.value() + "_x")
+      |      eng.with<TextTreeNode>(project, "/*[@name='pom.xml']/modelVersion()/mv1()", n => {
+      |        if (n.value() != "4.0.0") project.fail("" + n.value())
+      |        let msg = `The node is ${n}`
+      |        //console.log(msg)
+      |        n.update('Foo bar')
       |      })
       |    }
       |  }
@@ -186,7 +189,7 @@ class TypeScriptMicrogrammarTest extends FlatSpec with Matchers {
       RequiresFormatInfo))
   }
 
-  it should "#283 allow toString calls on node" in pendingUntilFixed {
+  it should "#283 allow toString calls on node" in {
     invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       ToStringOnMicrogrammarNode))
   }


### PR DESCRIPTION
`jsSafeCommittingProxy` now proxies objects returned by TypeScript navigation.

Added `children` convenience method on `TreeNode` for JavaScript callers, who can't cope with Scala collections.

Made further `ScalaTypeUsageTest` scenario work.

Also fixes #283