### PR TITLE
Changes to make neo-tree-materializer work

### DIFF
--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
@@ -55,7 +55,7 @@ class JavaScriptEventHandler(
       case Right(Nil) =>
       case Right(matches) =>
         val cm = jsContextMatch(
-          targetNode,
+          jsPathExpressionEngine.wrapOne(targetNode),
           jsPathExpressionEngine.wrap(matches),
           s2,
           teamId = e.teamId)

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsContextMatch.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsContextMatch.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
   * Fronts JavaScript Context object
   */
 case class jsContextMatch(root: Object,
-                          matches: _root_.java.util.List[Object],
+                          matches: _root_.java.util.List[jsSafeCommittingProxy],
                           s2: ServiceSource,
                           teamId: String) {
 

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -22,10 +22,11 @@ import scala.collection.JavaConverters._
 /**
   * Represents a Match from executing a PathExpression, exposed
   * to JavaScript/TypeScript.
+  *
   * @param root    root we evaluated path from
   * @param matches matches
   */
-case class jsMatch(root: TreeNode, matches: _root_.java.util.List[Object])
+case class jsMatch(root: TreeNode, matches: _root_.java.util.List[jsSafeCommittingProxy])
 
 /**
   * JavaScript-friendly facade to an ExpressionEngine.
@@ -145,7 +146,7 @@ class jsPathExpressionEngine(
     * @param root root of Tree. SafeComittingProxy wrapping a TreeNode
     * @param pe   path expression of object
     */
-  def scalar(root: TreeNode, pe: Object): Object = {
+  def scalar(root: TreeNode, pe: Object): jsSafeCommittingProxy = {
     val res = evaluate(root, pe)
     val ms = res.matches
     ms.size() match {
@@ -160,7 +161,7 @@ class jsPathExpressionEngine(
   /**
     * Try to cast the given node to the required type.
     */
-  def as(root: TreeNode, name: String): Object = scalar(root, s"->$name")
+  def as(root: TreeNode, name: String): jsSafeCommittingProxy = scalar(root, s"->$name")
 
   /**
     * Find the children of the current node of the named type
@@ -168,7 +169,7 @@ class jsPathExpressionEngine(
     * @param parent parent node we want to look under
     * @param name   name of the children we want to look for
     */
-  def children(parent: TreeNode, name: String): util.List[Object] = {
+  def children(parent: TreeNode, name: String): util.List[jsSafeCommittingProxy] = {
     val rootTn = toUnderlyingTreeNode(parent)
     val typ = typeRegistry.findByName(name).getOrElse(
       throw new IllegalArgumentException(s"Unknown type")
@@ -194,14 +195,13 @@ object jsPathExpressionEngine {
     * @param nodes sequence to wrap
     * @return TypeScript and JavaScript-friendly list
     */
-  def wrap(nodes: Seq[TreeNode], cr: CommandRegistry = DefaultCommandRegistry): java.util.List[Object] = {
+  def wrap(nodes: Seq[TreeNode], cr: CommandRegistry = DefaultCommandRegistry): java.util.List[jsSafeCommittingProxy] = {
     new JavaScriptArray(
-      nodes.map(n => wrapOne(n))
+      nodes.map(n => wrapOne(n, cr))
         .asJava)
   }
 
-  def wrapOne(n: TreeNode, cr: CommandRegistry = DefaultCommandRegistry): Object = n match {
-    case _ => new jsSafeCommittingProxy(n, cr)
-  }
+  def wrapOne(n: TreeNode, cr: CommandRegistry = DefaultCommandRegistry): jsSafeCommittingProxy =
+    new jsSafeCommittingProxy(n, cr)
 
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -120,8 +120,8 @@ class jsPathExpressionEngine(
 
   // If the node is a SafeCommittingProxy, find the underlying object
   private def toTreeNode(o: Object): TreeNode = o match {
-    case tn: TreeNode => tn
     case scp: jsSafeCommittingProxy => scp.node
+    case tn: TreeNode => tn
   }
 
   /**

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -22,14 +22,10 @@ import scala.collection.JavaConverters._
 /**
   * Represents a Match from executing a PathExpression, exposed
   * to JavaScript/TypeScript.
-  * Matches are actually TreeNodes, but wrapped in SafeCommittingProxy,
-  * hence the list of matches is a list of Object. We need to use a
-  * Java, rather than Scala, collection, for interop.
-  *
   * @param root    root we evaluated path from
   * @param matches matches
   */
-case class jsMatch(root: Object, matches: _root_.java.util.List[Object])
+case class jsMatch(root: TreeNode, matches: _root_.java.util.List[Object])
 
 /**
   * JavaScript-friendly facade to an ExpressionEngine.
@@ -97,7 +93,7 @@ class jsPathExpressionEngine(
     *             The latter allows us to define TypeScript classes.
     * @return a Match
     */
-  def evaluate(root: Object, pe: Object): jsMatch = {
+  def evaluate(root: TreeNode, pe: Object): jsMatch = {
     val parsed: PathExpression = pe match {
       case som: ScriptObjectMirror =>
         // Examine a JavaScript object passed to us. It's probably a
@@ -108,7 +104,7 @@ class jsPathExpressionEngine(
         PathExpressionParser.parsePathExpression(expr)
     }
 
-    val hydrated = teamContext.treeMaterializer.hydrate(teamContext.teamId, toTreeNode(root), parsed)
+    val hydrated = teamContext.treeMaterializer.hydrate(teamContext.teamId, toUnderlyingTreeNode(root), parsed)
     ee.evaluate(hydrated, parsed, typeRegistry) match {
       case Right(nodes) =>
         val m = jsMatch(root, wrap(nodes))
@@ -119,7 +115,7 @@ class jsPathExpressionEngine(
   }
 
   // If the node is a SafeCommittingProxy, find the underlying object
-  private def toTreeNode(o: Object): TreeNode = o match {
+  private def toUnderlyingTreeNode(o: TreeNode): TreeNode = o match {
     case scp: jsSafeCommittingProxy => scp.node
     case tn: TreeNode => tn
   }
@@ -132,7 +128,7 @@ class jsPathExpressionEngine(
     * @param pexpr path expression (compiled or string)
     * @param f     function to apply to each path expression
     */
-  def `with`(root: Object, pexpr: Object, f: Object): Unit = f match {
+  def `with`(root: TreeNode, pexpr: Object, f: Object): Unit = f match {
     case som: ScriptObjectMirror =>
       val r = evaluate(root, pexpr)
       r.matches.asScala.foreach(m => {
@@ -149,7 +145,7 @@ class jsPathExpressionEngine(
     * @param root root of Tree. SafeComittingProxy wrapping a TreeNode
     * @param pe   path expression of object
     */
-  def scalar(root: Object, pe: Object): Object = {
+  def scalar(root: TreeNode, pe: Object): Object = {
     val res = evaluate(root, pe)
     val ms = res.matches
     ms.size() match {
@@ -164,7 +160,7 @@ class jsPathExpressionEngine(
   /**
     * Try to cast the given node to the required type.
     */
-  def as(root: Object, name: String): Object = scalar(root, s"->$name")
+  def as(root: TreeNode, name: String): Object = scalar(root, s"->$name")
 
   /**
     * Find the children of the current node of the named type
@@ -172,9 +168,11 @@ class jsPathExpressionEngine(
     * @param parent parent node we want to look under
     * @param name   name of the children we want to look for
     */
-  def children(parent: Object, name: String): util.List[Object] = {
-    val rootTn = toTreeNode(parent)
-    val typ = typeRegistry.findByName(name).getOrElse(???)
+  def children(parent: TreeNode, name: String): util.List[Object] = {
+    val rootTn = toUnderlyingTreeNode(parent)
+    val typ = typeRegistry.findByName(name).getOrElse(
+      throw new IllegalArgumentException(s"Unknown type")
+    )
     (typ, rootTn) match {
       case (cvf: ContextlessViewFinder, mv: MutableView[_]) =>
         val kids = cvf.findAllIn(mv).getOrElse(Nil)

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -31,6 +31,23 @@ class jsSafeCommittingProxy(
 
   import jsSafeCommittingProxy.MagicJavaScriptMethods
 
+  //-----------------------------------------------------
+  // Delegate TreeNode methods to backing node
+
+  override def nodeName: String = node.nodeName
+
+  override def value: String = node.value
+
+  override def childNodeNames: Set[String] = node.childNodeNames
+
+  override def childNodeTypes: Set[String] = node.childNodeTypes
+
+  override def childrenNamed(key: String): Seq[TreeNode] =
+    node.childrenNamed(key)
+      .map(n => new jsSafeCommittingProxy(n, commandRegistry, typeRegistry))
+
+  //-----------------------------------------------------
+
   override def getMember(name: String): AnyRef = {
     //println(s"getMember: [$name]")
     if (MagicJavaScriptMethods.contains(name))
@@ -155,35 +172,6 @@ class jsSafeCommittingProxy(
     }
   }
 
-  /**
-    * Name of the node. This may vary with individual nodes: For example,
-    * with files. However, node names do not always need to be unique.
-    *
-    * @return name of the individual node
-    */
-  override def nodeName: String = node.nodeName
-
-  /**
-    * All nodes have values: Either a terminal value or the
-    * values built up from subnodes.
-    */
-  override def value: String = node.value
-
-  /**
-    * Return the names of children of this node
-    *
-    * @return the names of children. There may be multiple children
-    *         with a given name
-    */
-  override def childNodeNames: Set[String] = node.childNodeNames
-  override def childNodeTypes: Set[String] = node.childNodeTypes
-
-  /**
-    * Children under the given key. May be empty.
-    *
-    * @param key field name
-    */
-  override def childrenNamed(key: String): Seq[TreeNode] = node.childrenNamed(key)
 }
 
 private object jsSafeCommittingProxy {

--- a/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
+++ b/src/main/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializer.scala
@@ -48,6 +48,11 @@ object LinkedJsonTreeDeserializer extends LazyLogging {
           case None => throw new IllegalArgumentException(s"Type is required")
           case _ => ???
         }
+        val nodeTags: Set[String] = m.get(Type) match {
+          case Some(l: Seq[_]) => l.map(_.toString).toSet
+          case None => throw new IllegalArgumentException(s"Type is required")
+          case _ => ???
+        }
         val nodeName = nodeType
         val simpleFields =
           for {
@@ -61,7 +66,7 @@ object LinkedJsonTreeDeserializer extends LazyLogging {
             }
             SimpleTerminalTreeNode(k, nodeValue)
           }
-        val ctn = new LinkableContainerTreeNode(nodeName, Set(nodeType), simpleFields.toSeq)
+        val ctn = new LinkableContainerTreeNode(nodeName, nodeTags + TreeNode.Dynamic, simpleFields.toSeq)
         val nodeId: String = requiredStringEntry(m, NodeId)
         idToNode += (nodeId -> ctn)
         ctn
@@ -128,7 +133,9 @@ private class WrappingLinkableContainerTreeNode(val wrappedNode: LinkableContain
                                                 override val nodeName: String)
   extends ContainerTreeNode {
 
-  override def value: String = ???
+  override def value: String = wrappedNode.value
+
+  override def nodeTags: Set[String] = wrappedNode.nodeTags
 
   override def childNodeNames: Set[String] = wrappedNode.childNodeNames
 
@@ -148,9 +155,11 @@ class JsonBackedContainerTreeNode(val innerNode: ContainerTreeNode,
                                   val version: String)
   extends ContainerTreeNode {
 
-  override def value: String = ???
+  override def value: String = innerNode.value
 
   override def nodeName: String = innerNode.nodeName
+
+  override def nodeTags: Set[String] = innerNode.nodeTags
 
   override def childNodeNames: Set[String] = innerNode.childNodeNames
 

--- a/src/main/scala/com/atomist/tree/treeNode.scala
+++ b/src/main/scala/com/atomist/tree/treeNode.scala
@@ -107,7 +107,7 @@ object TreeNode {
   case object Undeclared extends Significance
 
   /**
-    * Tag added to all dynamically created nodes, such as those backed by microgrammars or Antlr
+    * Tag added to all dynamically created nodes, such as those backed by microgrammars, Antlr or LinkableContainerTreeNodes
     */
   val Dynamic: String = "-dynamic"
 }

--- a/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
@@ -1,5 +1,6 @@
 package com.atomist.tree.marshal
 
+import com.atomist.tree.TreeNode
 import org.scalatest.{FlatSpec, Matchers}
 
 class LinkedJsonTreeDeserializerTest extends FlatSpec with Matchers {
@@ -149,13 +150,13 @@ class LinkedJsonTreeDeserializerTest extends FlatSpec with Matchers {
 
   it should "deserialize simple tree" in {
     val node = LinkedJsonTreeDeserializer.fromJson(t1)
-    node.nodeTags should be (Set("Issue"))
+    node.nodeTags should be (Set("Issue", TreeNode.Dynamic))
     node.childrenNamed("number").size should be (1)
   }
 
   it should "deserialize a tree of n depth" in {
     val node = LinkedJsonTreeDeserializer.fromJson(t2)
-    node.nodeTags should be (Set("Build"))
+    node.nodeTags should be (Set("Build", TreeNode.Dynamic))
     node.childrenNamed("status").head.value should be ("Passed")
     val repo = node.childrenNamed("ON").head
     repo.childrenNamed("owner").size should be (1)


### PR DESCRIPTION
* `jsSafeCommittingProxy` is itself a `TreeNode` now that delegates earch call to `TreeNode` methods to the proxied/wrapped node
* Properly handle `nodeTags` in `LinkableContainerTreeNode`; add `TreeNode.Dyanamic` to `nodeTags` so that` jsSafeCommittingProxy` allows to dispatch through to childNodes
* `FunctionProxyToNodeNavigationMethods` now exposes `value()` for `TerminalTreeNode`s instead of returning the node