### PR TITLE
Prefer StringOps.stripSuffix to local implementations

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/rug/dsl/EditorMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/rug/dsl/EditorMutableView.scala
@@ -31,11 +31,7 @@ class EditorMutableView(originalBackingObject: FileArtifact,
 
   private def isRugDsl: Boolean = currentBackingObject.name.endsWith(RugArchiveProjectType.RugExtension)
 
-  private def removeSuffix(suffix: String, whole: String) =
-    if (whole.endsWith(suffix))
-      whole.substring(0, whole.length - suffix.length)
-    else
-      whole
+  private def removeSuffix(suffix: String, whole: String) = whole stripSuffix suffix
 
   private def removeFileSuffix(filename:String): String =
     {

--- a/src/main/scala/com/atomist/rug/spi/Typed.scala
+++ b/src/main/scala/com/atomist/rug/spi/Typed.scala
@@ -4,10 +4,7 @@ import com.atomist.util.lang.JavaHelpers
 
 object Typed {
 
-  private[spi] def trimSuffix(suffix: String, orig: String): String = orig match {
-    case n if n.endsWith(suffix) => n.dropRight(suffix.length)
-    case n => n
-  }
+  private[spi] def trimSuffix(suffix: String, orig: String): String = orig stripSuffix suffix
 
   private val TypeSuffix = "Type"
   private val TreeNodeSuffix = "TreeNode"

--- a/src/main/scala/com/atomist/util/lang/javaHelpers.scala
+++ b/src/main/scala/com/atomist/util/lang/javaHelpers.scala
@@ -90,9 +90,7 @@ object JavaHelpers {
     else name
   }
 
-  def stripSuffixIfPresent(name: String, suffix: String): String = {
-    if (name.endsWith(suffix)) name.dropRight(suffix.length) else name
-  }
+  def stripSuffixIfPresent(name: String, suffix: String): String = name stripSuffix suffix
 
   def upperize(s: String): String = s.length match {
     case 0 | 1 => s.take(1).toUpperCase


### PR DESCRIPTION

[stripSuffix](http://www.scala-lang.org/api/2.11.8/index.html#scala.collection.immutable.StringOps@stripSuffix(suffix:String):String)

```
scala> val a = "asdf.com" :: "asfdf.co" :: "asdf" :: "com.asdf" :: Nil
a: List[String] = List(asdf.com, asfdf.co, asdf, com.asdf)

scala> a map (x => (x, x.endsWith(".com"), x.stripSuffix(".com")))
res7: List[(String, Boolean, String)] = List(
  (asdf.com,true,asdf),
  (asfdf.co,false,asfdf.co),
  (asdf,false,asdf),
  (com.asdf,false,com.asdf)
)

```

Next action would be to remove these methods.