### PR TITLE
Upgrades ScalaTest assertions

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -41,3 +41,16 @@ editor:
     - "rug_archive_name": "rug"
     - "rug_archive_group_id": "atomist"
 
+---
+kind: "operation"
+client: "rug-cli 0.23.0-SNAPSHOT"
+executor:
+  name: "UpgradeScalaTestAssertions"
+  group: "atomist-rugs"
+  artifact: "scala-editors"
+  version: "0.1.0"
+  origin:
+    repo: "n/a"
+    branch: "n/a"
+    sha: "n/a"
+

--- a/src/test/scala/com/atomist/event/archive/HandlerArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/event/archive/HandlerArchiveReaderTest.scala
@@ -59,15 +59,15 @@ class HandlerArchiveReaderTest extends FlatSpec with Matchers {
     val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
     val handlers = har.handlers("XX", TypeScriptBuilder.compileWithModel(new SimpleFileBasedArtifactSource("", FirstHandler)), None, Nil,
       new ConsoleMessageBuilder("XX", null))
-    handlers.size should be(1)
-    handlers.head.rootNodeName should be("issue")
+    assert(handlers.size === 1)
+    assert(handlers.head.rootNodeName === "issue")
   }
 
   it should "parse two handlers" in {
     val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
     val handlers = har.handlers("XX", TypeScriptBuilder.compileWithModel(new SimpleFileBasedArtifactSource("", Seq(FirstHandler, SecondHandler))), None, Nil,
       new ConsoleMessageBuilder("XX", null))
-    handlers.size should be(2)
+    assert(handlers.size === 2)
     handlers.exists(h => h.rootNodeName == "issue") should be(true)
     handlers.exists(h => h.rootNodeName == "commit") should be(true)
   }
@@ -76,16 +76,16 @@ class HandlerArchiveReaderTest extends FlatSpec with Matchers {
     val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
     val handlers = har.handlers("XX", TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(NamedJavaScriptEventHandlerTest.reOpenCloseIssueProgram,NamedJavaScriptEventHandlerTest.issuesStuff)), None, Nil,
       new ConsoleMessageBuilder("XX", null))
-    handlers.size should be(1)
-    handlers.head.rootNodeName should be("issue")
+    assert(handlers.size === 1)
+    assert(handlers.head.rootNodeName === "issue")
   }
 
   it should "allow a correlationId to be set" in {
     val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
     val messageBuilder = new ConsoleMessageBuilder("XX", null)
     val handlers = har.handlers("XX", TypeScriptBuilder.compileWithModel(new SimpleFileBasedArtifactSource("", ThirdHandler)), None, Nil, messageBuilder)
-    handlers.size should be(1)
-    handlers.head.rootNodeName should be("commit")
+    assert(handlers.size === 1)
+    assert(handlers.head.rootNodeName === "commit")
   }
 
   object TestTreeMaterializer extends TreeMaterializer {

--- a/src/test/scala/com/atomist/project/ProjectOperationInfoTest.scala
+++ b/src/test/scala/com/atomist/project/ProjectOperationInfoTest.scala
@@ -9,18 +9,18 @@ class ProjectOperationInfoTest extends FlatSpec with Matchers {
 
   it should "not create default gav appropriately without group" in {
     val poi = SimpleProjectOperationInfo("name", "desc", Some("group"), None, Nil, Nil)
-    poi.gav.isPresent should be(false)
+    assert(poi.gav.isPresent === false)
   }
 
   it should "not create default gav appropriately without version" in {
     val poi = SimpleProjectOperationInfo("name", "desc", None, Some("version"), Nil, Nil)
-    poi.gav.isPresent should be(false)
+    assert(poi.gav.isPresent === false)
   }
 
   it should "create correct gav with group and version" in {
     val (group, version) = ("group", "version")
     val poi = SimpleProjectOperationInfo("name", "desc", Some(group), Some(version), Nil, Nil)
-    poi.gav.isPresent should be(true)
-    poi.gav.get should equal(SimpleResourceSpecifier(group, poi.name, version))
+    assert(poi.gav.isPresent === true)
+    assert(poi.gav.get === SimpleResourceSpecifier(group, poi.name, version))
   }
 }

--- a/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
@@ -55,34 +55,34 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
   it should "parse single editor" in {
     val apc = new ProjectOperationArchiveReader(atomistConfig)
     val ops = apc.findOperations(new SimpleFileBasedArtifactSource("", FirstEditor), None, Nil)
-    ops.editors.size should be(1)
-    ops.editorNames should equal(Seq("First"))
-    ops.reviewers should equal(Nil)
-    ops.reviewerNames should equal(Nil)
-    ops.generators should equal(Nil)
-    ops.generatorNames should equal(Nil)
+    assert(ops.editors.size === 1)
+    assert(ops.editorNames === Seq("First"))
+    assert(ops.reviewers === Nil)
+    assert(ops.reviewerNames === Nil)
+    assert(ops.generators === Nil)
+    assert(ops.generatorNames === Nil)
   }
 
   it should "parse editor and reviewer" in {
     val apc = new ProjectOperationArchiveReader(atomistConfig)
     val ops = apc.findOperations(new SimpleFileBasedArtifactSource("", Seq(FirstEditor, SecondOp)), None, Nil)
-    ops.editors.size should be(1)
-    ops.editorNames should equal(Seq("First"))
-    ops.reviewers.size should be(1)
-    ops.reviewerNames should equal(Seq("Second"))
-    ops.generators should equal(Nil)
-    ops.generatorNames should equal(Nil)
+    assert(ops.editors.size === 1)
+    assert(ops.editorNames === Seq("First"))
+    assert(ops.reviewers.size === 1)
+    assert(ops.reviewerNames === Seq("Second"))
+    assert(ops.generators === Nil)
+    assert(ops.generatorNames === Nil)
   }
 
   it should "parse editor and reviewer and generator" in {
     val apc = new ProjectOperationArchiveReader(atomistConfig)
     val ops = apc.findOperations(new SimpleFileBasedArtifactSource("", Seq(FirstEditor, SecondOp, Generator)), None, Nil)
-    ops.editors.size should be(1)
-    ops.editorNames.toSet should equal(Set("First"))
-    ops.reviewers.size should be(1)
-    ops.reviewerNames should equal(Seq("Second"))
-    ops.generators.size should equal(1)
-    ops.generatorNames should equal(Seq("Published"))
+    assert(ops.editors.size === 1)
+    assert(ops.editorNames.toSet === Set("First"))
+    assert(ops.reviewers.size === 1)
+    assert(ops.reviewerNames === Seq("Second"))
+    assert(ops.generators.size === 1)
+    assert(ops.generatorNames === Seq("Published"))
   }
 
   it should "find imports in a project that uses them" in {
@@ -106,8 +106,8 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
       StringFileArtifact(".atomist/editors/SimpleEditor.ts", TypeScriptRugEditorTest.SimpleEditorTaggedAndMeta)
     ))
     val ops = apc.findOperations(as, None, Nil)
-    ops.editors.size should be(1)
-    ops.editors.head.parameters.size should be(2)
+    assert(ops.editors.size === 1)
+    assert(ops.editors.head.parameters.size === 2)
   }
 
   val SimpleExecutor =
@@ -135,8 +135,8 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
       StringFileArtifact(".atomist/executors/SimpleExecutor.ts", SimpleExecutor)
     ))
     val ops = apc.findOperations(as, None, Nil)
-    ops.executors.size should be(1)
-    ops.executors.head.parameters.size should be(0)
+    assert(ops.executors.size === 1)
+    assert(ops.executors.head.parameters.size === 0)
     val s2 = new FakeServiceSource(Nil)
     ops.executors.head.execute(s2, SimpleProjectOperationArguments.Empty)
   }
@@ -152,12 +152,12 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
       f2
     ))
     val ops = apc.findOperations(rugAs, None, Nil)
-    ops.generators.size should be(1)
-    ops.generators.head.parameters.size should be(0)
+    assert(ops.generators.size === 1)
+    assert(ops.generators.head.parameters.size === 0)
     val result = ops.generators.head.generate("woot",
       SimpleProjectOperationArguments("", Map("content" -> "woot")))
     // Should preserve content from the backing archive
-    result.id.name should be("woot")
+    assert(result.id.name === "woot")
     result.findFile(f1.path).get.content.equals(f1.content) should be(true)
     result.findFile(f2.path).get.content.equals(f2.content) should be(true)
 
@@ -180,8 +180,8 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
     ) + TypeScriptBuilder.userModel
 
     val ops = apc.findOperations(rugAs, None, Nil)
-    ops.editors.size should be(1)
-    ops.editors.head.parameters.size should be(1)
+    assert(ops.editors.size === 1)
+    assert(ops.editors.head.parameters.size === 1)
   }
 
   it should "ignore unbound handler" in {
@@ -213,8 +213,8 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
       StringFileArtifact(".atomist/handlers/sub.ts", handler)
     ))
     val ops = apc.findOperations(rugAs, None, Nil)
-    ops.generators.size should be(1)
-    ops.generators.head.parameters.size should be(0)
+    assert(ops.generators.size === 1)
+    assert(ops.generators.head.parameters.size === 0)
     val result = ops.generators.head.generate("woot",
       SimpleProjectOperationArguments("", Map("content" -> "woot")))
     // Should preserve content from the backing archive
@@ -239,8 +239,8 @@ class ProjectOperationArchiveReaderTest extends FlatSpec with Matchers {
       NamedJavaScriptEventHandlerTest.issuesStuff
     ))
     val ops = apc.findOperations(rugAs, None, Nil)
-    ops.generators.size should be(1)
-    ops.generators.head.parameters.size should be(0)
+    assert(ops.generators.size === 1)
+    assert(ops.generators.head.parameters.size === 0)
     val result = ops.generators.head.generate("woot", SimpleProjectOperationArguments("", Map("content" -> "woot")))
     // Should preserve content from the backing archive
     result.findFile(f1.path).get.content.equals(f1.content) should be(true)
@@ -256,13 +256,16 @@ class FakeServiceSource(val projects: Seq[ArtifactSource]) extends ServiceSource
 
   val updatePersister = new FakeUpdatePersister
 
+
   val teamId = "atomist-test"
 
   override def pathExpressionEngine: jsPathExpressionEngine =
     new jsPathExpressionEngine(teamContext = this)
 
+
   override def messageBuilder: MessageBuilder =
     new ConsoleMessageBuilder(teamId, EmptyActionRegistry)
+
 
   var issues = ListBuffer.empty[Issue]
 

--- a/src/test/scala/com/atomist/project/common/template/MustacheMergeToolTest.scala
+++ b/src/test/scala/com/atomist/project/common/template/MustacheMergeToolTest.scala
@@ -38,33 +38,34 @@ class MustacheMergeToolTest extends FlatSpec with Matchers {
   it should "process template files" in {
     val mmt = new MustacheMergeTool(templateAs)
     val files = mmt.processTemplateFiles(FirstContext, templateAs.allFiles)
-    files.size should equal(3)
+    assert(files.size === 3)
     val expectedPath = "location_was_true.txt"
     // First.mustache
-    files.map(f => f.path).toSet should equal(Set(static1.path, expectedPath, "first.mustache"))
-    files.find(_.path.equals(expectedPath)).get.content should equal(FirstExpected)
+    assert(files.map(f => f.path).toSet === Set(static1.path, expectedPath, "first.mustache"))
+    assert(files.find(_.path.equals(expectedPath)).get.content === FirstExpected)
   }
 
   it should "process classpath template files" in {
     val mmt = new MustacheMergeTool(cpTemplateAs)
     val files = mmt.processTemplateFiles(FirstContext, cpTemplateAs.allFiles)
-    files.size should equal(1)
+    assert(files.size === 1)
     val expectedPath = "G'day Chris. You just scored 10000 dollars. But the ATO has hit you with tax so you'll only get 6000.0"
-    files.map(f => f.path).toSet should equal(Set("test.mustache"))
-    files.head.content should equal(expectedPath)
+    assert(files.map(f => f.path).toSet === Set("test.mustache"))
+    assert(files.head.content === expectedPath)
   }
 
   it should "process template ArtifactSource" in {
     val mmt = new MustacheMergeTool(templateAs)
     val files = mmt.processTemplateFiles(FirstContext, templateAs).allFiles
-    files.size should equal(3)
+    assert(files.size === 3)
     val expectedPath = "location_was_true.txt"
     // First.mustache
-    files.map(f => f.path).toSet should equal(Set(static1.path, expectedPath, "first.mustache"))
-    files.find(_.path.equals(expectedPath)).get.content should equal(FirstExpected)
+    assert(files.map(f => f.path).toSet === Set(static1.path, expectedPath, "first.mustache"))
+    assert(files.find(_.path.equals(expectedPath)).get.content === FirstExpected)
   }
 
   val mt = new MustacheMergeTool(new EmptyArtifactSource(""))
+
 
   it should "strip .mustache extension" in {
     val name = "template_.mustache"

--- a/src/test/scala/com/atomist/project/common/yml/YmlProjectOperationInfoParserTest.scala
+++ b/src/test/scala/com/atomist/project/common/yml/YmlProjectOperationInfoParserTest.scala
@@ -132,42 +132,42 @@ class YmlProjectOperationInfoParserTest extends FlatSpec with Matchers {
 
   it should "return empty parameters if no parameters specified" in {
     val poi = YmlProjectOperationInfoParser.parse(noParameters)
-    poi.parameters.isEmpty should be(true)
+    assert(poi.parameters.isEmpty === true)
   }
 
   it should "return empty tags if no tags specified" in {
     val poi = YmlProjectOperationInfoParser.parse(noParameters)
-    poi.tags.isEmpty should be(true)
+    assert(poi.tags.isEmpty === true)
   }
 
   it should "return no GAV if version and group not specified" in {
     val poi = YmlProjectOperationInfoParser.parse(noParameters)
-    poi.gav.isDefined should be(false)
+    assert(poi.gav.isDefined === false)
   }
 
   it should "return GAV if version and group specified" in {
     val poi = YmlProjectOperationInfoParser.parse(valid1)
-    poi.gav.isDefined should be(true)
-    poi.gav.get should equal(SimpleResourceSpecifier("atomist", "test1", "1.0"))
+    assert(poi.gav.isDefined === true)
+    assert(poi.gav.get === SimpleResourceSpecifier("atomist", "test1", "1.0"))
   }
 
   it should "find name in valid content" in {
     val poi = YmlProjectOperationInfoParser.parse(valid1)
-    poi.name should equal("test1")
-    poi.description should equal("descr1")
-    poi.parameters.size should equal(2)
+    assert(poi.name === "test1")
+    assert(poi.description === "descr1")
+    assert(poi.parameters.size === 2)
   }
 
   it should "find parameters in valid content using default values" in {
     val poi = YmlProjectOperationInfoParser.parse(valid1)
-    poi.name should equal("test1")
-    poi.description should equal("descr1")
-    poi.parameters.size should equal(2)
-    poi.parameters(0).getName should equal("foo")
-    poi.parameters(0).isRequired should equal(true)
-    poi.parameters(1).getName should equal("bar")
-    poi.parameters(1).isRequired should equal(false)
-    poi.parameters(1).getPattern should equal(ParameterValidationPatterns.MatchAny)
+    assert(poi.name === "test1")
+    assert(poi.description === "descr1")
+    assert(poi.parameters.size === 2)
+    assert(poi.parameters(0).getName === "foo")
+    assert(poi.parameters(0).isRequired === true)
+    assert(poi.parameters(1).getName === "bar")
+    assert(poi.parameters(1).isRequired === false)
+    assert(poi.parameters(1).getPattern === ParameterValidationPatterns.MatchAny)
   }
 
   it should "honor parameter overrides without strange characters" in {
@@ -180,25 +180,25 @@ class YmlProjectOperationInfoParserTest extends FlatSpec with Matchers {
 
   it should "respect tags" in {
     val poi = checkWithOverrides("name1", "description is good", required = true, ".+", "default_val", "You should've input something")
-    poi.tags.size should equal(2)
-    poi.tags(0).name should equal("spring")
-    poi.tags(0).description should equal("Spring Framework")
-    poi.tags(1).name should equal("spring-boot")
-    poi.tags(1).description should equal("Spring Boot")
+    assert(poi.tags.size === 2)
+    assert(poi.tags(0).name === "spring")
+    assert(poi.tags(0).description === "Spring Framework")
+    assert(poi.tags(1).name === "spring-boot")
+    assert(poi.tags(1).description === "Spring Boot")
   }
 
   it should "accept multiline description" is pending
 
-  private def checkWithOverrides(name: String, description: String, required: Boolean, pattern: String, default: String, validInputDescription: String) = {
+  private  def checkWithOverrides(name: String, description: String, required: Boolean, pattern: String, default: String, validInputDescription: String) = {
     val yml = withOverrides(name, description, required, pattern, default, validInputDescription)
     val poi = YmlProjectOperationInfoParser.parse(yml)
     val p = poi.parameters.head
-    p.getName should equal(name)
-    p.getDescription should equal(description)
-    p.isRequired should equal(required)
-    p.getPattern should equal(pattern)
-    p.getDefaultValue should equal(default)
-    p.getValidInputDescription should equal(validInputDescription)
+    assert(p.getName === name)
+    assert(p.getDescription === description)
+    assert(p.isRequired === required)
+    assert(p.getPattern === pattern)
+    assert(p.getDefaultValue === default)
+    assert(p.getValidInputDescription === validInputDescription)
     poi
   }
 
@@ -224,6 +224,6 @@ class YmlProjectOperationInfoParserTest extends FlatSpec with Matchers {
          |    valid_input_description: A name for this service
       """.stripMargin
     val parsed = YmlProjectOperationInfoParser.parse(yml)
-    parsed.parameters.head.getPattern should equal("""[a-zA-Z_$][a-zA-Z\d_$]*""")
+    assert(parsed.parameters.head.getPattern === """[a-zA-Z_$][a-zA-Z\d_$]*""")
   }
 }

--- a/src/test/scala/com/atomist/project/edit/ProjectEditorTest.scala
+++ b/src/test/scala/com/atomist/project/edit/ProjectEditorTest.scala
@@ -22,12 +22,13 @@ class ProjectEditorTest extends FlatSpec with Matchers {
     javaSourcePath = ""
   )
 
+
   val args = SimpleProjectOperationArguments.Empty
 
   val ed: ProjectEditor = new ProjectEditorSupport {
     addParameter(Parameter("class", ParameterValidationPatterns.JavaClass))
 
-    override protected def modifyInternal(as: ArtifactSource, pmi: ProjectOperationArguments): ModificationAttempt = {
+    override protected  def modifyInternal(as: ArtifactSource, pmi: ProjectOperationArguments): ModificationAttempt = {
       SuccessfulModification(as)
     }
 
@@ -50,11 +51,11 @@ class ProjectEditorTest extends FlatSpec with Matchers {
 
   it should "apply edit if needed" in {
     val as = ParsingTargets.SpringIoGuidesRestServiceSource
-    addFoobarAnnotationEditor.applicability(as).canApply should be(true)
+    assert(addFoobarAnnotationEditor.applicability(as).canApply === true)
     addFoobarAnnotationEditor.modify(as, args) match {
       case sma: SuccessfulModification =>
         val javaFiles = sma.result.files.filter(_.name.endsWith(".java"))
-        javaFiles.size should equal(2)
+        assert(javaFiles.size === 2)
         javaFiles.foreach(f => {
           f.content contains "@Mysterious" should be(true)
         })
@@ -76,14 +77,15 @@ class ProjectEditorTest extends FlatSpec with Matchers {
       override def failOnNoModification: Boolean = true
     })
 
-  private def testUnnecessaryEdit(ed: ProjectEditor): Unit = {
+  private  def testUnnecessaryEdit(ed: ProjectEditor): Unit = {
     val as = new SimpleFileBasedArtifactSource("", Seq(
       StringFileArtifact("SomeClass.java", "import com.megacorp.Mysterious; @Mysterious public class SomeClass {}"),
       StringFileArtifact("SomeInterface.java", "import com.megacorp.Mysterious;  @Mysterious public interface SomeInterface {}")
     ))
-    addFoobarAnnotationEditor.applicability(as).canApply should be(true)
+    assert(addFoobarAnnotationEditor.applicability(as).canApply === true)
     addFoobarAnnotationEditor.modify(as, args) match {
       case n: NoModificationNeeded =>
+      
       case _ => fail
     }
   }
@@ -93,9 +95,10 @@ class ProjectEditorTest extends FlatSpec with Matchers {
       StringFileArtifact("SomeClass.java", "import com.megacorp.Mysterious; @Mysterious public class SomeClass {}"),
       StringFileArtifact("SomeInterface.java", "import com.megacorp.Mysterious;  @Mysterious public interface SomeInterface {}")
     ))
-    addFoobarAnnotationEditor.applicability(as).canApply should be(true)
+    assert(addFoobarAnnotationEditor.applicability(as).canApply === true)
     addFoobarAnnotationEditor.modify(as, args) match {
       case n: NoModificationNeeded =>
+      
       case wtf => fail(s"$wtf not expected")
     }
   }
@@ -113,9 +116,10 @@ class ProjectEditorTest extends FlatSpec with Matchers {
       StringFileArtifact("SomeClass.java", "import com.megacorp.Mysterious; @Mysterious public class SomeClass {}"),
       StringFileArtifact("SomeInterface.java", "import com.megacorp.Mysterious;  @Mysterious public interface SomeInterface {}")
     ))
-    neverMatchEditor.applicability(as).canApply should be(true)
+    assert(neverMatchEditor.applicability(as).canApply === true)
     neverMatchEditor.modify(as, args) match {
       case n: FailedModificationAttempt =>
+      
       case wtf => fail(s"$wtf not expected")
     }
   }

--- a/src/test/scala/com/atomist/project/edit/java/AddClassAnnotationEditorTest.scala
+++ b/src/test/scala/com/atomist/project/edit/java/AddClassAnnotationEditorTest.scala
@@ -16,15 +16,16 @@ class AddClassAnnotationEditorTest extends FlatSpec with Matchers {
     javaSourcePath = ""
   )
 
+
   val args = SimpleProjectOperationArguments.Empty
 
   it should "apply annotations where needed" in {
     val as = ParsingTargets.SpringIoGuidesRestServiceSource
-    addFoobarAnnotationEditor.applicability(as).canApply should be(true)
+    assert(addFoobarAnnotationEditor.applicability(as).canApply === true)
     addFoobarAnnotationEditor.modify(as, args) match {
       case sma: SuccessfulModification =>
         val javaFiles = sma.result.files.filter(_.name.endsWith(".java"))
-        javaFiles.size should equal(2)
+        assert(javaFiles.size === 2)
         javaFiles.foreach(f => {
           f.content contains "@Mysterious" should be(true)
         })

--- a/src/test/scala/com/atomist/project/review/ReviewCommentTest.scala
+++ b/src/test/scala/com/atomist/project/review/ReviewCommentTest.scala
@@ -11,15 +11,15 @@ class ReviewCommentTest extends FlatSpec with Matchers {
     val rc3 = ReviewComment("comment2", BROKEN, Some("file"))
 
     val rr = ReviewResult("", Seq(rc1))
-    rr.severity should equal(MAJOR)
+    assert(rr.severity === MAJOR)
     val rr2 = ReviewResult("", Seq(rc1, rc2))
-    rr2.severity should equal(MAJOR)
+    assert(rr2.severity === MAJOR)
     val rr3 = ReviewResult("", Seq(rc1, rc2, rc3))
-    rr3.severity should equal(BROKEN)
+    assert(rr3.severity === BROKEN)
   }
 
   it should "compute severity without issues" in {
     val rr = ReviewResult("nothing")
-    rr.severity should be(FINE)
+    assert(rr.severity === FINE)
   }
 }

--- a/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
+++ b/src/test/scala/com/atomist/rug/AbstractRuntimeTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
 
-  protected def pipeline: RugPipeline
+  protected  def pipeline: RugPipeline
 
   val extraText = "// I'm talkin' about ethics"
 
@@ -25,7 +25,7 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
          |
       """.stripMargin
 
-    def as = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(pipeline.defaultFilenameFor(program), program)) + TypeScriptBuilder.userModel
+    def as = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(pipeline.defaultFilenameFor(program), program))  + TypeScriptBuilder.userModel
 
     val r = doModification(as, JavaAndText, EmptyArtifactSource(""), SimpleProjectOperationArguments.Empty, pipeline)
     r.allFiles.size should be > (0)
@@ -342,12 +342,12 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
         |    do copyEditorBackingFilesWithNewRelativePath sourcePath='test/' destinationPath='test_out'
         |  end
       """.stripMargin
-    val pas = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(pipeline.defaultFilenameFor(program), program)) + TypeScriptBuilder.userModel
+    val pas = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(pipeline.defaultFilenameFor(program), program))  + TypeScriptBuilder.userModel
     val r = doModification(pas, outputAs, rugAs, SimpleProjectOperationArguments.Empty, pipeline)
-    r.totalFileCount should be(2)
-    r.findFile(mergeOutputPath).get.content should equal("content")
-    r.findFile("test_out/foo").get.content should equal("file content")
-    r.cachedDeltas.size should be(3)
+    assert(r.totalFileCount === 2)
+    assert(r.findFile(mergeOutputPath).get.content === "content")
+    assert(r.findFile("test_out/foo").get.content === "file content")
+    assert(r.cachedDeltas.size === 3)
     r.cachedDeltas.exists(_.path == mergeOutputPath) should be(true)
     r.cachedDeltas.exists(_.path == "test_out") should be(true)
     r.cachedDeltas.exists(_.path == "test_out/foo") should be(true)
@@ -491,7 +491,7 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
     simpleAppenderProgramExpectingParameters(goBowling, pipeline = pipeline)
   }
 
-  protected def simpleAppenderProgramExpectingParameters(program: String,
+  protected  def simpleAppenderProgramExpectingParameters(program: String,
                                                          finalFileContent: Option[String] = None,
                                                          as: ArtifactSource = JavaAndText,
                                                          rugAs: ArtifactSource = EmptyArtifactSource(""),
@@ -501,14 +501,14 @@ abstract class AbstractRuntimeTest extends FlatSpec with Matchers {
     val poa = SimpleProjectOperationArguments("", Map(
       "text" -> extraText,
       "message" -> "say this") ++ extraParams)
-    val pas = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(pipeline.defaultFilenameFor(program), program)) + TypeScriptBuilder.userModel
+    val pas = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(pipeline.defaultFilenameFor(program), program))  + TypeScriptBuilder.userModel
     val r = doModification(pas, as, rugAs, poa, pipeline)
     val path = "src/main/java/Dog.java"
     val fO = r.findFile(path)
     if (fO.isEmpty)
       fail(s"Cannot find file at $path")
     val f = fO.get
-    f.content should equal(finalFileContent.getOrElse(
+    assert(f.content === finalFileContent.getOrElse(
       as.findFile("src/main/java/Dog.java").get.content + extraText))
   }
 }

--- a/src/test/scala/com/atomist/rug/ConditionsTest.scala
+++ b/src/test/scala/com/atomist/rug/ConditionsTest.scala
@@ -15,6 +15,7 @@ class ConditionsTest extends FlatSpec with Matchers {
     )
   )
 
+
   it should "use valid precondition in same file using reviewer" in
     validPreconditionInSameFile(
       """
@@ -32,7 +33,7 @@ class ConditionsTest extends FlatSpec with Matchers {
         |with Project when false
       """.stripMargin)
 
-  private def validPreconditionInSameFile(alwaysGripePrecondition: String) {
+  private  def validPreconditionInSameFile(alwaysGripePrecondition: String) {
     def prog(guard: Boolean) =
       s"""
          |editor Redeploy
@@ -52,17 +53,19 @@ class ConditionsTest extends FlatSpec with Matchers {
          |$alwaysGripePrecondition
       """.stripMargin
     val unguarded = create(prog(false))
-    unguarded.applicability(simpleAs).canApply should be(true)
+    assert(unguarded.applicability(simpleAs).canApply === true)
     unguarded.modify(simpleAs, SimpleProjectOperationArguments.Empty)
     match {
       case sm: SuccessfulModification =>
+      
       case _ => ???
     }
     val guarded = create(prog(true))
-    guarded.applicability(simpleAs).canApply should be(false)
+    assert(guarded.applicability(simpleAs).canApply === false)
     guarded.modify(simpleAs, SimpleProjectOperationArguments.Empty)
     match {
       case nmn: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
@@ -121,20 +124,22 @@ class ConditionsTest extends FlatSpec with Matchers {
 
     for (doit <- shouldDoIts) {
       val ja = create(doit)
-      ja.applicability(simpleAs).canApply should be(true)
+      assert(ja.applicability(simpleAs).canApply === true)
       ja.modify(simpleAs, SimpleProjectOperationArguments.Empty)
       match {
         case sm: SuccessfulModification =>
+        
         case _ => ???
       }
     }
 
     for (dont <- shouldNotDoIts) {
       val nein = create(dont)
-      nein.applicability(simpleAs).canApply should be(false)
+      assert(nein.applicability(simpleAs).canApply === false)
       nein.modify(simpleAs, SimpleProjectOperationArguments.Empty)
       match {
         case nmn: NoModificationNeeded =>
+        
         case _ => ???
       }
     }
@@ -166,7 +171,7 @@ class ConditionsTest extends FlatSpec with Matchers {
         |minorProblem "I'm a PITA"
       """.stripMargin
     val harmlessGuard = create(prog)
-    harmlessGuard.applicability(simpleAs).canApply should be(true)
+    assert(harmlessGuard.applicability(simpleAs).canApply === true)
     harmlessGuard.modify(simpleAs, SimpleProjectOperationArguments.Empty)
   }
 
@@ -221,7 +226,7 @@ class ConditionsTest extends FlatSpec with Matchers {
     an[InvalidRugUsesException] should be thrownBy create(prog)
   }
 
-  private def postconditionProg(postcondition: String) =
+  private  def postconditionProg(postcondition: String) =
     s"""
        |editor Redeploy
        |
@@ -257,27 +262,29 @@ class ConditionsTest extends FlatSpec with Matchers {
 
   it should "use no postcondition" in {
     val unguarded = create(postconditionProg(""))
-    unguarded.applicability(simpleAs).canApply should be(true)
+    assert(unguarded.applicability(simpleAs).canApply === true)
     unguarded.meetsPostcondition(simpleAs) should be(false)
     unguarded.modify(simpleAs, SimpleProjectOperationArguments.Empty) match {
       case sm: SuccessfulModification =>
+      
       case _ => ???
     }
   }
 
   it should "use always fails postcondition in same file" in {
     val guarded = create(postconditionProg("postcondition AlwaysGripe"))
-    guarded.applicability(simpleAs).canApply should be(true)
+    assert(guarded.applicability(simpleAs).canApply === true)
     guarded.meetsPostcondition(simpleAs) should be(false)
     guarded.modify(simpleAs, SimpleProjectOperationArguments.Empty) match {
       case fm: FailedModificationAttempt =>
+      
       case _ => ???
     }
   }
 
   it should "use verifying postcondition in same file" in {
     val guarded2 = create(postconditionProg("postcondition DidIt"))
-    guarded2.applicability(simpleAs).canApply should be(true)
+    assert(guarded2.applicability(simpleAs).canApply === true)
     guarded2.meetsPostcondition(simpleAs) should be(false)
     guarded2.modify(simpleAs, SimpleProjectOperationArguments.Empty) match {
       case sm: SuccessfulModification =>
@@ -292,11 +299,12 @@ class ConditionsTest extends FlatSpec with Matchers {
     guarded2.meetsPostcondition(simpleAs) should be(true)
     guarded2.modify(simpleAs, SimpleProjectOperationArguments.Empty) match {
       case sm: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
 
-  private def create(prog: String): ProjectEditor = {
+  private  def create(prog: String): ProjectEditor = {
     val filename = "whatever.txt"
 
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)

--- a/src/test/scala/com/atomist/rug/FailureModeTest.scala
+++ b/src/test/scala/com/atomist/rug/FailureModeTest.scala
@@ -21,6 +21,7 @@ class FailureModeTest extends FlatSpec with Matchers {
       """.stripMargin
     tryMod(prog) match {
       case n: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
@@ -37,11 +38,12 @@ class FailureModeTest extends FlatSpec with Matchers {
       """.stripMargin
     tryMod(prog) match {
       case f: FailedModificationAttempt if f.failureExplanation == msg =>
+      
       case _ => ???
     }
   }
 
-  private def tryMod(prog: String): ModificationAttempt = {
+  private  def tryMod(prog: String): ModificationAttempt = {
     val filename = "whatever.txt"
     val as = new SimpleFileBasedArtifactSource("name",
       Seq(
@@ -49,9 +51,10 @@ class FailureModeTest extends FlatSpec with Matchers {
       )
     )
 
+
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
     val eds = runtime.createFromString(prog)
-    eds.size should be (1)
+    assert(eds.size === 1)
     val pe = eds.head.asInstanceOf[ProjectEditor]
     pe.modify(as, SimpleProjectOperationArguments.Empty)
   }

--- a/src/test/scala/com/atomist/rug/ImportTest.scala
+++ b/src/test/scala/com/atomist/rug/ImportTest.scala
@@ -8,11 +8,11 @@ class ImportTest extends FlatSpec with Matchers {
 
   it should "get simple name from default package" in {
     val imp = Import(simpleName1)
-    imp.simpleName should equal (simpleName1)
+    assert(imp.simpleName === simpleName1)
   }
 
   it should "get simple name from non-default package" in {
     val imp = Import(s"com.foo.bar.$simpleName1")
-    imp.simpleName should equal (simpleName1)
+    assert(imp.simpleName === simpleName1)
   }
 }

--- a/src/test/scala/com/atomist/rug/PathExtractionTest.scala
+++ b/src/test/scala/com/atomist/rug/PathExtractionTest.scala
@@ -25,6 +25,7 @@ class PathExtractionTest extends FlatSpec with Matchers {
       """.stripMargin
     val rp = new DefaultRugPipeline
 
+
     val as = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(rp.defaultFilenameFor(prog), prog))
     val ed = rp.create(as,None).head
 
@@ -32,7 +33,7 @@ class PathExtractionTest extends FlatSpec with Matchers {
     ed.asInstanceOf[ProjectEditor].modify(project, SimpleProjectOperationArguments.Empty) match {
       case sm: SuccessfulModification =>
         val f = sm.result.findFile("src/main/resources/application.properties").get
-        f.content should equal("foo=bar")
+        assert(f.content === "foo=bar")
       case _ => ???
     }
   }
@@ -50,7 +51,9 @@ class PathExtractionTest extends FlatSpec with Matchers {
       """.stripMargin
     val rp = new DefaultRugPipeline
 
+
     val rugAs = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(rp.defaultFilenameFor(prog), prog))
+
 
     val ed = rp.create(rugAs,None).head
 
@@ -77,7 +80,9 @@ class PathExtractionTest extends FlatSpec with Matchers {
       """.stripMargin
     val rp = new DefaultRugPipeline
 
+
     val rugAs = new SimpleFileBasedArtifactSource("", StringFileArtifact("editor/LineCommenter.rug", prog))
+
 
     val ed = rp.create(rugAs,None).head
 

--- a/src/test/scala/com/atomist/rug/ReviewerExecutionTest.scala
+++ b/src/test/scala/com/atomist/rug/ReviewerExecutionTest.scala
@@ -48,9 +48,9 @@ class ReviewerExecutionTest extends FlatSpec with Matchers {
         """.stripMargin))
     val comment = "EJB Alert! EJB Alert!"
     val rr = review(as, ejbFinder(comment))
-    rr.comments.size should be (1)
-    rr.comments.head.comment should equal(comment)
-    rr.comments.head.severity should equal(MAJOR)
+    assert(rr.comments.size === 1)
+    assert(rr.comments.head.comment === comment)
+    assert(rr.comments.head.severity === MAJOR)
   }
 
   it should "not find pattern when not present" in {
@@ -61,8 +61,8 @@ class ReviewerExecutionTest extends FlatSpec with Matchers {
         """.stripMargin))
     val comment = "EJB Alert! EJB Alert!"
     val rr = review(as, ejbFinder(comment))
-    rr.comments.size should be (0)
-    rr.severity should be (FINE)
+    assert(rr.comments.size === 0)
+    assert(rr.severity === FINE)
   }
 
   it should "execute two reviewers" in {
@@ -76,14 +76,14 @@ class ReviewerExecutionTest extends FlatSpec with Matchers {
     val comment2 = "Needs Juergenization"
     val prog = combined + "\n" + alwaysGripe(comment2) + "\n" + ejbFinder(comment)
     val rr = review(as, prog)
-    rr.comments.size should be(2)
-    rr.comments.head.comment should equal(comment)
-    rr.comments.head.severity should equal(MAJOR)
-    rr.comments(1).comment should equal(comment2)
-    rr.comments(1).severity should equal(POLISH)
+    assert(rr.comments.size === 2)
+    assert(rr.comments.head.comment === comment)
+    assert(rr.comments.head.severity === MAJOR)
+    assert(rr.comments(1).comment === comment2)
+    assert(rr.comments(1).severity === POLISH)
   }
 
-  private def review(as: ArtifactSource, prog: String): ReviewResult = {
+  private  def review(as: ArtifactSource, prog: String): ReviewResult = {
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
     val eds = runtime.createFromString(prog)
     val pe = eds.head.asInstanceOf[ProjectReviewer]

--- a/src/test/scala/com/atomist/rug/RugCompilerTest.scala
+++ b/src/test/scala/com/atomist/rug/RugCompilerTest.scala
@@ -23,6 +23,7 @@ object RugCompilerTest extends LazyLogging {
     )
   )
 
+
   def show(as: ArtifactSource): Unit = {
     as.allFiles.foreach(f => {
       logger.debug(f.path + "\n" + f.content + "\n\n")
@@ -37,6 +38,7 @@ class RugCompilerTest extends FlatSpec with Matchers {
   val compiler: RugCompiler = new DefaultRugCompiler(
     new DefaultEvaluator(fr),
     DefaultTypeRegistry)
+
 
   it should "demand referenced kinds exist" in {
     val bogusType = "what_in_gods_holy_name_are_you_blathering_about"
@@ -90,6 +92,7 @@ class RugCompilerTest extends FlatSpec with Matchers {
     FixedRugFunctionRegistry(
       Map(
         "absquatulate" -> new LambdaPredicate[FileMutableView]("absquatulate", f => true)
+      
       )
     )
 
@@ -118,7 +121,7 @@ class RugCompilerTest extends FlatSpec with Matchers {
     val program = RugEditor("foobar", None, Nil, "something goes here", Nil, Nil, None, Nil, Nil,
       Seq(With("File", "f", None, fileExpression, Seq(doStep))))
     val pe = compiler.compile(program)
-    pe.name should equal(program.name)
+    assert(pe.name === program.name)
   }
 
   it should "expose correct parameters" in {
@@ -129,23 +132,23 @@ class RugCompilerTest extends FlatSpec with Matchers {
       Seq(With("File", "f", None, fileExpression, Seq(doStep))))
 
     val pe = compiler compile program
-    pe.parameters.size should be(1)
-    pe.parameters.head should equal(p1)
+    assert(pe.parameters.size === 1)
+    assert(pe.parameters.head === p1)
   }
 
   it should "use supplied editor name" in {
     val name = "someName"
     val pe = simpleEditor(name)
-    pe.name should equal(name)
+    assert(pe.name === name)
   }
 
   it should "expose no parameters unless declared" in {
     val name = "someName"
     val pe = simpleEditor(name)
-    pe.parameters.size should be(0)
+    assert(pe.parameters.size === 0)
   }
 
-  private def simpleEditor(name: String): ProjectEditor = {
+  private  def simpleEditor(name: String): ProjectEditor = {
     val fileExpression = ParsedRegisteredFunctionPredicate("isJava")
     val doStep = FunctionDoStep("name")
     val program = RugEditor(name, None, Nil, name, Nil, Nil, None, Nil, Nil,

--- a/src/test/scala/com/atomist/rug/RugPackagingTest.scala
+++ b/src/test/scala/com/atomist/rug/RugPackagingTest.scala
@@ -12,13 +12,14 @@ class RugPackagingTest extends FlatSpec with Matchers {
 
   val rp = new DefaultRugPipeline()
 
+
   it should "compile validly packaged programs" in {
     val as = new SimpleFileBasedArtifactSource("", Seq(
       StringFileArtifact(fileBase + "First.rug", "editor First  Second"),
       StringFileArtifact(fileBase + "Second.rug", "editor Second with File f do setName 'foo'")
     ))
     val ops = rp.create(as, None, Nil)
-    ops.size should be(2)
+    assert(ops.size === 2)
   }
 
   it should "reject invalidly packaged programs" in {
@@ -33,7 +34,7 @@ class RugPackagingTest extends FlatSpec with Matchers {
     val as = new SimpleFileBasedArtifactSource("", Seq(
       StringFileArtifact(fileBase + "First.rug", "editor First Second\neditor Second with File f do setName 'foo'")
     ))
-    rp.create(as, None).size should be (2)
+    assert(rp.create(as, None).size === 2)
   }
 
   it should "reject multiple programs in single source file with non-matching name" in {

--- a/src/test/scala/com/atomist/rug/UsesTest.scala
+++ b/src/test/scala/com/atomist/rug/UsesTest.scala
@@ -19,6 +19,7 @@ class UsesTest extends FlatSpec with Matchers {
     )
   )
 
+
   it should "not allow using unknown editor" in {
     val prog =
       """
@@ -82,9 +83,9 @@ class UsesTest extends FlatSpec with Matchers {
     pe.modify(simpleAs, SimpleProjectOperationArguments.Empty)
     match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(1)
+        assert(sm.result.totalFileCount === 1)
         // Check that both editors ran
-        sm.result.findFile("filename").get.content should equal("foo bar")
+        assert(sm.result.findFile("filename").get.content === "foo bar")
       case _ => ???
     }
   }
@@ -107,12 +108,12 @@ class UsesTest extends FlatSpec with Matchers {
       """.stripMargin
     val namespace = "com.foobar"
     val pe = create(prog, Some(namespace)).find(_.name.equals(namespace + ".Redeploy")).get
-    pe.name should equal(namespace + ".Redeploy")
+    assert(pe.name === namespace + ".Redeploy")
     pe.modify(simpleAs, SimpleProjectOperationArguments.Empty) match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(1)
+        assert(sm.result.totalFileCount === 1)
         // Check that both editors ran
-        sm.result.findFile("filename").get.content should equal("foo bar")
+        assert(sm.result.findFile("filename").get.content === "foo bar")
       case _ => ???
     }
   }
@@ -143,9 +144,9 @@ class UsesTest extends FlatSpec with Matchers {
     pe.modify(simpleAs, SimpleProjectOperationArguments.Empty)
     match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(1)
+        assert(sm.result.totalFileCount === 1)
         // Check that both editors ran
-        sm.result.findFile("filename").get.content should equal("foo baz")
+        assert(sm.result.findFile("filename").get.content === "foo baz")
       case _ => ???
     }
   }
@@ -173,12 +174,12 @@ class UsesTest extends FlatSpec with Matchers {
     val namespace = "com.foobar"
     val foo = create(global, Some("foo")).head
     val pe = create(prog, Some(namespace), Seq(foo)).head
-    pe.name should equal(namespace + ".Redeploy")
+    assert(pe.name === namespace + ".Redeploy")
     pe.modify(simpleAs, SimpleProjectOperationArguments.Empty) match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(1)
+        assert(sm.result.totalFileCount === 1)
         // Check that both editors ran
-        sm.result.findFile("filename").get.content should equal("foo bar")
+        assert(sm.result.findFile("filename").get.content === "foo bar")
       case _ => ???
     }
   }
@@ -198,7 +199,7 @@ class UsesTest extends FlatSpec with Matchers {
         |do replace "some" "bar"
       """.stripMargin
     val ed = create(prog).find(_.name.equals("Redeploy")).get
-    ed.parameters should equal(Nil)
+    assert(ed.parameters === Nil)
   }
 
   it should "export single parameters from used editor" in {
@@ -221,9 +222,9 @@ class UsesTest extends FlatSpec with Matchers {
       """.stripMargin
     val ed = create(prog).find(_.name.equals("Redeploy")).get
     val red = ed.asInstanceOf[RugDrivenProjectEditor]
-    red.program.runs should equal(Seq(RunOtherOperation("Foo", Nil, None, None, None)))
-    ed.parameters.size should be(1)
-    ed.parameters.head.getName should be("foo")
+    assert(red.program.runs === Seq(RunOtherOperation("Foo", Nil, None, None, None)))
+    assert(ed.parameters.size === 1)
+    assert(ed.parameters.head.getName === "foo")
   }
 
   it should "export all extra parameters from imported editor minus ones that are set" in
@@ -232,7 +233,7 @@ class UsesTest extends FlatSpec with Matchers {
   it should "export all extra parameters from imported editor minus ones that are set, in namespace" in
     exportAllExtraParametersFromImportedEditorMinusOnesThatAreSet(Some("foo.bar"))
 
-  private def exportAllExtraParametersFromImportedEditorMinusOnesThatAreSet(namespace: Option[String]) = {
+  private  def exportAllExtraParametersFromImportedEditorMinusOnesThatAreSet(namespace: Option[String]) = {
     val prog =
       """
         |editor Redeploy
@@ -253,8 +254,8 @@ class UsesTest extends FlatSpec with Matchers {
         | do replace "some" "bar"
       """.stripMargin
     val ed = create(prog, namespace).find(_.name.equals(namespace.map(ns => ns + ".").getOrElse("") + "Redeploy")).get
-    ed.parameters.size should be(2)
-    ed.parameters.map(p => p.name).toSet should equal(Set("foo", "bar"))
+    assert(ed.parameters.size === 2)
+    assert(ed.parameters.map(p => p.name).toSet === Set("foo", "bar"))
   }
 
   it should "not export duplicate parameters" in {
@@ -287,8 +288,8 @@ class UsesTest extends FlatSpec with Matchers {
         | do replace "some" "bar"
       """.stripMargin
     val ed = create(prog, None).find(_.name.equals("Redeploy")).get
-    ed.parameters.size should be(2)
-    ed.parameters.map(p => p.name).toSet should equal(Set("foo", "bar"))
+    assert(ed.parameters.size === 2)
+    assert(ed.parameters.map(p => p.name).toSet === Set("foo", "bar"))
   }
 
   it should "preserve parameter ordering per order of editors" in {
@@ -318,7 +319,7 @@ class UsesTest extends FlatSpec with Matchers {
         | do replace "some" "bar"
       """.stripMargin
     val ed = create(prog, None).find(_.name.equals("Redeploy")).get
-    ed.parameters.map(p => p.name).toList should equal(List("foo", "bar", "baz"))
+    assert(ed.parameters.map(p => p.name).toList === List("foo", "bar", "baz"))
     val prog2 =
       """
         |editor Redeploy
@@ -345,7 +346,7 @@ class UsesTest extends FlatSpec with Matchers {
         | do replace "some" "bar"
       """.stripMargin
     val ed2 = create(prog2, None).find(_.name.equals("Redeploy")).get
-    ed2.parameters.map(p => p.name).toList should equal(List("baz", "foo", "bar"))
+    assert(ed2.parameters.map(p => p.name).toList === List("baz", "foo", "bar"))
   }
 
   it should "export for otherwise empty using editor" in
@@ -354,7 +355,7 @@ class UsesTest extends FlatSpec with Matchers {
   it should "export for otherwise empty using namespace" in
     exportForOtherwiseEmpty(Some("whatever"))
 
-  private def exportForOtherwiseEmpty(namespace: Option[String]) {
+  private  def exportForOtherwiseEmpty(namespace: Option[String]) {
     val prog =
       """
         |editor PackageMove
@@ -372,15 +373,16 @@ class UsesTest extends FlatSpec with Matchers {
         |PackageMove
       """.stripMargin
     val ed = create(prog, namespace).find(_.name.equals(namespace.map(ns => ns + ".").getOrElse("") + "ParameterizePackage")).get
-    ed.parameters.size should be(1)
+    assert(ed.parameters.size === 1)
     val red = ed.asInstanceOf[RugDrivenProjectEditor]
-    red.program.runs should equal(Seq(RunOtherOperation("PackageMove", Nil, None, None, None)))
-    red.program.computations.size should be(1)
-    red.program.withs.size should be(0)
-    ed.parameters.map(p => p.name).toSet should equal(Set("new_package"))
+    assert(red.program.runs === Seq(RunOtherOperation("PackageMove", Nil, None, None, None)))
+    assert(red.program.computations.size === 1)
+    assert(red.program.withs.size === 0)
+    assert(ed.parameters.map(p => p.name).toSet === Set("new_package"))
     // Check it works OK with these parameters
     ed.modify(new EmptyArtifactSource(""), SimpleProjectOperationArguments("", Map[String, String]("new_package" -> "test"))) match {
       case nmn: NoModificationNeeded =>
+      
       case _ => ???
     }
     val as = new SimpleFileBasedArtifactSource("", StringFileArtifact("src/main/java/com/atomist/springrest/Dog.java",
@@ -390,6 +392,7 @@ class UsesTest extends FlatSpec with Matchers {
       """.stripMargin))
     ed.modify(as, SimpleProjectOperationArguments("", Map[String, String]("new_package" -> "com.foo"))) match {
       case sm: SuccessfulModification =>
+      
       case _ => ???
     }
   }
@@ -410,15 +413,16 @@ class UsesTest extends FlatSpec with Matchers {
         | PackageMove old_package = "com.atomist.test1", new_package = "com.foo.bar"
       """.stripMargin
     val ed = create(prog, None).find(_.name.equals("ParameterizePackage")).get
-    ed.parameters.size should be(0)
+    assert(ed.parameters.size === 0)
     val red = ed.asInstanceOf[RugDrivenProjectEditor]
-    red.program.runs should equal(Seq(RunOtherOperation("PackageMove", Seq(
+    assert(red.program.runs === Seq(RunOtherOperation("PackageMove", Seq(
       WrappedFunctionArg(SimpleLiteral("com.atomist.test1"), parameterName = Some("old_package")),
       WrappedFunctionArg(SimpleLiteral("com.foo.bar"), parameterName = Some("new_package"))
     ), None, None, None)))
-    red.program.withs.size should be(0)
+    assert(red.program.withs.size === 0)
     ed.modify(JavaTypeUsageTest.NewSpringBootProject, SimpleProjectOperationArguments("", Map[String, String]())) match {
       case sm: SuccessfulModification =>
+      
       case _ => ???
     }
   }
@@ -475,13 +479,13 @@ class UsesTest extends FlatSpec with Matchers {
         | do replace "some" "bar"
       """.stripMargin
     val ed = create(prog).find(_.name.equals("Redeploy")).get
-    ed.parameters.size should be(1)
-    ed.parameters.map(p => p.name).toSet should equal(Set("foo"))
+    assert(ed.parameters.size === 1)
+    assert(ed.parameters.map(p => p.name).toSet === Set("foo"))
   }
 
   it should "validate setting used operation parameters via compute" is pending
 
-  private def create(prog: String, namespace: Option[String] = None, globals: Seq[ProjectEditor] = Nil): Seq[ProjectEditor] = {
+  private  def create(prog: String, namespace: Option[String] = None, globals: Seq[ProjectEditor] = Nil): Seq[ProjectEditor] = {
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
     val rugAs = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(runtime.defaultFilenameFor(prog), prog))
     runtime.create(rugAs,namespace,globals).asInstanceOf[Seq[ProjectEditor]]

--- a/src/test/scala/com/atomist/rug/kind/core/FileMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/core/FileMutableViewTest.scala
@@ -17,7 +17,7 @@ class FileMutableViewTest extends FlatSpec with Matchers {
   it should "return linecount in single line file" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.lineCount should be (1)
+    assert(fmv.lineCount === 1)
   }
 
   it should "return linecount in longer file" in {
@@ -32,7 +32,7 @@ class FileMutableViewTest extends FlatSpec with Matchers {
         |on
       """.stripMargin)
     val fmv = new FileMutableView(f, null)
-    fmv.lineCount should be (9)
+    assert(fmv.lineCount === 9)
   }
 
   it should "handle contains" in {
@@ -55,39 +55,39 @@ class FileMutableViewTest extends FlatSpec with Matchers {
   it should "setPath" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.path should equal (f.path)
-    fmv.dirty should be (false)
+    assert(fmv.path === f.path)
+    assert(fmv.dirty === false)
     val path2 = "foobar/name"
     fmv.setPath(path2)
-    fmv.dirty should be (true)
-    fmv.path should equal (path2)
-    fmv.currentBackingObject.path should equal (path2)
-    fmv.originalBackingObject should equal (f)
+    assert(fmv.dirty === true)
+    assert(fmv.path === path2)
+    assert(fmv.currentBackingObject.path === path2)
+    assert(fmv.originalBackingObject === f)
   }
 
   it should "setName in root" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.name should equal("name")
-    fmv.dirty should be (false)
+    assert(fmv.name === "name")
+    assert(fmv.dirty === false)
     val name2 = "foobar"
     fmv.setName(name2)
-    fmv.dirty should be (true)
-    fmv.path should equal (name2)
-    fmv.currentBackingObject.path should equal (name2)
-    fmv.originalBackingObject should equal (f)
+    assert(fmv.dirty === true)
+    assert(fmv.path === name2)
+    assert(fmv.currentBackingObject.path === name2)
+    assert(fmv.originalBackingObject === f)
   }
 
   it should "setName under path" in {
     val f = StringFileArtifact("foo/name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.name should equal("name")
-    fmv.dirty should be (false)
+    assert(fmv.name === "name")
+    assert(fmv.dirty === false)
     val name2 = "foobar"
     fmv.setName(name2)
-    fmv.dirty should be (true)
-    fmv.originalBackingObject should equal (f)
-    fmv.currentBackingObject.path should equal ("foo/" + name2)
+    assert(fmv.dirty === true)
+    assert(fmv.originalBackingObject === f)
+    assert(fmv.currentBackingObject.path === "foo/" + name2)
   }
 
   it should "verify permissions and unique id after setPath" is pending
@@ -99,43 +99,43 @@ class FileMutableViewTest extends FlatSpec with Matchers {
   it should "setContent" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.content should equal (f.content)
-    fmv.dirty should be (false)
+    assert(fmv.content === f.content)
+    assert(fmv.dirty === false)
     val content2 = "To be or not to be"
     fmv.setContent(content2)
-    fmv.dirty should be (true)
-    fmv.content should equal (content2)
-    fmv.originalBackingObject should equal (f)
+    assert(fmv.dirty === true)
+    assert(fmv.content === content2)
+    assert(fmv.originalBackingObject === f)
   }
 
   it should "handle prepend" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.content should equal (f.content)
-    fmv.dirty should be (false)
+    assert(fmv.content === f.content)
+    assert(fmv.dirty === false)
     val prepended = "To be or not to be"
     fmv.prepend(prepended)
-    fmv.dirty should be (true)
-    fmv.content should equal (prepended + f.content)
-    fmv.originalBackingObject should equal (f)
+    assert(fmv.dirty === true)
+    assert(fmv.content === prepended + f.content)
+    assert(fmv.originalBackingObject === f)
   }
 
   it should "handle append" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.content should equal (f.content)
-    fmv.dirty should be (false)
+    assert(fmv.content === f.content)
+    assert(fmv.dirty === false)
     val appended = "To be or not to be"
     fmv.append(appended)
-    fmv.dirty should be (true)
-    fmv.content should equal (f.content + appended)
-    fmv.originalBackingObject should equal (f)
+    assert(fmv.dirty === true)
+    assert(fmv.content === f.content + appended)
+    assert(fmv.originalBackingObject === f)
   }
 
   it should "return name" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.filename should equal (f.name)
+    assert(fmv.filename === f.name)
   }
 
   it should "not add a string if the text already contains it" in {
@@ -143,9 +143,10 @@ class FileMutableViewTest extends FlatSpec with Matchers {
     val f = StringFileArtifact("name",  initialContent)
     val fmv = new FileMutableView(f, null)
 
+
     val newString: String = " over the lazy dog"
     fmv.mustContain(newString)
-    fmv.content should equal(initialContent + newString)
+    assert(fmv.content === initialContent + newString)
   }
 
   it should "add a string if it isn't already present" in {
@@ -153,8 +154,9 @@ class FileMutableViewTest extends FlatSpec with Matchers {
     val f = StringFileArtifact("name",  initialContent)
     val fmv = new FileMutableView(f, null)
 
+
     fmv.mustContain("over the lazy dog")
-    fmv.content should equal(initialContent)
+    assert(fmv.content === initialContent)
   }
 
   it should "not add a required string twice" in {
@@ -162,18 +164,19 @@ class FileMutableViewTest extends FlatSpec with Matchers {
     val f = StringFileArtifact("name",  initialContent)
     val fmv = new FileMutableView(f, null)
 
+
     fmv.mustContain("over the lazy dog")
     fmv.mustContain("over the lazy dog")
-    fmv.content should equal(initialContent)
+    assert(fmv.content === initialContent)
   }
 
   it should "make file executable" in {
     val f = StringFileArtifact("name.sh", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    fmv.name should equal("name.sh")
-    fmv.dirty should be (false)
+    assert(fmv.name === "name.sh")
+    assert(fmv.dirty === false)
     fmv.makeExecutable()
-    fmv.dirty should be (true)
-    fmv.currentBackingObject.mode should equal (FileArtifact.ExecutableMode)
+    assert(fmv.dirty === true)
+    assert(fmv.currentBackingObject.mode === FileArtifact.ExecutableMode)
   }
 }

--- a/src/test/scala/com/atomist/rug/kind/core/ProjectMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/core/ProjectMutableViewTest.scala
@@ -53,7 +53,7 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     val regexToReplace = "To run locally"
     val replacementText = "To run somewhere else..."
     pmv.regexpReplace(regexToReplace, replacementText)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
     val r = pmv.currentBackingObject
     val readmeFile = r.findFile("README.md").get
     readmeFile.content.contains(replacementText) should be(true)
@@ -65,7 +65,7 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     val regexToReplace = "@project_name"
     val replacementText = "To run somewhere else on @ symbol..."
     pmv.regexpReplace(regexToReplace, replacementText)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
     val r = pmv.currentBackingObject
     val readmeFile = r.findFile("README.md").get
     readmeFile.content.contains(replacementText) should be(true)
@@ -77,7 +77,7 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     val as = ParsingTargets.NewStartSpringIoProject
     as.isInstanceOf[FileSystemArtifactSource] should be(true)
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), as)
-    pmv.name should equal("demo")
+    assert(pmv.name === "demo")
   }
 
   it should "handle path and content replace" in {
@@ -87,7 +87,7 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     val newPackage = "com.foo.bar"
     pmv.replace(oldPackage, newPackage)
     pmv.replaceInPath(oldPackage.replace(".", "/"), newPackage.replace(".", "/"))
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
     val r = pmv.currentBackingObject
     val pingPath = s"src/main/java/${newPackage.replace(".", "/")}/PingController.java"
     val pinger = r.findFile(pingPath).get
@@ -105,15 +105,15 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
       FirstPoa.parameterValues.map(pv => (pv.getName, pv.getValue)).toMap,
       FirstPoa, Nil)
     pmv.mergeTemplates("", newContentDir, ic)
-    pmv.currentBackingObject.totalFileCount should be(3)
+    assert(pmv.currentBackingObject.totalFileCount === 3)
 
     val expectedPath = newContentDir + "/location_was_true.txt"
     // First.mustache
-    pmv.currentBackingObject.findFile(newContentDir + "/" + static1.path).get.content should equal(static1.content)
-    pmv.currentBackingObject.findFile(expectedPath).get.content should equal(FirstExpected)
-    pmv.dirty should be(true)
+    assert(pmv.currentBackingObject.findFile(newContentDir + "/" + static1.path).get.content === static1.content)
+    assert(pmv.currentBackingObject.findFile(expectedPath).get.content === FirstExpected)
+    assert(pmv.dirty === true)
     pmv.changeLogEntries should be(empty)
-    pmv.changeCount should be(1)
+    assert(pmv.changeCount === 1)
   }
 
   // Written in response to community report of failure to preserve changes following this:
@@ -140,16 +140,16 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
       FirstPoa.parameterValues.map(pv => (pv.getName, pv.getValue)).toMap,
       FirstPoa, Nil)
     pmv.merge(templatePath, mergeOutputPath, ic)
-    pmv.currentBackingObject.totalFileCount should be(1)
-    pmv.currentBackingObject.cachedDeltas.size should be(1)
-    pmv.currentBackingObject.findFile(mergeOutputPath).get.content should equal("content")
+    assert(pmv.currentBackingObject.totalFileCount === 1)
+    assert(pmv.currentBackingObject.cachedDeltas.size === 1)
+    assert(pmv.currentBackingObject.findFile(mergeOutputPath).get.content === "content")
     pmv.currentBackingObject.cachedDeltas.exists(d => d.path == mergeOutputPath) should be(true)
 
     pmv.copyEditorBackingFilesWithNewRelativePath(sourceDir = copyInputDir, destinationPath = copyOutputDir)
-    pmv.fileCount should be(2)
-    pmv.currentBackingObject.cachedDeltas.size should be(3)
-    pmv.currentBackingObject.findFile(mergeOutputPath).get.content should equal("content")
-    pmv.currentBackingObject.findFile(copyOutputPath).get.content should equal("file content")
+    assert(pmv.fileCount === 2)
+    assert(pmv.currentBackingObject.cachedDeltas.size === 3)
+    assert(pmv.currentBackingObject.findFile(mergeOutputPath).get.content === "content")
+    assert(pmv.currentBackingObject.findFile(copyOutputPath).get.content === "file content")
     pmv.currentBackingObject.cachedDeltas.exists(_.path == mergeOutputPath) should be(true)
     pmv.currentBackingObject.cachedDeltas.exists(_.path == copyOutputDir) should be(true)
     pmv.currentBackingObject.cachedDeltas.exists(_.path == copyOutputPath) should be(true)
@@ -163,9 +163,9 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     pmv.addFile("src/main/emoji", "\uD83E\uDD17")
     pmv.describeChange("Added valid program in emoji programming language, which will be exclusively " +
       "used by everyone born after 2005")
-    pmv.dirty should be(true)
-    pmv.changeLogEntries.size should be(2)
-    pmv.changeCount should be(2)
+    assert(pmv.dirty === true)
+    assert(pmv.changeLogEntries.size === 2)
+    assert(pmv.changeCount === 2)
   }
 
   it should "count files in a directory" in {
@@ -175,9 +175,9 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), asToEdit)
     pmv.countFilesInDirectory("src") should be(1)
     pmv.countFilesInDirectory("xxx") should be(0)
-    pmv.changeCount should be(0)
-    pmv.dirty should be(false)
-    pmv.changeLogEntries.isEmpty should be(true)
+    assert(pmv.changeCount === 0)
+    assert(pmv.dirty === false)
+    assert(pmv.changeLogEntries.isEmpty === true)
   }
 
   it should "copy files under dir preserving path" in {
@@ -192,10 +192,10 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     ))
     val pmv = new ProjectMutableView(backingAs, outputAs)
     pmv.copyEditorBackingFilesPreservingPath("src")
-    pmv.currentBackingObject.totalFileCount should be(2)
-    pmv.currentBackingObject.findFile(src1.path).get.content should equal(src1.content)
-    pmv.currentBackingObject.findFile(src2.path).get.content should equal(src2.content)
-    pmv.dirty should be(true)
+    assert(pmv.currentBackingObject.totalFileCount === 2)
+    assert(pmv.currentBackingObject.findFile(src1.path).get.content === src1.content)
+    assert(pmv.currentBackingObject.findFile(src2.path).get.content === src2.content)
+    assert(pmv.dirty === true)
   }
 
   it should "copy files under dir preserving path should respect children" in {
@@ -211,13 +211,13 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     ))
     val pmv = new ProjectMutableView(backingAs, outputAs)
     pmv.copyEditorBackingFilesPreservingPath("src")
-    pmv.currentBackingObject.findFile(alreadyThere.path).get should equal(alreadyThere)
+    assert(pmv.currentBackingObject.findFile(alreadyThere.path).get === alreadyThere)
 
-    pmv.currentBackingObject.totalFileCount should be(3)
+    assert(pmv.currentBackingObject.totalFileCount === 3)
 
-    pmv.currentBackingObject.findFile(src1.path).get.content should equal(src1.content)
-    pmv.currentBackingObject.findFile(src2.path).get.content should equal(src2.content)
-    pmv.dirty should be(true)
+    assert(pmv.currentBackingObject.findFile(src1.path).get.content === src1.content)
+    assert(pmv.currentBackingObject.findFile(src2.path).get.content === src2.content)
+    assert(pmv.dirty === true)
   }
 
   it should "copy files under dir preserving path should not allow file specification" in {
@@ -248,71 +248,76 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     ))
     val pmv = new ProjectMutableView(backingAs, outputAs)
     pmv.copyEditorBackingFilesWithNewRelativePath("src", newContentDir)
-    pmv.currentBackingObject.totalFileCount should be(2)
-    pmv.currentBackingObject.findFile(s"$newContentDir/thing").get.content should equal(src1.content)
-    pmv.currentBackingObject.findFile(s"$newContentDir/main/otherThing").get.content should equal(src2.content)
-    pmv.dirty should be(true)
+    assert(pmv.currentBackingObject.totalFileCount === 2)
+    assert(pmv.currentBackingObject.findFile(s"$newContentDir/thing").get.content === src1.content)
+    assert(pmv.currentBackingObject.findFile(s"$newContentDir/main/otherThing").get.content === src2.content)
+    assert(pmv.dirty === true)
   }
 
   it should "handle deleting of a directory" in {
     val project = JavaTypeUsageTest.NewSpringBootProject
     val pmv = new ProjectMutableView(backingTemplates, project)
 
+
     val gitDirectoryPath = s"dirToDelete"
     pmv.directoryExists(gitDirectoryPath) should be(true)
-    pmv.dirty should be(false)
+    assert(pmv.dirty === false)
     pmv.deleteDirectory(gitDirectoryPath)
     pmv.directoryExists(gitDirectoryPath) should be(false)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
   }
 
   it should "handle deleting of a file" in {
     val project = JavaTypeUsageTest.NewSpringBootProject
     val pmv = new ProjectMutableView(backingTemplates, project)
 
+
     val fileToDelete = "src/main/resources/application.properties"
     pmv.fileExists(fileToDelete) should be(true)
-    pmv.dirty should be(false)
+    assert(pmv.dirty === false)
     pmv.deleteFile(fileToDelete)
     pmv.fileExists(fileToDelete) should be(false)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
   }
 
   it should "handle copying a file" in {
     val project = JavaTypeUsageTest.NewSpringBootProject
     val pmv = new ProjectMutableView(backingTemplates, project)
 
+
     val src = "pom.xml"
     val dest = "foobar/pom2.xml"
     pmv.copyFile(src, dest)
-    pmv.dirty should be(true)
-    pmv.currentBackingObject.findFile(dest).get.content should equal(pmv.currentBackingObject.findFile(src).get.content)
+    assert(pmv.dirty === true)
+    assert(pmv.currentBackingObject.findFile(dest).get.content === pmv.currentBackingObject.findFile(src).get.content)
   }
 
   it should "handle creating a directory" in {
     val project = JavaTypeUsageTest.NewSpringBootProject
     val pmv = new ProjectMutableView(backingTemplates, project)
 
+
     val directoryToCreate = "static"
     val pathToDirectory = "src/main/resources"
     val pathAndDirectoryName = pathToDirectory + "/" + directoryToCreate
     pmv.directoryExists(pathAndDirectoryName) should be(false)
-    pmv.dirty should be(false)
+    assert(pmv.dirty === false)
     pmv.addDirectory(directoryToCreate, pathToDirectory)
     pmv.directoryExists(pathAndDirectoryName) should be(true)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
   }
 
   it should "create directory and intermediate directories if not present" in {
     val project = JavaTypeUsageTest.NewSpringBootProject
     val pmv = new ProjectMutableView(backingTemplates, project)
 
+
     val directoryAndIntermdiateDirectoriesToCreate = "src/main/resources/parent/static/stuff"
     pmv.directoryExists(directoryAndIntermdiateDirectoriesToCreate) should be(false)
-    pmv.dirty should be(false)
+    assert(pmv.dirty === false)
     pmv.addDirectoryAndIntermediates(directoryAndIntermdiateDirectoriesToCreate)
     pmv.directoryExists(directoryAndIntermdiateDirectoriesToCreate) should be(true)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
   }
 
   it should "handle empty directory name and path" in {
@@ -320,10 +325,10 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(backingTemplates, project)
     val directoryAndIntermdiateDirectoriesToCreate = ""
     pmv.directoryExists(directoryAndIntermdiateDirectoriesToCreate) should be(false)
-    pmv.dirty should be(false)
+    assert(pmv.dirty === false)
     pmv.addDirectoryAndIntermediates(directoryAndIntermdiateDirectoriesToCreate)
     pmv.directoryExists(directoryAndIntermdiateDirectoriesToCreate) should be(true)
-    pmv.dirty should be(true)
+    assert(pmv.dirty === true)
   }
 
   it should "move a file so that it's not found at its former address" in
@@ -345,18 +350,18 @@ class ProjectMutableViewTest extends FlatSpec with Matchers {
     backingPMV.countFilesInDirectory("xxx") should be(0)
   }
 
-  private def moveAFileAndVerifyNotFoundAtFormerAddress(stuffToDoLater: ProjectMutableView => Unit) = {
+  private  def moveAFileAndVerifyNotFoundAtFormerAddress(stuffToDoLater: ProjectMutableView => Unit) = {
     val project = JavaTypeUsageTest.NewSpringBootProject
     val pmv = new ProjectMutableView(backingTemplates, project)
     val fmv = pmv.files.asScala.head
     val oldPath = fmv.path
-    fmv.dirty should be(false)
+    assert(fmv.dirty === false)
     val newPath = "foobar/name"
     fmv.setPath(newPath)
     stuffToDoLater(pmv)
-    fmv.dirty should be(true)
-    fmv.path should equal(newPath)
-    fmv.currentBackingObject.path should equal(newPath)
+    assert(fmv.dirty === true)
+    assert(fmv.path === newPath)
+    assert(fmv.currentBackingObject.path === newPath)
     pmv.files.asScala.map(_.path).contains(oldPath) should be(false)
     pmv.files.asScala.map(_.path).contains(newPath) should be(true)
   }

--- a/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeTest.scala
@@ -83,8 +83,10 @@ object CSharpFileTypeTest {
 
   def helloWorldProject = new ProjectMutableView(EmptyArtifactSource(), HelloWorldSources)
 
+
   def projectWithBogusCSharp = new ProjectMutableView(EmptyArtifactSource(),
     HelloWorldSources + StringFileArtifact("bogus.cs", "And this is nothing like C#"))
+
 
   def exceptionProject =
     SimpleFileBasedArtifactSource(StringFileArtifact("src/exception.cs", Exceptions))
@@ -97,18 +99,20 @@ class CSharpFileTypeTest extends FlatSpec with Matchers {
 
   val ee: ExpressionEngine = new PathExpressionEngine
 
+
   val csFileType = new CSharpFileType
+
 
   it should "ignore ill-formed file without error" in {
     val cs = new CSharpFileType
     val csharps = cs.findAllIn(projectWithBogusCSharp)
     // Should have silently ignored the bogus file
-    csharps.size should be(1)
+    assert(csharps.size === 1)
   }
 
   it should "parse hello world" in {
     val csharps = csFileType.findAllIn(helloWorldProject)
-    csharps.size should be(1)
+    assert(csharps.size === 1)
   }
 
   it should "parse hello world and write out correctly" in {
@@ -121,7 +125,7 @@ class CSharpFileTypeTest extends FlatSpec with Matchers {
 
   it should "parse hello world into mutable view and write out unchanged" in {
     val csharps = csFileType.findAllIn(helloWorldProject)
-    csharps.size should be(1)
+    assert(csharps.size === 1)
     csharps.head.head match {
       case mtn: MutableContainerMutableView =>
         val content = mtn.value
@@ -132,20 +136,21 @@ class CSharpFileTypeTest extends FlatSpec with Matchers {
   it should "find hello world using path expression" in {
     val expr = "/src//CSharpFile()"
     val rtn = ee.evaluate(helloWorldProject, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
   }
 
   it should "find specification exception class" in {
     val csharps: Option[Seq[TreeNode]] = csFileType.findAllIn(new ProjectMutableView(EmptyArtifactSource(), exceptionProject))
-    csharps.size should be(1)
+    assert(csharps.size === 1)
     val csharpFileNode = csharps.get.head.asInstanceOf[MutableContainerMutableView]
 
     val expr = "//specific_catch_clause//class_type[@value='IndexOutOfRangeException']"
     ee.evaluate(csharpFileNode, PathExpressionParser.parseString(expr), DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
+    
     }
 
-    csharpFileNode.value should equal(Exceptions)
+    assert(csharpFileNode.value === Exceptions)
   }
 
   it should "find file that catches exception class" in {
@@ -153,7 +158,7 @@ class CSharpFileTypeTest extends FlatSpec with Matchers {
     val expr = "/src//*[CSharpFile()//specific_catch_clause//class_type[@value='IndexOutOfRangeException']]"
     ee.evaluate(project, PathExpressionParser.parseString(expr), DefaultTypeRegistry) match {
       case Right(Seq(fileCatchingIndexOutOfRange: FileArtifactBackedMutableView)) =>
-        fileCatchingIndexOutOfRange.path should equal(exceptionProject.allFiles.head.path)
+        assert(fileCatchingIndexOutOfRange.path === exceptionProject.allFiles.head.path)
     }
   }
 }

--- a/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/csharp/CSharpFileTypeUsageTest.scala
@@ -9,10 +9,12 @@ class CSharpFileTypeUsageTest extends AbstractTypeUnderFileTest {
 
   override val typeBeingTested = new CSharpFileType
 
+
   it should "enumerate usings in simple project" in {
     val r = modify("ListImports.ts", HelloWorldSources)
     r match {
       case _: NoModificationNeeded =>
+      
       case wtf => fail(s"Expected NoModificationNeeded, not $wtf")
     }
   }
@@ -20,6 +22,7 @@ class CSharpFileTypeUsageTest extends AbstractTypeUnderFileTest {
   it should "enumerate usings in simple project with ill-formed C#" in {
     modify("ListImports.ts", projectWithBogusCSharp.currentBackingObject) match {
       case _: NoModificationNeeded =>
+      
       case wtf => fail(s"Expected NoModificationNeeded, not $wtf")
     }
   }
@@ -41,6 +44,7 @@ class CSharpFileTypeUsageTest extends AbstractTypeUnderFileTest {
     modify("AddUsingUsingMethod.ts", HelloWorldSources,
       Map("packageName" -> "System")) match {
       case _: NoModificationNeeded =>
+      
       case wtf => fail(s"Expected NoModificationNeeded, not $wtf")
     }
   }
@@ -61,7 +65,7 @@ class CSharpFileTypeUsageTest extends AbstractTypeUnderFileTest {
       Map("newException" -> newExceptionType)) match {
       case sm: SuccessfulModification =>
         val theFile = sm.result.findFile("src/exception.cs").get
-        theFile.content should be (Exceptions.replace("IndexOutOfRangeException", newExceptionType))
+        assert(theFile.content === Exceptions.replace("IndexOutOfRangeException", newExceptionType))
       case wtf => fail(s"Expected SuccessfulModification, not $wtf")
     }
   }
@@ -69,6 +73,7 @@ class CSharpFileTypeUsageTest extends AbstractTypeUnderFileTest {
   it should "navigate up and down tree with TypeScript helper" in {
     modify("NavigateTree.ts", exceptionProject) match {
       case _: NoModificationNeeded =>
+      
       case wtf => fail(s"Expected NoModificationNeeded, not $wtf")
     }
   }

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerFileTypeTestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerFileTypeTestRunnerTest.scala
@@ -55,9 +55,11 @@ class DockerFileTypeTestRunnerTest extends FlatSpec with Matchers with RugTestRu
 
     val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, new SimpleFileBasedArtifactSource("", dockerfile), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+        // Ok
+    
         // Ok
     }
   }

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerfileParserTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerfileParserTest.scala
@@ -6,11 +6,11 @@ import org.scalatest.{FlatSpec, Matchers}
 class DockerfileParserTest extends FlatSpec with Matchers {
 
   it should "parse empty file" in {
-    parse(null).toString should equal("")
+    assert(parse(null).toString === "")
   }
 
   it should "parse simple file" in {
-    parse("FROM java:8-jre").toString should equal("FROM java:8-jre")
+    assert(parse("FROM java:8-jre").toString === "FROM java:8-jre")
   }
 
   it should "parse multiline file" in {

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerfileTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerfileTest.scala
@@ -23,7 +23,7 @@ class DockerfileTest extends FlatSpec with Matchers {
         |ENTRYPOINT ["java"]
         |CMD ["-Xmx1g", "-jar", "test1-0.0.1.jar"]""".stripMargin
 
-    df.toString should equal(expectedContent)
+    assert(df.toString === expectedContent)
   }
 
   it should "update file" in {
@@ -51,7 +51,7 @@ class DockerfileTest extends FlatSpec with Matchers {
         |WORKDIR /opt/dude
         |ENTRYPOINT ["java"]
         |CMD ["-Xmx2g", "-jar", "test1-0.0.1.jar"]""".stripMargin
-    df.toString should equal(expectedContent)
+    assert(df.toString === expectedContent)
   }
 
   it should "get single port via EXPOSE" in {

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmCaseManipulationTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmCaseManipulationTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.OptionValues._
 
 class ElmCaseManipulationTest extends FlatSpec with Matchers {
 
-  private val bodyAppenderUnderUpdateFunction: String =
+  private  val bodyAppenderUnderUpdateFunction: String =
     """
       |editor AddClause
       |
@@ -24,7 +24,7 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
       |
     """.stripMargin
 
-  private val bodyAppenderMatchingOnCaseExpression: String =
+  private  val bodyAppenderMatchingOnCaseExpression: String =
     """
       |editor AddClause
       |
@@ -36,7 +36,7 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
       |
     """.stripMargin
 
-  private val clauseAdderMatchingExpression: String =
+  private  val clauseAdderMatchingExpression: String =
     """
       |editor AddClause
       |
@@ -60,7 +60,7 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
   it should "add clause to case statement matching case expression" in
     addClauseToCase(clauseAdderMatchingExpression)
 
-  private def appendToCase(rugProg: String) {
+  private  def appendToCase(rugProg: String) {
     val todoSource = StringFileArtifact("Main.elm", ElmParserTest.FullProgram)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), rugProg)
     val f = r.findFile("Main.elm").value
@@ -68,7 +68,7 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
     content should include("! []")
   }
 
-  private def addClauseToCase(rugProg: String) {
+  private  def addClauseToCase(rugProg: String) {
     val todoSource = StringFileArtifact("Main.elm", ElmParserTest.FullProgram)
     val expr = "Expression"
     val rhs = "bar"
@@ -85,13 +85,14 @@ class ElmCaseManipulationTest extends FlatSpec with Matchers {
       )
   }
 
-  private def elmExecute(elmProject: ArtifactSource, program: String,
+  private  def elmExecute(elmProject: ArtifactSource, program: String,
                          params: Map[String, String] = Map()): ArtifactSource = {
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
 
+
     val as = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(runtime.defaultFilenameFor(program), program))
     val eds = runtime.create(as,None)
-    eds.size should be(1)
+    assert(eds.size === 1)
     val pe = eds.head.asInstanceOf[ProjectEditor]
 
     val r = pe.modify(elmProject, SimpleProjectOperationArguments("", params))

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmParserCombinatorIndividualProductionTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmParserCombinatorIndividualProductionTest.scala
@@ -9,7 +9,7 @@ class ElmParserCombinatorIndividualProductionTest extends FlatSpec with Matchers
     val input = """ "Foo" """
     val result = ElmParserCombinator.parseProduction(ElmParserCombinator.ElmExpressions.stringConstant, input)
     result match {
-      case sc: StringConstant => sc.s should be ("Foo")
+      case sc: StringConstant => assert(sc.s === "Foo")
       case _ => ???
     }
   }
@@ -25,7 +25,7 @@ class ElmParserCombinatorIndividualProductionTest extends FlatSpec with Matchers
         |            model
       """.stripMargin
     val cs = ElmParserCombinator.parseProduction(ElmParserCombinator.ElmExpressions.caseExpression, input)
-    cs.clauses.size should be (2)
+    assert(cs.clauses.size === 2)
   }
 
   it should "parse this function call" in {
@@ -39,7 +39,7 @@ class ElmParserCombinatorIndividualProductionTest extends FlatSpec with Matchers
 
     val e = ElmParserCombinator.parseProduction(ElmParserCombinator.ElmExpressions.expression, input)
     e match {
-      case fa: ElmFunctionApplication => fa.parameters.size should be(1)
+      case fa: ElmFunctionApplication => assert(fa.parameters.size === 1)
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmParserTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmParserTest.scala
@@ -14,7 +14,7 @@ class ElmParserTest extends FlatSpec with Matchers {
   it should "not lose trailing empty newline when marking up source" in checkMarkingUp(
     "module Todo exposing (..)\n")
 
-  private def checkMarkingUp(starterSource: String) {
+  private  def checkMarkingUp(starterSource: String) {
     val markedUp = ElmParser.markLinesThatAreLessIndented(starterSource)
     val unmarkedUp = ElmParser.unmark(markedUp)
     withClue(s"starter=\n[$starterSource], markedUp=\n[$unmarkedUp]") {
@@ -38,14 +38,14 @@ class ElmParserTest extends FlatSpec with Matchers {
   it should "parse module with .." in {
     val input: String = "module Todo exposing (..)" + restOfModule
     val em = parseAndVerifyCanWriteOutFromParsedStructureUnchanged(input)
-    em.nodeName should equal("Todo")
+    assert(em.nodeName === "Todo")
     em.exposing.isInstanceOf[AllExposing]
   }
 
   it should "parse module with function names and type names" in {
     val input: String = "module Todo exposing (Banana, carrot)" + restOfModule
     val em = parseAndVerifyCanWriteOutFromParsedStructureUnchanged(input)
-    em.nodeName should equal("Todo")
+    assert(em.nodeName === "Todo")
     val exposedNamesAsStrings = em.exposing match {
       case mttns : FunctionNamesExposing => mttns.names.map(_.value)
       case _ => ???
@@ -95,7 +95,7 @@ class ElmParserTest extends FlatSpec with Matchers {
         |import Todo as T
       """.stripMargin
     val em = parseAndVerifyCanWriteOutFromParsedStructureUnchanged(input)
-    em.nodeName should equal("UsesTodo")
+    assert(em.nodeName === "UsesTodo")
     //???
     //em.imports should equal(Seq(Import(moduleName = "Todo", alias = Some("T"))))
   }
@@ -108,7 +108,7 @@ class ElmParserTest extends FlatSpec with Matchers {
         |deet = (1, 2)
       """.stripMargin
     val em = parseAndVerifyCanWriteOutFromParsedStructureUnchanged(input)
-    em.nodeName should equal("Deeter")
+    assert(em.nodeName === "Deeter")
     em.functions.head.body match {
       case ElmTuple(innards) => "yay"
       case _ => ???

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTextInputTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTextInputTest.scala
@@ -72,7 +72,7 @@ class ElmTextInputTest extends FlatSpec with Matchers {
 
     // TODO should really bring this back, but there appears to be an ordering thing and
     // I'm not sure you've implemented all necessary edits
-    content.trim should equal(ElmParserTest.AdvancedProgram)
+    assert(content.trim === ElmParserTest.AdvancedProgram)
   }
 
   it should "add to model" in {

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTypeScriptEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTypeScriptEditorTest.scala
@@ -12,6 +12,7 @@ class ElmTypeScriptEditorTest extends FlatSpec with Matchers {
   val typeScriptPipeline: RugPipeline =
     new CompilerChainPipeline(Seq(new RugTranspiler(), TypeScriptBuilder.compiler))
 
+
   it should "produce a README with a link" in {
     val projectName = "Elminess"
     val after = ElmTypeUsageTest.elmExecute(
@@ -20,7 +21,7 @@ class ElmTypeScriptEditorTest extends FlatSpec with Matchers {
       runtime = typeScriptPipeline)
 
     val maybeReadme = after.findFile("README.md")
-    maybeReadme.isDefined should be(true)
+    assert(maybeReadme.isDefined === true)
     val readme : String = maybeReadme.get.content
 
     readme should (
@@ -30,12 +31,13 @@ class ElmTypeScriptEditorTest extends FlatSpec with Matchers {
     )
   }
 
-  private def singleFileArtifactSource(projectName: String): SimpleFileBasedArtifactSource = {
+  private  def singleFileArtifactSource(projectName: String): SimpleFileBasedArtifactSource = {
     new SimpleFileBasedArtifactSource(
       projectName,
       StringFileArtifact(
         "elm-package.json",
         elmPackageDotJson))
+  
   }
 }
 

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmTypeUsageTest.scala
@@ -18,6 +18,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
   val typeScriptPipeline: RugPipeline =
     new CompilerChainPipeline(Seq(new RugTranspiler()))
 
+
   it should "rename module using native Rug predicate" in doRename(
     """
       |@description "Renames an Elm module"
@@ -37,7 +38,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     """.stripMargin
   )
 
-  private def createElmRenamerClass(param: Boolean, prints: Boolean = false) = {
+  private  def createElmRenamerClass(param: Boolean, prints: Boolean = false) = {
     val p1 = """{name: "old_name", description: "Name of module we're renaming", required: true, maxLength: 100, pattern: "^[A-Z][\w]+$"}"""
     val p2 = """{name: "new_name", description: "New name for the module", required: true, maxLength: 100, pattern: "^[A-Z][\w]+$"}"""
 
@@ -165,7 +166,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     """.stripMargin
   )
 
-  private def doRename(program: String,
+  private  def doRename(program: String,
                        runtime: RugPipeline = new DefaultRugPipeline()) {
     val oldModuleName = "Todo"
     val newModuleName = "Foobar"
@@ -182,6 +183,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
     )
     )
 
+
     val result = elmExecute(elmProject, program, Map(
       "old_name" -> oldModuleName,
       "new_name" -> newModuleName
@@ -189,9 +191,9 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
       runtime = runtime)
 
     val newTodoContent = result.findFile(s"$newModuleName.elm").value.content
-    newTodoContent.trim should equal("module Foobar exposing (..)")
+    assert(newTodoContent.trim === "module Foobar exposing (..)")
     val newUsesTodoContent = result.findFile(usesTodoSource.path).value.content
-    newUsesTodoContent.trim should equal(makeUsesTodoSource(newModuleName).content.trim)
+    assert(newUsesTodoContent.trim === makeUsesTodoSource(newModuleName).content.trim)
   }
 
   it should "rename module directly under project using native Rug predicate" in {
@@ -368,7 +370,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
     val content = r.findFile("Main.elm").value.content
-    content.trim should equal(output.trim)
+    assert(content.trim === output.trim)
   }
 
   it should "rename a simple constant" in {
@@ -395,7 +397,7 @@ class ElmTypeUsageTest extends FlatSpec with Matchers {
 
     val r = elmExecute(new SimpleFileBasedArtifactSource("", todoSource), prog)
     val content = r.findFile("Main.elm").value.content
-    content.trim should equal(output.trim)
+    assert(content.trim === output.trim)
   }
 
   it should "add a value to the model in an advanced program with quotes around any string" in {
@@ -784,15 +786,18 @@ object ElmTypeUsageTest extends FlatSpec {
 
   class TestDidNotModifyException extends RuntimeException
 
+
   def elmExecute(elmProject: ArtifactSource, program: String,
                  params: Map[String, String] = Map(),
                  runtime: RugPipeline = new DefaultRugPipeline(DefaultTypeRegistry)
+                
                 ): ArtifactSource = {
 
     val as = TypeScriptBuilder.compileWithModel(new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(runtime.defaultFilenameFor(program), program)))
     val eds = runtime.create(as,  None)
     if (eds.isEmpty) {
       print(program); throw new Exception("No editor was parsed")
+    
     }
     val pe = eds.head.asInstanceOf[ProjectEditor]
 

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmUpgradeProgramTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmUpgradeProgramTest.scala
@@ -27,7 +27,7 @@ class ElmUpgradeProgramTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", elm)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), editor)
 
-    r.findFile("Main.elm").value.content.lines.find(_.contains("import Foo")).headOption.value should equal("import Foo exposing (fooFunction)")
+    assert(r.findFile("Main.elm").value.content.lines.find(_.contains("import Foo")).headOption.value === "import Foo exposing (fooFunction)")
 
   }
 

--- a/src/test/scala/com/atomist/rug/kind/elm/PredicateTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/PredicateTest.scala
@@ -41,18 +41,20 @@ class PositivePredicateTest extends FlatSpec with Matchers {
 
     val elmProject = new SimpleFileBasedArtifactSource("", Seq(source))
 
+
     val result = elmExecute(elmProject, editor, Map[String, String](),
       runtime = new DefaultRugPipeline())
 
     val carrotContent = result.findFile(s"Banana.elm").value.content
     // TODO: remove the trims! this finds the newline problem
-    carrotContent.trim should equal(expected.trim)
+    assert(carrotContent.trim === expected.trim)
   }
 
   it should "not delete the trailing newline" in pendingUntilFixed {
     val source = StringFileArtifact("Banana.elm", original)
 
     val elmProject = new SimpleFileBasedArtifactSource("", Seq(source))
+
 
     val result = elmExecute(elmProject, editor, Map[String, String](),
       runtime = new DefaultRugPipeline())
@@ -97,6 +99,7 @@ class NegativePredicateTest extends FlatSpec with Matchers {
     val source = StringFileArtifact("Banana.elm", original)
 
     val elmProject = new SimpleFileBasedArtifactSource("", Seq(source))
+
 
     an [TestDidNotModifyException] should be thrownBy {
       elmExecute(elmProject, editor, Map[String, String](),

--- a/src/test/scala/com/atomist/rug/kind/grammar/SimpleMutableContainerTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/grammar/SimpleMutableContainerTreeNodeTest.scala
@@ -16,13 +16,14 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
 
+
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
     soo.pad(line)
 
     val newInputA = "barnacles"
-    soo.dirty should be(false)
+    assert(soo.dirty === false)
     f1.update(newInputA)
-    soo.dirty should be(true)
+    assert(soo.dirty === true)
     val updated =
       soo.value
     updated should equal(newInputA + inputB)
@@ -36,12 +37,14 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
 
+
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
 
+
     val newInputB = "barnacles"
-    soo.dirty should be(false)
+    assert(soo.dirty === false)
     f2.update(newInputB)
-    soo.dirty should be(true)
+    assert(soo.dirty === true)
     soo.pad(line)
     val updated = soo.value
     updated should equal(inputA + newInputB)
@@ -56,12 +59,13 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length))
 
+
     val soo = SimpleMutableContainerTreeNode.wholeInput("x", Seq(f1, f2), line)
 
     val newInputB = "barnacles"
-    soo.dirty should be(false)
+    assert(soo.dirty === false)
     f2.update(newInputB)
-    soo.dirty should be(true)
+    assert(soo.dirty === true)
     val updated = soo.value
     updated should equal(inputA + unmatchedContent + newInputB)
   }
@@ -75,14 +79,15 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 1))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, 1 + inputA.length + unmatchedContent.length))
 
+
     val soo = SimpleMutableContainerTreeNode.wholeInput("x", Seq(f1, f2), line)
     soo.fieldValues.head.nodeName.contains("pad") should be(true)
     soo.childNodes.head.nodeName.contains("pad") should be(false)
 
     val newInputB = "barnacles"
-    soo.dirty should be(false)
+    assert(soo.dirty === false)
     f2.update(newInputB)
-    soo.dirty should be(true)
+    assert(soo.dirty === true)
     val updated = soo.value
     updated should equal(" " + inputA + unmatchedContent + newInputB)
   }
@@ -99,17 +104,20 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length))
 
+
     val ff1 = new MutableTerminalTreeNode("c1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
     val ff2 = new MutableTerminalTreeNode("c2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + bollocks2.length))
 
+
     val f3 = new SimpleMutableContainerTreeNode("c", Seq(ff1, ff2), ff1.startPosition, endOf(line))
+
 
     val soo = SimpleMutableContainerTreeNode.wholeInput("x", Seq(f1, f2, f3), line)
 
     val newInputC = "tentacles"
-    soo.dirty should be(false)
+    assert(soo.dirty === false)
     ff1.update(newInputC)
-    soo.dirty should be(true)
+    assert(soo.dirty === true)
     val updated = soo.value
     val expected = line.replace(inputC, newInputC)
     updated should equal(expected)
@@ -124,7 +132,7 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
   it should "allow add in nested match with trailing spaces" in
     handleLine("    ")
 
-  private def handleLine(trailingPadding: String) {
+  private  def handleLine(trailingPadding: String) {
     val inputA = "foo"
     val inputB = "bar"
     val inputC = "Lisbon"
@@ -136,26 +144,29 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("f1", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("f2", inputB, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length))
 
+
     val ff1 = new MutableTerminalTreeNode("ff1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
     val ff2 = new MutableTerminalTreeNode("ff2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + moreContent.length))
+
 
     val f3 = new SimpleMutableContainerTreeNode("f3", Seq(ff1, ff2), ff1.startPosition, endOf(line),
       significance = TreeNode.Signal)
 
+
     val topLevel = new SimpleMutableContainerTreeNode("full-line", Seq(f1, f2, f3), startOf(line), endOf(line))
     topLevel.pad(line)
 
-    topLevel.value should equal(line)
+    assert(topLevel.value === line)
 
     val newInputD = "tentacles"
-    topLevel.dirty should be(false)
+    assert(topLevel.dirty === false)
     ff2.update(newInputD)
 
-    topLevel.value should equal(line.replace(inputD, newInputD))
+    assert(topLevel.value === line.replace(inputD, newInputD))
 
     f3.appendField(SimpleTerminalTreeNode("what", "dog"))
 
-    topLevel.dirty should be(true)
+    assert(topLevel.dirty === true)
     //println(s"${TreeNodeUtils.toShortString(soo)}")
     val updated = topLevel.value
     val expected = line.replace(inputD, newInputD) + "dog"
@@ -165,7 +176,7 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
   it should "pull up grandchildren of noise container" in
     pullUpGrandKids("woeiruwoeiurowieurowiuer")
 
-  private def pullUpGrandKids(trailingPadding: String) {
+  private  def pullUpGrandKids(trailingPadding: String) {
     val inputA = "foo"
     val inputB = "bar"
     val inputC = "Lisbon"
@@ -177,20 +188,22 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val ff1 = new MutableTerminalTreeNode("ff1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
     val ff2 = new MutableTerminalTreeNode("ff2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + moreContent.length))
 
+
     val f3 = new SimpleMutableContainerTreeNode("f3", Seq(ff1, ff2), ff1.startPosition, endOf(line),
       significance = TreeNode.Noise)
+
 
     val topLevel = new SimpleMutableContainerTreeNode("full-line", Seq(f3), startOf(line), endOf(line), significance = TreeNode.Signal)
     topLevel.fieldValues.contains(ff2) should be(false)
     topLevel.pad(line)
 
-    topLevel.value should equal(line)
+    assert(topLevel.value === line)
 
     val newInputD = "tentacles"
-    topLevel.dirty should be(false)
+    assert(topLevel.dirty === false)
     ff2.update(newInputD)
 
-    topLevel.value should equal(line.replace(inputD, newInputD))
+    assert(topLevel.value === line.replace(inputD, newInputD))
 
     withClue("child nodes should have been pulled up") {
       topLevel.fieldValues.contains(ff1) should be(true)
@@ -209,7 +222,7 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
   it should "pull up great-grandchildren of noise container" in
     pullUpGreatGrandKids("woeiruwoeiurowieurowiuer")
 
-  private def pullUpGreatGrandKids(trailingPadding: String) {
+  private  def pullUpGreatGrandKids(trailingPadding: String) {
     val inputA = "foo"
     val inputB = "bar"
     val inputC = "Lisbon"
@@ -221,20 +234,23 @@ class SimpleMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val ff1 = new MutableTerminalTreeNode("ff1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
     val ff2 = new MutableTerminalTreeNode("ff2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + moreContent.length))
 
+
     val extraNoiseLayer = new SimpleMutableContainerTreeNode("extraNoiseLayer", Seq(ff1, ff2), ff1.startPosition, endOf(line),
       significance = TreeNode.Noise)
 
+
     val f3 = new SimpleMutableContainerTreeNode("f3", Seq(extraNoiseLayer), ff1.startPosition, endOf(line),
       significance = TreeNode.Noise)
+
 
     val topLevel = new SimpleMutableContainerTreeNode("full-line", Seq(f3), startOf(line), endOf(line), significance = TreeNode.Signal)
     topLevel.fieldValues.contains(ff2) should be(false)
     topLevel.pad(line)
 
-    topLevel.value should equal(line)
+    assert(topLevel.value === line)
 
     val newInputD = "tentacles"
-    topLevel.dirty should be(false)
+    assert(topLevel.dirty === false)
     ff2.update(newInputD)
 
     // topLevel.value should equal(line.replace(inputD, newInputD))

--- a/src/test/scala/com/atomist/rug/kind/java/JavaProjectMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/JavaProjectMutableViewTest.scala
@@ -30,13 +30,14 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(new EmptyArtifactSource(""), NewSpringBootProject, DefaultAtomistConfig)
     val jpv = new JavaProjectMutableView(pmv)
 
+
     val oldPackage = "com.atomist.test1"
     jpv.packages.asScala.map(_.name).contains(oldPackage) should be(true)
     jpv.currentBackingObject.allFiles.exists(_.content.contains(oldPackage)) should be(true)
 
     val newPackage = "com.whatever"
     jpv.renamePackage(oldPackage, newPackage)
-    jpv.dirty should be(true)
+    assert(jpv.dirty === true)
 
     val unchanged = jpv.currentBackingObject.allFiles.filter(f => f.name.endsWith(".java")).find(_.content.contains(oldPackage))
     if (unchanged.nonEmpty) {
@@ -49,12 +50,13 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(new EmptyArtifactSource(""), NewSpringBootProject, DefaultAtomistConfig)
     val jpv = new JavaProjectMutableView(pmv)
 
+
     val oldPackage = "com.atomist"
     jpv.currentBackingObject.allFiles.exists(_.content.contains(oldPackage)) should be(true)
 
     val newPackage = "com.whatever"
     jpv.renamePackage(oldPackage, newPackage)
-    jpv.dirty should be(true)
+    assert(jpv.dirty === true)
 
     jpv.currentBackingObject.allFiles.exists(_.content.contains("com.whatever.test1")) should be(true)
 
@@ -85,6 +87,7 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(editorBackingAs, NewSpringBootProject, DefaultAtomistConfig)
     val jpv = new JavaProjectMutableView(pmv)
 
+
     val copiedInDir = "src/main/java/com/foo"
 
     jpv.copyEditorBackingFilesPreservingPath(copiedInDir)
@@ -94,11 +97,11 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
 
     val newPackage = "com.whatever"
     jpv.renamePackage(oldPackage, newPackage)
-    jpv.dirty should be(true)
+    assert(jpv.dirty === true)
 
     jpv.currentBackingObject.allFiles.exists(_.content.contains(newPackage)) should be(true)
     jpv.directoryExists(copiedInDir) should be(false)
-    jpv.currentBackingObject.findDirectory(copiedInDir).isDefined should be(false)
+    assert(jpv.currentBackingObject.findDirectory(copiedInDir).isDefined === false)
 
     val unchanged = jpv.currentBackingObject.allFiles.filter(f => f.name.endsWith(".java")).find(_.content.contains(oldPackage))
     if (unchanged.nonEmpty) {
@@ -126,6 +129,7 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(editorBackingAs, NewSpringBootProject, DefaultAtomistConfig)
     val jpv = new JavaProjectMutableView(pmv)
 
+
     val copiedInDir = "src/main/java/com/foo"
 
     jpv.copyEditorBackingFileOrFail("src/main/java/com/foo/Bar.java")
@@ -140,7 +144,7 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     jpv.renamePackage(oldPackage + ".baz", newPackage + ".newbaz")
 
     jpv.renamePackage(oldPackage, newPackage)
-    jpv.dirty should be(true)
+    assert(jpv.dirty === true)
 
     jpv.currentBackingObject.allFiles.exists(_.content.contains(newPackage)) should be(true)
     jpv.directoryExists(copiedInDir) should be(false)
@@ -165,12 +169,13 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(new EmptyArtifactSource(""), projectToUse, DefaultAtomistConfig)
     val jpv = new JavaProjectMutableView(pmv)
 
+
     val oldPackage = "com.atomist"
     jpv.currentBackingObject.allFiles.exists(_.content.contains(oldPackage)) should be(true)
 
     val newPackage = "com.whatever"
     jpv.renamePackage(oldPackage, newPackage)
-    jpv.dirty should be(true)
+    assert(jpv.dirty === true)
 
     jpv.currentBackingObject.allFiles.exists(_.content.contains("com.whatever.test1")) should be(true)
 
@@ -205,17 +210,18 @@ class JavaProjectMutableViewTest extends FlatSpec with Matchers {
     updateOtherFileRefOnPackageMove(newFile)
   }
 
-  private def updateOtherFileRefOnPackageMove(newFile: FileArtifact): Unit = {
+  private  def updateOtherFileRefOnPackageMove(newFile: FileArtifact): Unit = {
     val projectToUse = NewSpringBootProject + newFile
     val pmv = new ProjectMutableView(new EmptyArtifactSource(""), projectToUse, DefaultAtomistConfig)
     val jpv = new JavaProjectMutableView(pmv)
+
 
     val oldPackage = "com.atomist"
     jpv.currentBackingObject.allFiles.exists(_.content.contains(oldPackage)) should be(true)
 
     val newPackage = "com.whatever"
     jpv.renamePackage(oldPackage, newPackage)
-    jpv.dirty should be(true)
+    assert(jpv.dirty === true)
 
     jpv.currentBackingObject.allFiles.exists(_.content.contains("com.whatever.test1")) should be(true)
 

--- a/src/test/scala/com/atomist/rug/kind/java/JavaSourceMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/JavaSourceMutableViewTest.scala
@@ -11,7 +11,7 @@ class JavaSourceMutableViewTest extends FlatSpec with Matchers {
       .allFiles
       .filter(f => f.name.endsWith(".java"))
       .map(f => new JavaSourceMutableView(f, null))
-      .foreach(f => f.isWellFormed should be(true))
+      .foreach(f => assert(f.isWellFormed === true))
   }
 
   it should "detect ill-formed files" in {

--- a/src/test/scala/com/atomist/rug/kind/java/JavaTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/JavaTypeUsageTest.scala
@@ -58,6 +58,7 @@ object JavaTypeUsageTest extends Matchers {
     )
   )
 
+
   def executeJava(program: String, rugPath: String, as: ArtifactSource = JavaAndText): ArtifactSource = {
     val r = attemptToModify(program, rugPath, as, Map[String, String]())
     r match {
@@ -86,7 +87,8 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
 
   import JavaTypeUsageTest._
 
-  private val tsPipeline = new CompilerChainPipeline(Seq(TypeScriptBuilder.compiler))
+  private  val tsPipeline = new CompilerChainPipeline(Seq(TypeScriptBuilder.compiler))
+
 
   it should "find boot package using let and rug" in {
     val program =
@@ -102,6 +104,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
 
     attemptToModify(program, "editors/PackageFinder.rug", NewSpringBootProject, Map()) match {
       case _: NoModificationNeeded => // Ok
+       // Ok
       case _ => ???
     }
   }
@@ -128,6 +131,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
 
     attemptToModify(program, "editors/PackageFinder.ts", NewSpringBootProject, Map(), runtime = tsPipeline) match {
       case nmn: NoModificationNeeded => // Ok
+       // Ok
       case _ => ???
     }
   }
@@ -337,7 +341,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
       logger.debug(f.path + "\n" + f.content + "\n"))
 
     val f = result.findFile("src/main/java/com/atomist/Dog.java").get
-    result.findFile(dog.path).isDefined should be(false)
+    assert(result.findFile(dog.path).isDefined === false)
     f.content should include("package com.atomist;")
   }
 
@@ -354,11 +358,12 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
 
     val as = new SimpleFileBasedArtifactSource("", Seq(dog, cat, squirrel))
 
+
     val result = executeJava(program,"editors/ClassAnnotated.rug",  as)
     result.allFiles.foreach(f => logger.debug(f.path + "\n" + f.content + "\n"))
 
     val f = result.findFile("src/main/java/com/atomist/Dog.java").get
-    result.findFile(dog.path).isDefined should be(false)
+    assert(result.findFile(dog.path).isDefined === false)
     f.content.contains("package com.atomist;") should be(true)
 
     // Should now import Dog
@@ -379,13 +384,13 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
     val result = executeJava(program, "editors/ClassAnnotated.rug", as)
 
     val f = result.findFile("src/main/java/com/foo/bar/Dingo.java").get
-    result.findFile(dog.path).isDefined should be(false)
+    assert(result.findFile(dog.path).isDefined === false)
     f.content should include("class Dingo")
   }
 
   it should "verify users of renamed class are updated" is pending
 
-  private def annotateClass(program: String): Unit = {
+  private  def annotateClass(program: String): Unit = {
     val result = executeJava(program, "editors/ClassAnnotated.rug")
     val f = result.findFile("src/main/java/Dog.java").get
 
@@ -461,6 +466,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
       """.stripMargin)
     val as = new SimpleFileBasedArtifactSource("", Seq(impl))
 
+
     val (pkg, ann) = ("com.foo", "Baz")
 
     val program =
@@ -489,6 +495,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
       """.stripMargin)
 
     val as = new SimpleFileBasedArtifactSource("", Seq(childFile, parentFile))
+
 
     val (pkg, ann) = ("com.foo", "Baz")
 
@@ -519,6 +526,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
         |}
       """.stripMargin)
     val as = new SimpleFileBasedArtifactSource("", Seq(childFile, parentFile))
+
 
     val (pkg, ann) = ("com.foo", "Baz")
 
@@ -551,6 +559,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
       """.stripMargin)
 
     val as = new SimpleFileBasedArtifactSource("", Seq(notRelevantFile, impl))
+
 
     val newHeader = "It appears that Rod still likes long names"
     val program =
@@ -600,6 +609,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
 
     val as = new SimpleFileBasedArtifactSource("", Seq(interfaceFile, impl))
 
+
     val program =
       s"""
          |editor ClassAnnotated
@@ -624,6 +634,7 @@ class JavaTypeUsageTest extends FlatSpec with Matchers with LazyLogging {
     val abstractFile = StringFileArtifact("src/main/java/AbstractAbsquatulator.java", "public abstract class AbstractAbsquatulator implements Absquatulated {}")
     val concreteFile = StringFileArtifact("src/main/java/Absquatulator.java", "public class Absquatulator extends AbstractAbsquatulator {}")
     val as = new SimpleFileBasedArtifactSource("", Seq(interfaceFile, abstractFile, concreteFile))
+
 
     val program =
       s"""

--- a/src/test/scala/com/atomist/rug/kind/java/SpringBootProjectMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/SpringBootProjectMutableViewTest.scala
@@ -13,7 +13,7 @@ class SpringBootProjectMutableViewTest extends FlatSpec {
   it should "confirm is Spring Boot project" in {
     val sbp = new SpringBootProjectMutableView(new SpringProjectMutableView(
       new JavaProjectMutableView(new ProjectMutableView(EmptyArtifactSource(""), NewSpringBootProject))))
-    sbp.isSpringBoot should be(true)
+    assert(sbp.isSpringBoot === true)
   }
 
   it should "annotate Spring Boot class" in {
@@ -29,21 +29,21 @@ class SpringBootProjectMutableViewTest extends FlatSpec {
   it should "find Spring Boot application class simple name" in {
     val sbp = new SpringBootProjectMutableView(new SpringProjectMutableView(
       new JavaProjectMutableView(new ProjectMutableView(EmptyArtifactSource(""), NewSpringBootProject))))
-    sbp.applicationClassSimpleName should be ("Test1Application")
+    assert(sbp.applicationClassSimpleName === "Test1Application")
     verifyJavaIsWellFormed(sbp.currentBackingObject)
   }
 
   it should "find Spring Boot application class FQN" in {
     val sbp = new SpringBootProjectMutableView(new SpringProjectMutableView(
       new JavaProjectMutableView(new ProjectMutableView(EmptyArtifactSource(""), NewSpringBootProject))))
-    sbp.applicationClassFQN should be ("com.atomist.test1.Test1Application")
+    assert(sbp.applicationClassFQN === "com.atomist.test1.Test1Application")
     verifyJavaIsWellFormed(sbp.currentBackingObject)
   }
 
   it should "find Spring Boot application package" in {
     val sbp = new SpringBootProjectMutableView(new SpringProjectMutableView(
       new JavaProjectMutableView(new ProjectMutableView(EmptyArtifactSource(""), NewSpringBootProject))))
-    sbp.applicationClassPackage should be ("com.atomist.test1")
+    assert(sbp.applicationClassPackage === "com.atomist.test1")
     verifyJavaIsWellFormed(sbp.currentBackingObject)
   }
   

--- a/src/test/scala/com/atomist/rug/kind/java/path/JavaFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/path/JavaFileTypeTest.scala
@@ -17,15 +17,16 @@ class JavaFileTypeTest extends AbstractTypeUnderFileTest {
 
   override val typeBeingTested = new JavaFileType
 
+
   it should "ignore ill-formed file without error" in {
     val javas = typeBeingTested.findAllIn(projectWithBogusJava)
     // Should have silently ignored the bogus file
-    javas.size should be(1)
+    assert(javas.size === 1)
   }
 
   it should "parse hello world" in {
     val javas = typeBeingTested.findAllIn(helloWorldProject)
-    javas.size should be(1)
+    assert(javas.size === 1)
   }
 
   it should "parse hello world and write out correctly" in {
@@ -41,7 +42,7 @@ class JavaFileTypeTest extends AbstractTypeUnderFileTest {
 
   it should "parse hello world into mutable view and write out unchanged" in {
     val javas = typeBeingTested.findAllIn(helloWorldProject)
-    javas.size should be(1)
+    assert(javas.size === 1)
     javas.head.head match {
       case mtn: MutableContainerMutableView =>
         val content = mtn.value
@@ -53,19 +54,19 @@ class JavaFileTypeTest extends AbstractTypeUnderFileTest {
   it should "find hello world using path expression" in {
     val expr = "//JavaFile()"
     val rtn = expressionEngine.evaluate(helloWorldProject, expr, DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
   }
 
   it should "find specific exception catch" in {
     val javas: Option[Seq[TreeNode]] = typeBeingTested.findAllIn(exceptionsProject)
-    javas.size should be(1)
+    assert(javas.size === 1)
     val javaFileNode = javas.get.head.asInstanceOf[MutableContainerMutableView]
 
     val expr = "//catchClause//catchType[@value='ThePlaneHasFlownIntoTheMountain']"
     expressionEngine.evaluate(javaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
-        nodes.head.value should be("ThePlaneHasFlownIntoTheMountain")
+        assert(nodes.size === 1)
+        assert(nodes.head.value === "ThePlaneHasFlownIntoTheMountain")
       case wtf => fail(s"Expression didn't match [$wtf]. The tree was " + TreeNodeUtils.toShorterString(javaFileNode))
     }
   }
@@ -73,7 +74,7 @@ class JavaFileTypeTest extends AbstractTypeUnderFileTest {
   it should "find and modify specific exception catch" in {
     val proj = exceptionsProject
     val javas: Option[Seq[TreeNode]] = typeBeingTested.findAllIn(proj)
-    javas.size should be(1)
+    assert(javas.size === 1)
     val javaFileNode = javas.get.head.asInstanceOf[MutableContainerMutableView]
 
     val newException = "MicturationException"
@@ -81,7 +82,7 @@ class JavaFileTypeTest extends AbstractTypeUnderFileTest {
     val expr = "//catchClause//catchType[@value='ThePlaneHasFlownIntoTheMountain']"
     expressionEngine.evaluate(javaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
+        assert(nodes.size === 1)
         val mut = nodes.head.asInstanceOf[MutableContainerMutableView]
         println(s"Mut content was [${mut.value}]")
         mut.update(newException)
@@ -90,11 +91,11 @@ class JavaFileTypeTest extends AbstractTypeUnderFileTest {
     }
 
     val newContent = Exceptions.content.replaceFirst("ThePlaneHasFlownIntoTheMountain", newException)
-    javaFileNode.value should equal(newContent)
+    assert(javaFileNode.value === newContent)
 
-    javaFileNode.dirty should be(true)
+    assert(javaFileNode.dirty === true)
     val updatedFile = proj.findFile(Exceptions.path)
-    updatedFile.content should be(newContent)
+    assert(updatedFile.content === newContent)
     //updatedFile.dirty should be(true)
   }
 
@@ -106,6 +107,8 @@ object JavaFileTypeTest {
 
   def projectWithBogusJava =
     new ProjectMutableView(EmptyArtifactSource(), SimpleFileBasedArtifactSource(BogusJava))
+
+  /** So simple it doesn't even have a newline */
 
   /** So simple it doesn't even have a newline */
   val HelloWorldJava = StringFileArtifact("Hello.java", "public class Hello { }")
@@ -128,8 +131,12 @@ object JavaFileTypeTest {
   def helloWorldProject =
     new ProjectMutableView(EmptyArtifactSource(), SimpleFileBasedArtifactSource(HelloWorldJava))
 
+
   def exceptionsProject =
     new ProjectMutableView(EmptyArtifactSource(), SimpleFileBasedArtifactSource(Exceptions))
+
+
+
 
 
 }

--- a/src/test/scala/com/atomist/rug/kind/java/spring/ApplicationPropertiesToApplicationYmlEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/java/spring/ApplicationPropertiesToApplicationYmlEditorTest.scala
@@ -14,6 +14,7 @@ class ApplicationPropertiesToApplicationYmlEditorTest extends FlatSpec with Matc
 
   val eap = new ExtractApplicationProperties(JavaAssertions.ApplicationPropertiesFilePath)
 
+
   val SpringDocsSampleFile = StringFileArtifact(JavaAssertions.ApplicationPropertiesFilePath,
     """
       |spring.application.name=cruncher
@@ -38,7 +39,7 @@ class ApplicationPropertiesToApplicationYmlEditorTest extends FlatSpec with Matc
   val SpringDocsSampleArtifactSource = EmptyArtifactSource("") + SpringDocsSampleFile
 
   "ApplicationPropertiesToApplicationYmlEditor" should "not be applicable to empty ArtifactSource" in {
-    ApplicationPropertiesToApplicationYmlEditor.applicability(new EmptyArtifactSource("")).canApply should equal(false)
+    assert(ApplicationPropertiesToApplicationYmlEditor.applicability(new EmptyArtifactSource("")).canApply === false)
   }
 
   it should "transform Spring docs sample" in testAgainst(SpringDocsSampleArtifactSource)
@@ -59,7 +60,7 @@ class ApplicationPropertiesToApplicationYmlEditorTest extends FlatSpec with Matc
     ayml.get.content shouldBe SpringDocsOutputYmlFile.content
   }
 
-  private def testAgainst(as: ArtifactSource): ArtifactSource = {
+  private  def testAgainst(as: ArtifactSource): ArtifactSource = {
     // Read config first for comparison
     // Wouldn't normally call get without checking, but if it fails the test that's fine
     val config = eap(as.findFile(JavaAssertions.ApplicationPropertiesFilePath).get)
@@ -79,7 +80,7 @@ class ApplicationPropertiesToApplicationYmlEditorTest extends FlatSpec with Matc
     }
   }
 
-  private def validateYmlRepresentationOfConfiguration(ymlString: String, config: Configuration): Unit = {
+  private  def validateYmlRepresentationOfConfiguration(ymlString: String, config: Configuration): Unit = {
     logger.debug(s"Config length = ${config.configurationValues.size}, yml=[$ymlString]")
     // ymlString should not equal ""
     // compare to expected yaml

--- a/src/test/scala/com/atomist/rug/kind/json/JsonMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/json/JsonMutableViewTest.scala
@@ -14,13 +14,14 @@ class JsonMutableViewTest extends FlatSpec with Matchers {
 
   val jsonParser = new JsonParser
 
+
   it should "parse and find node in root" in {
     val f = StringFileArtifact("glossary.json", Simple)
     val proj = SimpleFileBasedArtifactSource(f)
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj)
     val j = new JsonMutableView(f, pmv, jsonParser.parse(f.content).get)
     j.nodeTags.contains("Json") should be (true)
-    j.childrenNamed("glossary").size should be(1)
+    assert(j.childrenNamed("glossary").size === 1)
   }
 
   it should "support path find" in {
@@ -31,8 +32,8 @@ class JsonMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj)
     val j = new JsonMutableView(f, pmv, jsonParser.parse(f.content).get)
     val rtn = ee.evaluate(j, expr, DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
-    rtn.right.get.head.asInstanceOf[ContainerTreeNode].childrenNamed("STRING").head.value should be ("S")
+    assert(rtn.right.get.size === 1)
+    assert(rtn.right.get.head.asInstanceOf[ContainerTreeNode].childrenNamed("STRING").head.value === "S")
   }
 
   it should "update path find" in {
@@ -43,11 +44,11 @@ class JsonMutableViewTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj)
     val j = new JsonMutableView(f, pmv, jsonParser.parse(f.content).get)
     val rtn = ee.evaluate(j, expr, DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
     val target = rtn.right.get.head.asInstanceOf[ContainerTreeNode].childrenNamed("STRING").head.asInstanceOf[MutableTreeNode]
-    target.value should be ("markup")
+    assert(target.value === "markup")
     target.update("XSLT")
-    j.value should equal(Simple.replace("\"markup", "\"XSLT"))
+    assert(j.value === Simple.replace("\"markup", "\"XSLT"))
   }
 
   it should "find descendant in project" in {
@@ -57,11 +58,11 @@ class JsonMutableViewTest extends FlatSpec with Matchers {
     val proj = SimpleFileBasedArtifactSource(f)
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj)
     val rtn = ee.evaluate(pmv, expr, DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
     val x = rtn.right.get.head.asInstanceOf[ContainerTreeNode]
-    x.nodeName should be ("GlossSee")
+    assert(x.nodeName === "GlossSee")
     val target = x.childrenNamed("STRING").head.asInstanceOf[MutableTreeNode]
-    target.value should be ("markup")
+    assert(target.value === "markup")
     target.update("XSLT")
     //j.value should equal(Simple.replace("\"markup", "\"XSLT"))
   }

--- a/src/test/scala/com/atomist/rug/kind/pom/EveryPomUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/EveryPomUsageTest.scala
@@ -12,7 +12,7 @@ class EveryPomUsageTest extends FlatSpec with Matchers {
 
   import com.atomist.rug.TestUtils._
 
-  private def runProgAndCheck(as: ArtifactSource, mods: Int): ArtifactSource = {
+  private  def runProgAndCheck(as: ArtifactSource, mods: Int): ArtifactSource = {
     val prog =
       """
         |editor EveryPomEdit
@@ -25,15 +25,16 @@ class EveryPomUsageTest extends FlatSpec with Matchers {
       StringFileArtifact(new DefaultRugPipeline().defaultFilenameFor(prog), prog)
     )
 
+
     val result = doModification(progArtifact, as, EmptyArtifactSource(""),
       SimpleProjectOperationArguments("", Map.empty[String,Object]))
 
-    result.cachedDeltas.size should be(mods)
+    assert(result.cachedDeltas.size === mods)
 
     result
   }
 
-  private val pomFileArtifact = JavaTypeUsageTest.NewSpringBootProject.findFile("pom.xml").get
+  private  val pomFileArtifact = JavaTypeUsageTest.NewSpringBootProject.findFile("pom.xml").get
 
   it should "edit a single pom" in {
     val singlePom: ArtifactSource = new SimpleFileBasedArtifactSource("simple", pomFileArtifact)

--- a/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
@@ -21,15 +21,16 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   var validPomWithDependencyManagement: PomMutableView = _
 
-  private def testConditions(uut: PomMutableView, response: String, expectedResponse: String, dirty: Boolean = false) = {
+  private  def testConditions(uut: PomMutableView, response: String, expectedResponse: String, dirty: Boolean = false) = {
     response should be (expectedResponse)
-    uut.dirty should be (dirty)
+    assert(uut.dirty === dirty)
   }
 
   override def beforeEach() {
     validPomUut = new PomMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
     validPomNoParent = new PomMutableView(pomNoParent, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
     validPomWithDependencyManagement = new PomMutableView(pomWithDependencyManagement, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+  
   }
 
   it should "get the project group id" in {
@@ -287,7 +288,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
   it should "add a new project property" in {
     validPomUut.contains("/project/properties/my.new.property") should be (false)
-    validPomUut.dirty should be (false)
+    assert(validPomUut.dirty === false)
 
     val propertyName = "my.new.property"
     val newValue = "mine-all-mine"
@@ -302,7 +303,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.removeProperty(propertyName)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.property(propertyName) should be ("")
   }
@@ -325,7 +326,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.removeProperty(propertyName)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.property(propertyName) should be ("")
 
@@ -340,7 +341,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependency(dependencyGroupId, dependencyArtifactId)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
   }
@@ -354,7 +355,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependency(dependencyGroupId, dependencyArtifactId, dependencyScope)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
 
@@ -371,7 +372,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependencyOfVersion(dependencyGroupId, dependencyArtifactId, dependencyVersion, dependencyScope)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
 
@@ -388,7 +389,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependency(dependencyGroupId, dependencyArtifactId)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (true)
   }
@@ -402,7 +403,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependencyVersion(dependencyGroupId, dependencyArtifactId, newVersion)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.dependencyVersion(dependencyGroupId, dependencyArtifactId) should be (newVersion)
   }
@@ -442,7 +443,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependencyScope(dependencyGroupId, dependencyArtifactId , newScope)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (newScope)
   }
@@ -457,7 +458,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceDependencyScope(dependencyGroupId, dependencyArtifactId, newScope)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (newScope)
   }
@@ -472,7 +473,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.removeDependencyScope(dependencyGroupId, dependencyArtifactId)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (expectedOutcomeScope)
   }
@@ -487,7 +488,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.removeDependencyScope(dependencyGroupId, dependencyArtifactId)
 
-    validPomUut.dirty should be (false)
+    assert(validPomUut.dirty === false)
 
     validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (expectedOutcomeScope)
   }
@@ -500,7 +501,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.removeDependency(dependencyGroupId, dependencyArtifactId)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isDependencyPresent(dependencyGroupId, dependencyArtifactId) should be (false)
   }
@@ -513,7 +514,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.removeDependency(dependencyGroupId, dependencyArtifactId)
 
-    validPomUut.dirty should be (false)
+    assert(validPomUut.dirty === false)
 
     validPomUut.isDependencyPresent(dependencyArtifactId, dependencyArtifactId) should be (false)
   }
@@ -527,7 +528,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceBuildPlugin(groupId, artifactId, plugin)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isBuildPluginPresent(groupId, artifactId) should be (true)
   }
@@ -544,7 +545,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.addOrReplaceBuildPlugin(groupId, artifactId, plugin)
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isBuildPluginPresent(newGroupId, newArtifactId) should be (true)
     validPomUut.isBuildPluginPresent(groupId, artifactId) should be (false)
@@ -556,7 +557,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.isDependencyManagementDependencyPresent(groupId, artifactId) should be (false)
 
-    validPomUut.dirty should be (false)
+    assert(validPomUut.dirty === false)
   }
 
   it should "be able to test that a dependency management dependency is present when it is" in {
@@ -565,7 +566,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomWithDependencyManagement.isDependencyManagementDependencyPresent(groupId, artifactId) should be (true)
 
-    validPomWithDependencyManagement.dirty should be (false)
+    assert(validPomWithDependencyManagement.dirty === false)
   }
 
   it should "add a dependency management dependency when no dependency management section is present" in {
@@ -577,7 +578,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomUut.contains("/project/dependencyManagement")
 
-    validPomUut.dirty should be (true)
+    assert(validPomUut.dirty === true)
 
     validPomUut.isDependencyManagementDependencyPresent(groupId, artifactId) should be (true)
   }
@@ -592,7 +593,7 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
 
     validPomWithDependencyManagement.addOrReplaceDependencyManagementDependency(groupId, artifactId, dependencyContent)
 
-    validPomWithDependencyManagement.dirty should be (true)
+    assert(validPomWithDependencyManagement.dirty === true)
 
     validPomWithDependencyManagement.isDependencyManagementDependencyPresent(groupId, artifactId) should be (true)
   }

--- a/src/test/scala/com/atomist/rug/kind/properties/PropertiesMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/properties/PropertiesMutableViewTest.scala
@@ -12,6 +12,7 @@ class PropertiesMutableViewTest extends FlatSpec with Matchers {
   "PropertiesMutableView" should "get an existing valid property" in {
     val propertiesView = new PropertiesMutableView(propertiesFile, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     propertiesView.getValue("server.port") should be ("8080")
 
     propertiesView.dirty equals false
@@ -20,6 +21,7 @@ class PropertiesMutableViewTest extends FlatSpec with Matchers {
   it should "fail to get a property that doesn't exist" in {
     val propertiesView = new PropertiesMutableView(propertiesFile, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     propertiesView.getValue("server.portlet") should be ("")
 
     propertiesView.dirty equals false
@@ -27,6 +29,7 @@ class PropertiesMutableViewTest extends FlatSpec with Matchers {
 
   it should "set a property that exists" in {
     val propertiesView = new PropertiesMutableView(propertiesFile, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+
 
     val preExistingPropertyKey = "server.port"
     val newValueToBeSet = "8181"
@@ -37,6 +40,7 @@ class PropertiesMutableViewTest extends FlatSpec with Matchers {
 
   it should "add a property that does not exist" in {
     val propertiesView = new PropertiesMutableView(propertiesFile, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+
 
     val newPropertyKey = "server.portlet"
     val newValueToBeSet = "8181"
@@ -64,16 +68,18 @@ class PropertiesMutableViewTest extends FlatSpec with Matchers {
   it should "provide access to a list of keys" in {
     val propertiesView = new PropertiesMutableView(propertiesFile, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val keys = propertiesView.keys
-    keys.size should be (4)
+    assert(keys.size === 4)
     propertiesView.dirty equals false
   }
 
   it should "add two new properties and format correctly" in {
     val propertiesView = new PropertiesMutableView(propertiesFile, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val keys = propertiesView.keys
-    keys.size should be (4)
+    assert(keys.size === 4)
     propertiesView.dirty equals false
 
     val newPropertyKey1 = "abc"
@@ -83,7 +89,7 @@ class PropertiesMutableViewTest extends FlatSpec with Matchers {
 
     propertiesView.setProperty(newPropertyKey1, newPropertyValue1)
     propertiesView.setProperty(newPropertyKey2, newPropertyValue2)
-    propertiesView.keys.size should be (6)
+    assert(propertiesView.keys.size === 6)
     propertiesView.dirty equals true
 
     propertiesView.getValue(newPropertyKey1) should be (newPropertyValue1)

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonFileTypeTest.scala
@@ -13,14 +13,15 @@ class PythonFileTypeTest extends FlatSpec with Matchers {
 
   import Python3ParserTest._
 
-  private val pex = new PathExpressionEngine
+  private  val pex = new PathExpressionEngine
+
 
   it should "find Python file type using path expression" in {
     val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/setup.py", setupDotPy))
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val expr = "/src/File()/PythonFile()"
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
     //    rtn.right.get.foreach {
     //      case p: PythonFileMutableView =>
     //    }
@@ -34,7 +35,9 @@ class PythonFileTypeTest extends FlatSpec with Matchers {
     rtn.right.get.size should be>(2)
     rtn.right.get.foreach {
       case n: TreeNode if n.value.nonEmpty =>
+      
       case x => //println(s"Was empty: $x")
+     //println(s"Was empty: $x")
     }
   }
 
@@ -46,7 +49,9 @@ class PythonFileTypeTest extends FlatSpec with Matchers {
     rtn.right.get.size should be>(2)
     rtn.right.get.foreach {
       case n: TreeNode if n.value.nonEmpty =>
+      
       case x => //println(s"Was empty: $x")
+     //println(s"Was empty: $x")
     }
   }
 }

--- a/src/test/scala/com/atomist/rug/kind/python3/RequirementsTxtParserTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/RequirementsTxtParserTest.scala
@@ -52,22 +52,22 @@ class RequirementsTxtParserTest extends FlatSpec with Matchers {
 
   it should "return tree and spit out unchanged" in {
     val reqs: TreeNode = RequirementsTxtParser.parseFile(simple1)
-    reqs.value.trim should equal(simple1.trim)
+    assert(reqs.value.trim === simple1.trim)
   }
 
   it should "allow update in place" in {
     val reqs = RequirementsTxtParser.parseFile(simple1)
     val req0 = reqs.requirements.head
-    req0.packageName.value should be("flask")
-    req0.version.get.value should be("0.11.1")
+    assert(req0.packageName.value === "flask")
+    assert(req0.version.get.value === "0.11.1")
     req0.version.get.update("0.12")
-    reqs.value.trim should equal(simple1.trim.replace("0.11.1", "0.12"))
+    assert(reqs.value.trim === simple1.trim.replace("0.11.1", "0.12"))
   }
 
   it should "perform upgrade operation" in {
     val reqs = RequirementsTxtParser.parseFile(simple1)
     reqs.update("flask", "0.12")
-    reqs.value.trim should equal(simple1.trim.replace("0.11.1", "0.12"))
+    assert(reqs.value.trim === simple1.trim.replace("0.11.1", "0.12"))
   }
 
   it should "add requirement" in {
@@ -80,15 +80,15 @@ class RequirementsTxtParserTest extends FlatSpec with Matchers {
 
   it should "parse without versions" in {
     val reqs = parsesOk(noVersions)
-    reqs.requirements.size should be(3)
+    assert(reqs.requirements.size === 3)
   }
 
   it should "parse with versions" in {
     val reqs = parsesOk(withVersions)
-    reqs.requirements.size should be(4)
+    assert(reqs.requirements.size === 4)
   }
 
-  private def parsesOk(content: String): Requirements = {
+  private  def parsesOk(content: String): Requirements = {
     val reqs = RequirementsTxtParser.parseFile(content)
     reqs
   }

--- a/src/test/scala/com/atomist/rug/kind/python3/RequirementsTxtTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/RequirementsTxtTypeUsageTest.scala
@@ -20,7 +20,7 @@ abstract class RequirementsTxtTypeUsageTest extends FlatSpec with Matchers {
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
     val as = new SimpleFileBasedArtifactSource("", StringFileArtifact("editor/LineCommenter.rug", program))
     val eds = runtime.create(as,None)
-    eds.size should be(1)
+    assert(eds.size === 1)
     val pe = eds.head.asInstanceOf[ProjectEditor]
     pe.modify(as, SimpleProjectOperationArguments("", params))
   }
@@ -93,6 +93,7 @@ abstract class RequirementsTxtTypeUsageTest extends FlatSpec with Matchers {
     val r = exec(prog, bad)
     r match {
       case nm: NoModificationNeeded =>
+      
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/rug/kind/rug/RugArchiveTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/rug/RugArchiveTypeTest.scala
@@ -37,10 +37,12 @@ class RugArchiveTypeTest extends FlatSpec
       Seq(StringFileArtifact(".atomist/editors/BananaToCarrot.rug", StartingRug
     )))
 
+
   val InputProject =
     new SimpleFileBasedArtifactSource("my-rug-archive",
       Seq(StringFileArtifact("whatever.txt", "armadillo banana carrots"
       )))
+
 
   it should "convert a rug to TS" in {
     val resultOfRugEditor = executeRug(StartingRug, InputProject)
@@ -49,7 +51,7 @@ class RugArchiveTypeTest extends FlatSpec
       StartingProject, Map("rug_name" -> "BananaToCarrot"))
 
     val tsEditorFile = result.findFile(".atomist/editors/BananaToCarrot.ts")
-    tsEditorFile.isDefined should be(true)
+    assert(tsEditorFile.isDefined === true)
     val tsEditor = tsEditorFile.get.content
     //println("it turned into: " + tsEditor)
 
@@ -60,8 +62,8 @@ class RugArchiveTypeTest extends FlatSpec
   }
 
   def singleFileArtifactSourcesAreEquivalent(as1: ArtifactSource, as2: ArtifactSource): Boolean = {
-    as1.allFiles.size should be(1)
-    as2.allFiles.size should be(1)
+    assert(as1.allFiles.size === 1)
+    assert(as2.allFiles.size === 1)
 
     val as1Name = as1.allFiles.head.path
     val as2Name = as2.allFiles.head.path

--- a/src/test/scala/com/atomist/rug/kind/rug/RugEditorTestHelper.scala
+++ b/src/test/scala/com/atomist/rug/kind/rug/RugEditorTestHelper.scala
@@ -15,14 +15,16 @@ trait RugEditorTestHelper extends Matchers {
                  params: Map[String, String] = Map()): ArtifactSource = {
     val runtime = new DefaultRugPipeline(DefaultTypeRegistry)
 
+
     val editorName = parseRugForEditorName(program)
     val editorPath = s".atomist/editors/$editorName.rug"
 
     val rugArchive = new SimpleFileBasedArtifactSource(DefaultRugArchive,
       StringFileArtifact(editorPath, program))
 
+
     val eds = runtime.create(rugArchive,None)
-    eds.size should be(1)
+    assert(eds.size === 1)
     val pe = eds.head.asInstanceOf[ProjectEditor]
 
     val r = pe.modify(startingProject, SimpleProjectOperationArguments("", params))
@@ -34,7 +36,7 @@ trait RugEditorTestHelper extends Matchers {
     }
   }
 
-  private def parseRugForEditorName(program: String) =
+  private  def parseRugForEditorName(program: String) =
     new ParserCombinatorRugParser().parse(program).head.name
 
 }

--- a/src/test/scala/com/atomist/rug/kind/rug/RugFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/rug/RugFileTypeTest.scala
@@ -131,31 +131,37 @@ object RugFileTypeTest {
       StringFileArtifact("HelloProject.rug", HelloProject)
     ))
 
+
   val DumbAndDumberGenerator: ArtifactSource = new SimpleFileBasedArtifactSource("name",
     Seq(
       StringFileArtifact("DumbGenerator.rug", DumbGenerator),
       StringFileArtifact("DumberGenerator.rug", DumberGenerator)
     ))
 
+
   val TwoEditors: ArtifactSource = new SimpleFileBasedArtifactSource("name",
     Seq(
       StringFileArtifact("TwoEditors.rug", SomeEditors)
     ))
+
 
   val ManyParamsEditor: ArtifactSource = new SimpleFileBasedArtifactSource("name",
     Seq(
       StringFileArtifact("ManyParamsEditor.rug", ManyParams)
     ))
 
+
   val UsesVariousEditor: ArtifactSource = new SimpleFileBasedArtifactSource("name",
     Seq(
       StringFileArtifact("UsesVariousEditor.rug", UsesVarious)
     ))
 
+
   val SomeUsingSemverEditor: ArtifactSource = new SimpleFileBasedArtifactSource("name",
     Seq(
       StringFileArtifact("SomeUsingSemverEditor.rug", SomeUsingSemver)
     ))
+
 
   val UsingOldGeneratorAnnotationEditor: ArtifactSource = new SimpleFileBasedArtifactSource("name",
     Seq(
@@ -163,14 +169,19 @@ object RugFileTypeTest {
     ))
 
 
+
+
   def helloProjectEditorProject = new ProjectMutableView(EmptyArtifactSource(),
     HelloProjectEditor)
+
 
   def multiRugsInASingleRugFile = new ProjectMutableView(EmptyArtifactSource(),
     TwoEditors)
 
+
   def rugArchive = new ProjectMutableView(EmptyArtifactSource(),
     HelloProjectEditor + DumbAndDumberGenerator + TwoEditors + UsingOldGeneratorAnnotationEditor)
+
 }
 
 class RugFileTypeTest extends FlatSpec with Matchers {
@@ -179,7 +190,9 @@ class RugFileTypeTest extends FlatSpec with Matchers {
 
   val ee: ExpressionEngine = new PathExpressionEngine
 
+
   val rugFileType = new RugFileType
+
 
   it should "load a basic Rug" in {
     val rugs = rugFileType.findAllIn(helloProjectEditorProject)
@@ -188,7 +201,7 @@ class RugFileTypeTest extends FlatSpec with Matchers {
 
   it should "parse a Rug into mutable view and write out unchanged" in {
     val rugs = rugFileType.findAllIn(helloProjectEditorProject)
-    rugs.size should be(1)
+    assert(rugs.size === 1)
     rugs.head.head match {
       case mtn: MutableContainerMutableView =>
         val content = mtn.value

--- a/src/test/scala/com/atomist/rug/kind/rug/RugFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/rug/RugFileTypeUsageTest.scala
@@ -6,7 +6,8 @@ import com.atomist.project.edit.{NoModificationNeeded, SuccessfulModification}
 
 class RugFileTypeUsageTest extends AbstractTypeUnderFileTest {
 
-  override protected def typeBeingTested: AntlrRawFileType = new RugFileType
+  override protected  def typeBeingTested: AntlrRawFileType = new RugFileType
+
 
   import RugFileTypeTest._
 
@@ -14,6 +15,7 @@ class RugFileTypeUsageTest extends AbstractTypeUnderFileTest {
     val r = modify("ListEditors.ts", TwoEditors)
     r match {
       case nmn: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
@@ -22,6 +24,7 @@ class RugFileTypeUsageTest extends AbstractTypeUnderFileTest {
     val r = modify("ListParams.ts", ManyParamsEditor)
     r match {
       case nmn: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
@@ -30,6 +33,7 @@ class RugFileTypeUsageTest extends AbstractTypeUnderFileTest {
     val r = modify("ListUses.ts", UsesVariousEditor)
     r match {
       case nmn: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
@@ -38,6 +42,7 @@ class RugFileTypeUsageTest extends AbstractTypeUnderFileTest {
     val r = modify("ListEditorsUsingSemanticVersion.ts", SomeUsingSemverEditor)
     r match {
       case nmn: NoModificationNeeded =>
+      
       case _ => ???
     }
   }
@@ -46,9 +51,10 @@ class RugFileTypeUsageTest extends AbstractTypeUnderFileTest {
     val r = modify("ReplaceEditorWithGenerator.ts", UsingOldGeneratorAnnotationEditor)
     r match {
       case nmn: NoModificationNeeded =>
+      
       case sma: SuccessfulModification =>
         val rugs = sma.result.files.filter(_.name.endsWith(".rug"))
-        rugs.size should equal(1)
+        assert(rugs.size === 1)
         rugs.foreach(f => {
           f.content contains "@generator \"UberGenerator\"" should be(false)
           f.content contains "editor UberGenerator" should be(false)

--- a/src/test/scala/com/atomist/rug/kind/rug/TypeScriptEditorTestHelper.scala
+++ b/src/test/scala/com/atomist/rug/kind/rug/TypeScriptEditorTestHelper.scala
@@ -15,6 +15,7 @@ trait TypeScriptEditorTestHelper extends Matchers {
   val typeScriptPipeline: RugPipeline =
     new CompilerChainPipeline(Seq(new RugTranspiler(), TypeScriptBuilder.compiler))
 
+
   def executeTypescript(editorName: String, program: String,
                                       target: ArtifactSource,
                                       params: Map[String, String] = Map(),
@@ -30,10 +31,12 @@ trait TypeScriptEditorTestHelper extends Matchers {
 
     if (eds.isEmpty) {
       print(program); throw new Exception("No editor was parsed")
+    
     }
 
+
     val jsed = eds.head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be(editorName)
+    assert(jsed.name === editorName)
     jsed.setContext(others)
 
     val pe = eds.head.asInstanceOf[ProjectEditor]

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaFileTypeTest.scala
@@ -17,15 +17,16 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
 
   override val typeBeingTested = new ScalaFileType
 
+
   it should "ignore ill-formed file without error" in {
     val scalas = typeBeingTested.findAllIn(projectWithBogusScala)
     // Should have silently ignored the bogus file
-    scalas.size should be(1)
+    assert(scalas.size === 1)
   }
 
   it should "parse hello world" in {
     val scalas = typeBeingTested.findAllIn(helloWorldProject)
-    scalas.size should be(1)
+    assert(scalas.size === 1)
   }
 
   it should "parse hello world and write out correctly" in {
@@ -38,7 +39,7 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
 
   it should "parse hello world into mutable view and write out unchanged" in {
     val scalas = typeBeingTested.findAllIn(helloWorldProject)
-    scalas.size should be(1)
+    assert(scalas.size === 1)
     scalas.head.head match {
       case mtn: MutableContainerMutableView =>
         val content = mtn.value
@@ -49,29 +50,29 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
   it should "find hello world using path expression" in {
     val expr = "//ScalaFile()"
     val rtn = expressionEngine.evaluate(helloWorldProject, expr, DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
   }
 
   it should "find specific exception catch" in {
     val scalas: Option[Seq[TreeNode]] = typeBeingTested.findAllIn(exceptionsProject)
-    scalas.size should be(1)
+    assert(scalas.size === 1)
     val scalaFileNode = scalas.get.head.asInstanceOf[MutableContainerMutableView]
 
     val expr = "//termTryWithCases/case//typeName[@value='ThePlaneHasFlownIntoTheMountain']"
     expressionEngine.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
-        nodes.head.value should be("ThePlaneHasFlownIntoTheMountain")
+        assert(nodes.size === 1)
+        assert(nodes.head.value === "ThePlaneHasFlownIntoTheMountain")
       case wtf => fail(s"Expression didn't match [$wtf]. The tree was " + TreeNodeUtils.toShorterString(scalaFileNode))
     }
 
-    scalaFileNode.value should equal(Exceptions.content)
+    assert(scalaFileNode.value === Exceptions.content)
   }
 
   it should "find and modify specific exception catch" in {
     val proj = exceptionsProject
     val scalas: Option[Seq[TreeNode]] = typeBeingTested.findAllIn(proj)
-    scalas.size should be(1)
+    assert(scalas.size === 1)
     val scalaFileNode = scalas.get.head.asInstanceOf[MutableContainerMutableView]
 
     val newException = "MicturationException"
@@ -79,7 +80,7 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
     val expr = "//termTryWithCases/case//typeName[@value='ThePlaneHasFlownIntoTheMountain']"
     expressionEngine.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
+        assert(nodes.size === 1)
         val mut = nodes.head.asInstanceOf[MutableContainerMutableView]
         mut.update(newException)
       case wtf =>
@@ -87,18 +88,18 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
     }
 
     val newContent = Exceptions.content.replaceFirst("ThePlaneHasFlownIntoTheMountain", newException)
-    scalaFileNode.value should equal(newContent)
+    assert(scalaFileNode.value === newContent)
 
-    scalaFileNode.dirty should be(true)
+    assert(scalaFileNode.dirty === true)
     val updatedFile = proj.findFile(Exceptions.path)
-    updatedFile.content should be(newContent)
+    assert(updatedFile.content === newContent)
     //updatedFile.dirty should be(true)
   }
 
   it should "find and modify multiple points" in {
     val proj = exceptionsProject
     val scalas: Option[Seq[TreeNode]] = typeBeingTested.findAllIn(proj)
-    scalas.size should be(1)
+    assert(scalas.size === 1)
     val scalaFileNode = scalas.get.head.asInstanceOf[MutableContainerMutableView]
 
     val newException = "MicturationException"
@@ -106,28 +107,29 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
     val expr = "//case//typeName[@value='ThePlaneHasFlownIntoTheMountain']"
     expressionEngine.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(2)
+        assert(nodes.size === 2)
         nodes.foreach {
           case mut: MutableContainerMutableView => mut.update(newException)
           case _ =>
+        
         }
       case wtf =>
         fail(s"Expression didn't match [$wtf]. The tree was " + TreeNodeUtils.toShorterString(scalaFileNode))
     }
 
     val newContent = Exceptions.content.replaceAll("ThePlaneHasFlownIntoTheMountain", newException)
-    scalaFileNode.value should equal(newContent)
+    assert(scalaFileNode.value === newContent)
 
-    scalaFileNode.dirty should be(true)
+    assert(scalaFileNode.dirty === true)
     val updatedFile = proj.findFile(Exceptions.path)
-    updatedFile.content should be(newContent)
+    assert(updatedFile.content === newContent)
     //updatedFile.dirty should be(true)
   }
 
   it should "find and modify specific exception catch body" in {
     val proj = exceptionsProject
     val scalas: Option[Seq[TreeNode]] = typeBeingTested.findAllIn(proj)
-    scalas.size should be(1)
+    assert(scalas.size === 1)
     val scalaFileNode = scalas.get.head.asInstanceOf[MutableContainerMutableView]
 
     val newException = "MicturationException"
@@ -136,7 +138,7 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
     val expr = "//termTryWithCases/case[//typeName[@value='ThePlaneHasFlownIntoTheMountain']]"
     expressionEngine.evaluate(scalaFileNode, expr, DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
+        assert(nodes.size === 1)
         val mut = nodes.head.asInstanceOf[MutableContainerMutableView]
         val terminals = TreeNodeOperations.terminals(mut)
         //println(terminals)
@@ -146,11 +148,11 @@ class ScalaFileTypeTest extends AbstractTypeUnderFileTest {
     }
 
     val newContent = Exceptions.content.replaceFirst("ThePlaneHasFlownIntoTheMountain", newException)
-    scalaFileNode.value should equal(newContent)
+    assert(scalaFileNode.value === newContent)
 
-    scalaFileNode.dirty should be(true)
+    assert(scalaFileNode.dirty === true)
     val updatedFile = proj.findFile(Exceptions.path)
-    updatedFile.content should be(newContent)
+    assert(updatedFile.content === newContent)
     //updatedFile.dirty should be(true)
   }
 
@@ -162,6 +164,7 @@ object ScalaFileTypeTest {
 
   def projectWithBogusScala =
     new ProjectMutableView(EmptyArtifactSource(), SimpleFileBasedArtifactSource(BogusScala))
+
 
   val HelloWorldScala = StringFileArtifact("Hello.scala",
     """
@@ -271,8 +274,12 @@ object ScalaFileTypeTest {
   def helloWorldProject =
     new ProjectMutableView(SimpleFileBasedArtifactSource(HelloWorldScala))
 
+
   def exceptionsProject =
     new ProjectMutableView(SimpleFileBasedArtifactSource(Exceptions))
+
+
+
 
 
 }

--- a/src/test/scala/com/atomist/rug/kind/scala/ScalaMetaBackedTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/scala/ScalaMetaBackedTreeNodeTest.scala
@@ -13,6 +13,7 @@ class ScalaMetaBackedTreeNodeTest extends FlatSpec with Matchers {
 
   val ee: ExpressionEngine = new PathExpressionEngine
 
+
   it should "parse simple class without error" in {
     val source =
       """class Foo(bar: String, i: Int)
@@ -20,6 +21,7 @@ class ScalaMetaBackedTreeNodeTest extends FlatSpec with Matchers {
 
     val str: Parsed[Source] = source.parse[Source]
     val tn = new ScalaMetaTreeBackedTreeNode(str.get)
+  
   }
 
   it should "satisfy simple path expression" in {
@@ -30,8 +32,8 @@ class ScalaMetaBackedTreeNodeTest extends FlatSpec with Matchers {
     val tn = new ScalaMetaTreeBackedTreeNode(str.get)
     ee.evaluate(tn, "//termParam[/typeName[@value='String']]/termName", DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
-        nodes.head.value should be("bar")
+        assert(nodes.size === 1)
+        assert(nodes.head.value === "bar")
       case wtf => fail(s"Unexpected: $wtf")
     }
   }
@@ -44,10 +46,10 @@ class ScalaMetaBackedTreeNodeTest extends FlatSpec with Matchers {
     val tn = new ScalaMetaTreeBackedTreeNode(str.get)
     ee.evaluate(tn, "//termParam[/typeName[@value='String']]/termName", DefaultTypeRegistry) match {
       case Right(nodes) if nodes.nonEmpty =>
-        nodes.size should be(1)
+        assert(nodes.size === 1)
         val tn: PositionedTreeNode = nodes.head.asInstanceOf[PositionedTreeNode]
-        tn.value should be("bar")
-        tn.startPosition.offset should equal (source.indexOf("bar"))
+        assert(tn.value === "bar")
+        assert(tn.startPosition.offset === source.indexOf("bar"))
         //nodes.head.
       case wtf => fail(s"Unexpected: $wtf")
     }

--- a/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeTest.scala
@@ -12,17 +12,18 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class XmlFileTypeTest extends FlatSpec with Matchers {
 
-  private val pex = new PathExpressionEngine
+  private  val pex = new PathExpressionEngine
+
 
   it should "find XML file type using path expression" in {
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val expr = "/File()[@name='pom.xml']/XmlFile()"
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case n: ContainerTreeNode =>
-        n.value should equal(proj.findFile("pom.xml").get.content)
+        assert(n.value === proj.findFile("pom.xml").get.content)
     }
   }
 
@@ -31,7 +32,7 @@ class XmlFileTypeTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val expr = "//XmlFile()/project/dependencies/dependency"
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
-    rtn.right.get.size should be(2)
+    assert(rtn.right.get.size === 2)
     rtn.right.get.foreach {
       case n: TreeNode if n.value.nonEmpty =>
       n.value.contains("org.springframework.boot") should be (true)
@@ -48,12 +49,12 @@ class XmlFileTypeTest extends FlatSpec with Matchers {
   it should "drill down to named XML elements using path expression and type //" in
     drillToGroupIds("//XmlFile()//element()", tn => tn.nodeName == "groupId")
 
-  private def drillToGroupIds(expr: String, filter: TreeNode => Boolean = tn => true): Unit = {
+  private  def drillToGroupIds(expr: String, filter: TreeNode => Boolean = tn => true): Unit = {
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
     val results = rtn.right.get.filter(filter)
-    results.size should be(5)
+    assert(results.size === 5)
     // TODO note that we can't presently rely on ordering
 //    println(results.map(TreeNodeUtils.toShortString))
 //    println(results.map(n => n.asInstanceOf[MutableContainerMutableView].currentBackingObject.asInstanceOf[PositionedTreeNode].startPosition))
@@ -69,9 +70,11 @@ class XmlFileTypeTest extends FlatSpec with Matchers {
     val expr = "/*[@name='pom.xml']/XmlFile()/project/groupId"
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
 
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case n: TreeNode if n.value.nonEmpty =>
+      //println(n.value)
+      
       //println(n.value)
       case x => fail(s"Was empty: $x")
     }
@@ -84,8 +87,8 @@ class XmlFileTypeTest extends FlatSpec with Matchers {
     val rtn = pex.evaluate(pmv, PathExpressionParser.parseString(expr), DefaultTypeRegistry)
     //println(TreeNodeUtils.toShortString(rtn.right.get.head))
 
-    rtn.right.get.size should be(1)
-    rtn.right.get.head.value should equal ("test")
+    assert(rtn.right.get.size === 1)
+    assert(rtn.right.get.head.value === "test")
   }
 
 }

--- a/src/test/scala/com/atomist/rug/kind/xml/XmlMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/xml/XmlMutableViewTest.scala
@@ -12,13 +12,14 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
   "XmlMutableView" should "add a new block as a child of another block" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val newNodeContent = "<plugin><groupId>com.atomist</groupId><artifactId>our-great-plugin</artifactId></plugin>"
 
     val newNodeName = "plugin"
 
     xv.addOrReplaceNode("/project/build/plugins", """/project/build/plugins/plugin/artifactId [text() = "our-great-plugin"]""", newNodeName, newNodeContent)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     checkCommentStillPresent(xv, "Add GIT commit information to the info endpoint")
 
@@ -30,7 +31,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
     xv.addOrReplaceNode("/project/dependencies", """/project/dependencies/dependency/artifactId [text() = "an-atomist-artifact"]""", secondNewNodeName, secondNewNodeContent)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     checkCommentStillPresent(xv, "Add GIT commit information to the info endpoint")
 
@@ -39,6 +40,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
   it should "report if an element is present according to xpath" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+
 
     val validXPath = "//project/dependencies"
     val invalidXPath = "//project/stuff"
@@ -51,6 +53,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
   it should "get a value from an element with text content" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val xpathToElementWithTextValue = "//project/groupId"
 
     xv.getTextContentFor(xpathToElementWithTextValue) should be ("atomist")
@@ -59,17 +62,19 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
   it should "set a value on an element with text content" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val xpathToElementWithTextValue = "/project/groupId"
 
     xv.setTextContentFor(xpathToElementWithTextValue, "donny")
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     xv.getTextContentFor(xpathToElementWithTextValue) should be ("donny")
   }
 
   it should "add or replace an existing node with a new node" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+
 
     val replacementNode = "project.build.sourceEncoding"
     val xPathToParentNode = s"/project/properties"
@@ -79,7 +84,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
     xv.addOrReplaceNode(xPathToParentNode, fullXPathToNode, replacementNode, newContent)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
    xv.getTextContentFor(fullXPathToNode) should be (newValue)
 
@@ -90,7 +95,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
     xv.addOrReplaceNode(xPathToParentNode, fullXPathToAddedNode, newNode, newContent2)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     xv.getTextContentFor(fullXPathToAddedNode) should be (newValue2)
   }
@@ -98,13 +103,14 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
   it should "delete the specified node" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val replacementNode = "project.build.sourceEncoding"
     val xPathToParentNode = s"/project/properties"
     val fullXPathToNode = s"$xPathToParentNode/$replacementNode"
 
     xv.deleteNode(fullXPathToNode)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     xv.getTextContentFor(fullXPathToNode) should be ("")
   }
@@ -112,17 +118,19 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
   it should "delete the specific node among many peers" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val fullXPathToNode = "/project/dependencies/dependency/artifactId[text()='spring-boot-starter-actuator']/.."
 
     xv.deleteNode(fullXPathToNode)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     xv.getTextContentFor(fullXPathToNode) should be ("")
   }
 
   it should "replace an existing node when an XPath condition is met" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+
 
     val nodeToReplaceXpathSelector = "/project/dependencies/dependency/artifactId[text()='spring-boot-starter-actuator']/.."
     val xPathToPlaceToInsertContent = "/project/dependencies"
@@ -131,7 +139,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
     xv.addOrReplaceNode(xPathToPlaceToInsertContent, nodeToReplaceXpathSelector, nodeName, newNodeContent)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     xv.content.contains("<artifactId>atomistartifact</artifactId>") should be (true)
     xv.content.contains("<artifactId>spring-boot-starter-actuator</artifactId>") should be (false)
@@ -140,6 +148,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
   it should "add a new node when an XPath condition is not met" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
 
+
     val nodeToReplaceXpathSelector = "/project/dependencies/dependency/artifactId[text()='spring-boot-starter-web-DUMMY']/.."
     val xPathToPlaceToInsertContent = "/project/dependencies"
     val nodeName = "dependency"
@@ -147,7 +156,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
     xv.addOrReplaceNode(xPathToPlaceToInsertContent, nodeToReplaceXpathSelector, nodeName, newNodeContent)
 
-    xv.dirty should be (true)
+    assert(xv.dirty === true)
 
     xv.content.contains("<artifactId>atomistartifact</artifactId>") should be (true)
     xv.content.contains("<artifactId>spring-boot-starter-web</artifactId>") should be (true)
@@ -155,6 +164,7 @@ class XmlMutableViewTest extends FlatSpec with Matchers {
 
   it should "replace the right child element when many are available" in {
     val xv = new XmlMutableView(pom, new ProjectMutableView(EmptyArtifactSource(""), JavaTypeUsageTest.NewSpringBootProject))
+
 
     val artifactId = "git-commit-id-plugin"
     val groupId = "pl.project13.maven"

--- a/src/test/scala/com/atomist/rug/kind/yml/YmlMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/yml/YmlMutableViewTest.scala
@@ -62,6 +62,7 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
     )
   )
 
+
   it should "find key in simple yml" in {
     val simpleYml =
       """
@@ -87,8 +88,8 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
     val ic = SimpleFunctionInvocationContext("p", null, yv, as, null, Map(),
       SimpleProjectOperationArguments.Empty, Nil)
     yv.updateKey("name", "Theresa")
-    yv.dirty should be(true)
-    "Theresa".r.findAllIn(yv.content).toList.size should be(1)
+    assert(yv.dirty === true)
+    assert("Theresa".r.findAllIn(yv.content).toList.size === 1)
   }
 
   it should "set key in simple yml without affecting other keys" in {
@@ -106,8 +107,8 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
     val ic = SimpleFunctionInvocationContext("p", null, yv, as, null, Map(),
       SimpleProjectOperationArguments.Empty, Nil)
     yv.updateKey("name", "Theresa")
-    yv.dirty should be(true)
-    "Theresa".r.findAllIn(yv.content).toList.size should be(1)
+    assert(yv.dirty === true)
+    assert("Theresa".r.findAllIn(yv.content).toList.size === 1)
   }
 
   it should "set keys in simple yml maintaining comments" in {
@@ -128,8 +129,8 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
     val ic = SimpleFunctionInvocationContext("p", null, yv, as, null, Map(),
       SimpleProjectOperationArguments.Empty, Nil)
     yv.updateKey("name", "Theresa")
-    yv.dirty should be(true)
-    "Theresa".r.findAllIn(yv.content).toList.size should be(1)
+    assert(yv.dirty === true)
+    assert("Theresa".r.findAllIn(yv.content).toList.size === 1)
     yv.content.contains(firstComment)
     yv.content.contains(secondComment)
     yv.content.contains(thirdComment)
@@ -156,8 +157,8 @@ class YmlMutableViewTest extends FlatSpec with Matchers {
     val ic = SimpleFunctionInvocationContext("p", null, yv, as, null, Map(),
       SimpleProjectOperationArguments.Empty, Nil)
     yv.updateKey("name", "Theresa")
-    yv.dirty should be(true)
-    "Theresa".r.findAllIn(yv.content).toList.size should be(1)
+    assert(yv.dirty === true)
+    assert("Theresa".r.findAllIn(yv.content).toList.size === 1)
     yv.content.contains(firstComment)
     yv.content.contains(secondComment)
     yv.content.contains(thirdComment)

--- a/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/CommonRugParserTest.scala
@@ -94,6 +94,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
 
   val ri = new ParserCombinatorRugParser
 
+
   it should "parse = literal string in predicates" in
     parseLiteralStringInPredicates(EqualsLiteralStringInPredicate)
 
@@ -137,8 +138,8 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |  replace "Dog" num
       """.stripMargin
     val rp = ri.parse(prog).head
-    rp.runs.size should be(1)
-    rp.runs.head.args.head.parameterName should equal(Some("num"))
+    assert(rp.runs.size === 1)
+    assert(rp.runs.head.args.head.parameterName === Some("num"))
   }
 
   it should "allow alias to be omitted and default correctly" in {
@@ -151,8 +152,8 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |  replace "Dog" "Cat"
       """.stripMargin
     val rp = ri.parse(prog).head
-    rp.withs.size should be(1)
-    rp.withs.head.alias should be("Project")
+    assert(rp.withs.size === 1)
+    assert(rp.withs.head.alias === "Project")
   }
 
   it should "allow alias to dotted type to be omitted and default correctly" in {
@@ -165,8 +166,8 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |  replace "Dog" "Cat"
       """.stripMargin
     val rp = ri.parse(prog).head
-    rp.withs.size should be(1)
-    rp.withs.head.alias should be("project")
+    assert(rp.withs.size === 1)
+    assert(rp.withs.head.alias === "project")
   }
 
   it should "allow arguments to be specified in JavaScript" in {
@@ -181,7 +182,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |  do regexpReplace { 'regex\s*with\s*"quotes"' } replacementText
       """.stripMargin
     val rp = ri.parse(prog).head
-    rp.actions.size should be(1)
+    assert(rp.actions.size === 1)
     val vis = new SaveAllDescendantsVisitor
     rp.accept(vis, 0)
     vis.descendants collect {
@@ -201,7 +202,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
         |  do regexpReplace "regex\\s*with\\s*\"quotes[^\"]+\"" { "\"" + replacementText + "\"" }
       """.stripMargin
     val rp = ri.parse(prog).head
-    rp.actions.size should be(1)
+    assert(rp.actions.size === 1)
     val vis = new SaveAllDescendantsVisitor
     rp.accept(vis, 0)
     vis.descendants collect {
@@ -261,11 +262,12 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
     )
 
-  private def parseLiteralStringInPredicates(prog: String) {
+  private  def parseLiteralStringInPredicates(prog: String) {
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case eq: EqualsExpression =>
+    
     }
   }
 
@@ -283,9 +285,10 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case AndExpression(a: EqualsExpression, b: ParsedRegisteredFunctionPredicate) =>
+    
     }
   }
 
@@ -306,7 +309,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case AndExpression(a: EqualsExpression, b: AndExpression) =>
         a.b.isInstanceOf[Literal[Int@unchecked]] should be(true)
@@ -332,7 +335,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case AndExpression(a: EqualsExpression, b: AndExpression) =>
         a.b.isInstanceOf[Literal[Int@unchecked]] should be(true)
@@ -357,14 +360,14 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.doSteps.head match {
       case fd: FunctionDoStep =>
-        fd.function should equal("fileHasContent")
-        fd.args.size should be(2)
+        assert(fd.function === "fileHasContent")
+        assert(fd.args.size === 2)
         fd.args(1) match {
           case WrappedFunctionArg(p: ParsedRegisteredFunctionPredicate, _) =>
-            p.args.size should be(2)
+            assert(p.args.size === 2)
           case _ => ???
         }
       case _ => ???
@@ -385,7 +388,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case EqualsExpression(a, b) =>
         b.isInstanceOf[Literal[Boolean@unchecked]] should be(true)
@@ -394,8 +397,8 @@ class CommonRugParserTest extends FlatSpec with Matchers {
 
   it should "resolve well-known regex in parameter" in {
     val parsed = ri.parse(WellKnownRegexInParameter).head
-    parsed.parameters.size should be(1)
-    parsed.parameters.head.getPattern should be(DefaultIdentifierResolver.knownIds("java_class"))
+    assert(parsed.parameters.size === 1)
+    assert(parsed.parameters.head.getPattern === DefaultIdentifierResolver.knownIds("java_class"))
   }
 
   it should "resolve well-known regex in parameter with comment on same line" in {
@@ -409,15 +412,15 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.parameters.size should be(1)
-    parsed.parameters.head.getPattern should be(DefaultIdentifierResolver.knownIds("java_class"))
+    assert(parsed.parameters.size === 1)
+    assert(parsed.parameters.head.getPattern === DefaultIdentifierResolver.knownIds("java_class"))
   }
 
   it should "expose parameter tags" in {
     val prog = InvokeOtherOperationWithSingleParameter
 
     val parsed = ri.parse(prog).head
-    parsed.parameters.size should be(1)
+    assert(parsed.parameters.size === 1)
     parsed.parameters.head.getTags.map(t => t.name) should equal(List("java", "spring"))
   }
 
@@ -436,11 +439,11 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.parameters.size should be(1)
+    assert(parsed.parameters.size === 1)
     val p = parsed.parameters.head
-    p.getMinLength should be(6)
-    p.getMaxLength should be(32)
-    p.getDefaultValue should be(name)
+    assert(p.getMinLength === 6)
+    assert(p.getMaxLength === 32)
+    assert(p.getDefaultValue === name)
   }
 
   it should "accept local arguments for run operation" in {
@@ -454,13 +457,12 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.runs.size should equal(1)
+    assert(parsed.runs.size === 1)
     val r = parsed.runs.head
-    r.name should equal("Foobar")
-    r.args should equal(Seq(
+    assert(r.name === "Foobar")
+    assert(r.args === Seq(
       WrappedFunctionArg(SimpleLiteral("foo"), Some("argA")),
-      WrappedFunctionArg(SimpleLiteral("bar"), Some("argB")))
-    )
+      WrappedFunctionArg(SimpleLiteral("bar"), Some("argB"))))
   }
 
   it should "reject bogus regex in parameter" in {
@@ -477,9 +479,10 @@ class CommonRugParserTest extends FlatSpec with Matchers {
 
   it should "parse = javascript block in predicate" in {
     val parsed = ri.parse(EqualsJavaScriptBlockInPredicate).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case eq: EqualsExpression =>
+    
     }
   }
 
@@ -497,9 +500,10 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case eq: EqualsExpression =>
+    
     }
   }
 
@@ -517,9 +521,10 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case eq: EqualsExpression =>
+      
       case _ => ???
     }
   }
@@ -539,10 +544,10 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.actions.size should be(2)
+    assert(parsed.actions.size === 2)
     parsed.actions.head.isInstanceOf[With] should be(true)
     parsed.actions(1) match {
-      case r: RunOtherOperation => r.name should equal("EditorA")
+      case r: RunOtherOperation => assert(r.name === "EditorA")
       case _ => ???
     }
   }
@@ -627,7 +632,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.publishedName should be(Some("Triplet"))
+    assert(parsed.publishedName === Some("Triplet"))
   }
 
   it should "parse @generator annotation on operation with name override" in {
@@ -646,7 +651,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.publishedName should be(Some(publishedName))
+    assert(parsed.publishedName === Some(publishedName))
   }
 
   it should "parse generator on operation with name override" in {
@@ -664,7 +669,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.publishedName should be(Some(publishedName))
+    assert(parsed.publishedName === Some(publishedName))
   }
 
   it should "pick up multiple @tags annotations on operation with name override" in {
@@ -685,8 +690,8 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.publishedName should be(Some(publishedName))
-    parsed.tags should equal(Seq("Foo", "Bar"))
+    assert(parsed.publishedName === Some(publishedName))
+    assert(parsed.tags === Seq("Foo", "Bar"))
   }
 
   it should "reject @publish annotation on parameters" in {
@@ -720,11 +725,11 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.doSteps.head match {
       case dds: FunctionDoStep =>
-        dds.function should equal("append")
-        dds.target should equal(Some("f"))
+        assert(dds.function === "append")
+        assert(dds.target === Some("f"))
       case _ => ???
     }
   }
@@ -739,14 +744,14 @@ class CommonRugParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val parsed = ri.parse(prog).head
-    parsed.withs.size should be(1)
+    assert(parsed.withs.size === 1)
     parsed.withs.head.predicate match {
       case cp: ComparisonPredicate =>
         cp.a match {
           case p: ParsedRegisteredFunctionPredicate =>
-            p.function should equal("name")
-            p.target should equal(Some("f"))
-            p.pathBelow should equal(Seq("length"))
+            assert(p.function === "name")
+            assert(p.target === Some("f"))
+            assert(p.pathBelow === Seq("length"))
         }
     }
   }
@@ -765,7 +770,7 @@ class CommonRugParserTest extends FlatSpec with Matchers {
     val comp = p.computations.head
     comp.te match {
       case sl: SimpleLiteral[String@unchecked] =>
-        sl.value should equal("elm-stuff\ntarget")
+        assert(sl.value === "elm-stuff\ntarget")
     }
   }
 
@@ -797,10 +802,11 @@ class CommonRugParserTest extends FlatSpec with Matchers {
     ri.parse(prog)
   }
 
-  private def updateWith(prog: String): Unit = {
+  private  def updateWith(prog: String): Unit = {
     val filename = "test.txt"
     val as = new SimpleFileBasedArtifactSource("name", Seq(StringFileArtifact(filename, "some content")))
     val pas = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(new DefaultRugPipeline().defaultFilenameFor(prog), prog))
+
 
     val r = doModification(pas, as, EmptyArtifactSource(""), SimpleProjectOperationArguments("", Seq.empty))
     val f = r.findFile(".gitignore").get

--- a/src/test/scala/com/atomist/rug/parser/ParsingErrorReportingTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/ParsingErrorReportingTest.scala
@@ -8,6 +8,7 @@ class ParsingErrorReportingTest extends FlatSpec with Matchers {
 
   val ri: RugParser = new ParserCombinatorRugParser()
 
+
   it should "give good error message for non reserved word" in {
     val prog =
       s"""
@@ -30,9 +31,9 @@ class ParsingErrorReportingTest extends FlatSpec with Matchers {
     catch {
       case b: BadRugSyntaxException =>
         b.getMessage.contains("l") should be(true)
-        b.info.line should be(5)
-        b.info.col should be(1)
-        b.info. filePath should be(RugParser.DefaultRugPath)
+        assert(b.info.line === 5)
+        assert(b.info.col === 1)
+        assert(b.info. filePath === RugParser.DefaultRugPath)
     }
   }
 
@@ -59,9 +60,9 @@ class ParsingErrorReportingTest extends FlatSpec with Matchers {
     catch {
       case b: BadRugSyntaxException =>
         b.getMessage.contains("le t") should be(true)
-        b.info.line should be(5)
+        assert(b.info.line === 5)
         b.info.col should be <(3)
-        b.info.filePath should equal(f.path)
+        assert(b.info.filePath === f.path)
         b.getMessage.startsWith(f.path + ":") should be(true)
     }
   }

--- a/src/test/scala/com/atomist/rug/parser/PathExpressionParsingTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/PathExpressionParsingTest.scala
@@ -24,9 +24,10 @@ class PathExpressionParsingTest extends FlatSpec with Matchers {
       """.stripMargin
     val f = StringFileArtifact(atomistConfig.editorsRoot + "/Redeploy.rug", prog)
     val ed = new ParserCombinatorRugParser().parse(f)
-    ed.head.computations.size should be (1)
+    assert(ed.head.computations.size === 1)
     ed.head.computations.head.te match {
       case pev: PathExpressionValue =>
+    
     }
   }
 
@@ -42,10 +43,10 @@ class PathExpressionParsingTest extends FlatSpec with Matchers {
       """.stripMargin
     val f = StringFileArtifact(atomistConfig.editorsRoot + "/Redeploy.rug", prog)
     val ed = new ParserCombinatorRugParser().parse(f)
-    ed.head.computations.size should be (1)
+    assert(ed.head.computations.size === 1)
     ed.head.computations.head.te match {
       case pev: PathExpressionValue =>
-        pev.scalarProperty should equal (Some("name"))
+        assert(pev.scalarProperty === Some("name"))
     }
   }
 }

--- a/src/test/scala/com/atomist/rug/parser/RugEditorParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/RugEditorParserTest.scala
@@ -8,6 +8,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
   val ri = new ParserCombinatorRugParser
 
+
   it should "parse simplest program" in
     simplestProgram("'Description'")
 
@@ -19,7 +20,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     simplestProgram(" \"\"\"description\"\"\" ")
   }
 
-  private def simplestProgram(description: String = ""): RugProgram = {
+  private  def simplestProgram(description: String = ""): RugProgram = {
     val prog =
       s"""
          |@description $description
@@ -67,8 +68,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     val p = ri.parse(prog).head
     p.withs.head.predicate match {
       case f: ParsedJavaScriptFunction =>
+    
     }
-    p.parameters should equal(Nil)
+    assert(p.parameters === Nil)
   }
 
   it should "parse editor precondition" in {
@@ -87,7 +89,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
     val p = ri.parse(prog).head match {
       case re: RugEditor =>
-        re.preconditions.head should equal(Condition("Foo"))
+        assert(re.preconditions.head === Condition("Foo"))
     }
   }
 
@@ -108,8 +110,8 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
     val p = ri.parse(prog).head match {
       case re: RugEditor =>
-        re.preconditions.headOption should equal(Some(Condition("Foo")))
-        re.postcondition should equal(Some(Condition("Bar")))
+        assert(re.preconditions.headOption === Some(Condition("Foo")))
+        assert(re.postcondition === Some(Condition("Bar")))
     }
   }
 
@@ -130,9 +132,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
     val actions = ri.parse(prog).head
 
-    actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.size should be(1)
+    assert(actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.size === 1)
     actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.head match {
-      case s: WrappedFunctionArg => s.te.asInstanceOf[Literal[String]].value should equal(tripleStringContent)
+      case s: WrappedFunctionArg => assert(s.te.asInstanceOf[Literal[String]].value === tripleStringContent)
     }
   }
 
@@ -153,9 +155,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
     val actions = ri.parse(prog).head
 
-    actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.size should be(1)
+    assert(actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.size === 1)
     actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.head match {
-      case s: WrappedFunctionArg => s.te.asInstanceOf[Literal[String]].value should equal(tripleStringContent)
+      case s: WrappedFunctionArg => assert(s.te.asInstanceOf[Literal[String]].value === tripleStringContent)
     }
   }
 
@@ -181,9 +183,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
 
     val actions = ri.parse(prog).head
 
-    actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.size should be(1)
+    assert(actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.size === 1)
     actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation].args.head match {
-      case s: WrappedFunctionArg => s.te.asInstanceOf[Literal[String]].value should equal(tripleStringContent)
+      case s: WrappedFunctionArg => assert(s.te.asInstanceOf[Literal[String]].value === tripleStringContent)
     }
   }
 
@@ -209,12 +211,12 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.getPattern should be("^...$")
-    p.isRequired should be(true)
-    p.isDisplayable should be(true)
+    assert(p.getName === "name")
+    assert(p.getPattern === "^...$")
+    assert(p.isRequired === true)
+    assert(p.isDisplayable === true)
   }
 
   it should "handle single parameter declaration with description and default value" in {
@@ -242,16 +244,16 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.getPattern should be("^.*$")
-    p.getDescription should be(paramDesc)
-    p.getDefaultValue should be(defaultVal)
-    p.getValidInputDescription should be(validInput)
-    p.isDisplayable should be(false)
-    p.isRequired should be(false)
-    p.getDisplayName should be(displayName)
+    assert(p.getName === "name")
+    assert(p.getPattern === "^.*$")
+    assert(p.getDescription === paramDesc)
+    assert(p.getDefaultValue === defaultVal)
+    assert(p.getValidInputDescription === validInput)
+    assert(p.isDisplayable === false)
+    assert(p.isRequired === false)
+    assert(p.getDisplayName === displayName)
   }
 
   it should "handle single parameter declaration and use in do step" in {
@@ -270,11 +272,11 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.getPattern should be("^.*$")
-    p.isRequired should be(true)
+    assert(p.getName === "name")
+    assert(p.getPattern === "^.*$")
+    assert(p.isRequired === true)
   }
 
   it should "handle single optional parameter declaration" in
@@ -283,7 +285,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
   it should "handle int do arg" in {
     val actions = simpleProgram(Seq("1"))
     val step = actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation]
-    step.args.size should equal(1)
+    assert(step.args.size === 1)
     step.args.head.isInstanceOf[WrappedFunctionArg] should be(true)
   }
 
@@ -302,10 +304,10 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         | append "a" name;
       """.stripMargin
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.isRequired should be(true)
+    assert(p.getName === "name")
+    assert(p.isRequired === true)
   }
 
   it should "not allow invalid allowed parameter values list" in {
@@ -341,11 +343,11 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         | append "a" name;
       """.stripMargin
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.getDefaultValue should be("432.678.980")
-    p.isRequired should be(false)
+    assert(p.getName === "name")
+    assert(p.getDefaultValue === "432.678.980")
+    assert(p.isRequired === false)
   }
 
   it should "not allow invalid default parameters" in {
@@ -382,11 +384,11 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         | append "a" name;
       """.stripMargin
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.getDefaultValue should be("valid")
-    p.isRequired should be(false)
+    assert(p.getName === "name")
+    assert(p.getDefaultValue === "valid")
+    assert(p.isRequired === false)
   }
 
   it should "not allow a default value not in parameter alternating regex" in {
@@ -410,14 +412,14 @@ class RugEditorParserTest extends FlatSpec with Matchers {
   it should "handle double do arg" in pendingUntilFixed {
     val actions = simpleProgram(Seq("1.9"))
     val step = actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation]
-    step.args.size should equal(1)
+    assert(step.args.size === 1)
     step.args.head.isInstanceOf[WrappedFunctionArg] should be(true)
   }
 
   it should "handle String literal do arg" in {
     val actions = simpleProgram(Seq("\"whatev\""))
     val step = actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation]
-    step.args.size should equal(1)
+    assert(step.args.size === 1)
     step.args.head match {
       case l: WrappedFunctionArg => l.te.asInstanceOf[Literal[String]].value.shouldEqual("whatev")
     }
@@ -426,13 +428,14 @@ class RugEditorParserTest extends FlatSpec with Matchers {
   it should "handle JavaScript do arg" in {
     val actions = simpleProgram(Seq("{ 42 + 63 }"))
     val step = actions.withs.head.doSteps.head.asInstanceOf[FunctionInvocation]
-    step.args.size should equal(1)
+    assert(step.args.size === 1)
     step.args.head match {
       case WrappedFunctionArg(te: JavaScriptBlock, _) =>
+    
     }
   }
 
-  private def simpleProgram(doArgs: Seq[String]): RugProgram = {
+  private  def simpleProgram(doArgs: Seq[String]): RugProgram = {
     val prog =
       s"""
          |@description "Something"
@@ -448,24 +451,24 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val progs = ri.parse(prog)
-    progs.size should be(1)
+    assert(progs.size === 1)
     val actions = progs.head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
-    p.getName should be("name")
-    p.getPattern should be("^.*$")
-    p.isRequired should be(false)
+    assert(p.getName === "name")
+    assert(p.getPattern === "^.*$")
+    assert(p.isRequired === false)
     actions
   }
 
   it should "compute parameter from string literal" in {
     val p = computeProgram(Seq("a = \"x\""))
-    p.computations.size should be(1)
+    assert(p.computations.size === 1)
   }
 
   it should "compute parameter from simple JavaScript expression" in {
     val p = computeProgram(Seq("a = { 42; }"))
-    p.computations.size should be(1)
+    assert(p.computations.size === 1)
   }
 
   it should "compute parameter from complex JavaScript expression" in {
@@ -477,11 +480,11 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         | if (true) { }
         |}
       """.stripMargin))
-    p.computations.size should be(1)
+    assert(p.computations.size === 1)
     p.computations.head
   }
 
-  private def computeProgram(infers: Seq[String]): RugProgram = {
+  private  def computeProgram(infers: Seq[String]): RugProgram = {
     val prog =
       s"""
          |@description 'Demonstrate computation'
@@ -499,7 +502,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.parameters.size should be(1)
+    assert(actions.parameters.size === 1)
     val p = actions.parameters.head
     actions
   }
@@ -570,8 +573,8 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val p = ri.parse(prog).head
-    p.actions.size should be(1)
-    p.withs.head.doSteps.size should be(2)
+    assert(p.actions.size === 1)
+    assert(p.withs.head.doSteps.size === 2)
   }
 
   it should "handle multiple with blocks" in {
@@ -592,7 +595,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.actions.size should equal(2)
+    assert(actions.actions.size === 2)
   }
 
   it should "handle multiple with blocks 2" in {
@@ -618,11 +621,11 @@ class RugEditorParserTest extends FlatSpec with Matchers {
         |   updateImport old_name new_name
       """.stripMargin
     val rug = ri.parse(prog).head
-    rug.actions.size should equal(2)
+    assert(rug.actions.size === 2)
     rug.withs(1).predicate match {
       case rp: ParsedRegisteredFunctionPredicate =>
-        rp.args.size should equal(1)
-        rp.args should equal(Seq(IdentifierFunctionArg("old_name")))
+        assert(rp.args.size === 1)
+        assert(rp.args === Seq(IdentifierFunctionArg("old_name")))
     }
   }
 
@@ -642,9 +645,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.actions.size should equal(1)
-    actions.withs.head.doSteps.size should be(1)
-    actions.withs.head.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.size should be(1)
+    assert(actions.actions.size === 1)
+    assert(actions.withs.head.doSteps.size === 1)
+    assert(actions.withs.head.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.size === 1)
   }
 
   it should "handle nested with blocks" in {
@@ -666,9 +669,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.actions.size should equal(1)
-    actions.withs.head.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.size should be(1)
-    actions.withs.head.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.size should be(2)
+    assert(actions.actions.size === 1)
+    assert(actions.withs.head.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.size === 1)
+    assert(actions.withs.head.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.head.asInstanceOf[WithDoStep].wth.doSteps.size === 2)
   }
 
   it should "find description" in {
@@ -685,7 +688,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
          | append "A";
       """.stripMargin
     val actions = ri.parse(prog).head
-    actions.description should equal(desc)
+    assert(actions.description === desc)
   }
 
   it should "find match alias and kind" in {
@@ -707,11 +710,11 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val actions = ri.parse(prog).head
-    actions.withs.size should be(2)
-    actions.withs.head.alias should be("f")
-    actions.withs.head.kind should be("File")
-    actions.withs(1).alias should be("t")
-    actions.withs(1).kind should be("thing")
+    assert(actions.withs.size === 2)
+    assert(actions.withs.head.alias === "f")
+    assert(actions.withs.head.kind === "File")
+    assert(actions.withs(1).alias === "t")
+    assert(actions.withs(1).kind === "thing")
   }
 
   it should "accept comments" in {
@@ -749,9 +752,9 @@ class RugEditorParserTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val progs = ri.parse(prog)
-    progs.head.name should be("RemoveEJB")
-    progs.size should be(2)
-    progs(1).name should be("Caspar")
+    assert(progs.head.name === "RemoveEJB")
+    assert(progs.size === 2)
+    assert(progs(1).name === "Caspar")
   }
 
   it should "fail invalid input after a valid editor" in {
@@ -792,6 +795,7 @@ class RugEditorParserTest extends FlatSpec with Matchers {
     }
     catch {
       case micturation: BadRugSyntaxException =>
+    
     }
   }
 

--- a/src/test/scala/com/atomist/rug/parser/RugPredicateParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/RugPredicateParserTest.scala
@@ -7,6 +7,7 @@ class RugPredicateParserTest extends FlatSpec with Matchers {
 
   val ri = new ParserCombinatorRugParser
 
+
   it should "parse simple with" in {
     val prog =
       s"""
@@ -15,7 +16,7 @@ class RugPredicateParserTest extends FlatSpec with Matchers {
          |with File when isJava
     """.stripMargin
     val pops = ri.parse(prog)
-    pops.size should be(1)
+    assert(pops.size === 1)
     pops.head match {
       case rpr: RugProjectPredicate => rpr
     }
@@ -30,7 +31,7 @@ class RugPredicateParserTest extends FlatSpec with Matchers {
          |   with File when name = "Foo"
     """.stripMargin
     val pops = ri.parse(prog)
-    pops.size should be(1)
+    assert(pops.size === 1)
     pops.head match {
       case rpr: RugProjectPredicate => rpr
     }

--- a/src/test/scala/com/atomist/rug/parser/RugReviewerParserTest.scala
+++ b/src/test/scala/com/atomist/rug/parser/RugReviewerParserTest.scala
@@ -7,10 +7,11 @@ class RugReviewerParserTest extends FlatSpec with Matchers {
 
   val ri = new ParserCombinatorRugParser
 
+
   it should "parse simplest program" in
     simplestProgram("'Description'")
 
-  private def simplestProgram(description: String = ""): RugReviewer = {
+  private  def simplestProgram(description: String = ""): RugReviewer = {
     val prog =
       s"""
          |@description $description
@@ -23,7 +24,7 @@ class RugReviewerParserTest extends FlatSpec with Matchers {
          | warn { "ejb found in " + f.name() };
     """.stripMargin
     val pops = ri.parse(prog)
-    pops.size should be (1)
+    assert(pops.size === 1)
     pops.head match {
       case rr: RugReviewer => rr
     }

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeDocTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeDocTest.scala
@@ -13,7 +13,7 @@ class TypeDocTest extends FlatSpec with Matchers {
   it should "generate type doc" in {
     val td = new TypeDoc()
     val output = td.generate("", SimpleProjectOperationArguments.Empty)
-    output.allFiles.size should be(1)
+    assert(output.allFiles.size === 1)
     val d = output.allFiles.head
     d.contentLength should be > (100000)
     val doc: String = d.content
@@ -33,7 +33,7 @@ class TypeDocTest extends FlatSpec with Matchers {
     val output = td.modify(EmptyArtifactSource(""), SimpleProjectOperationArguments.Empty)
     output match {
       case sm: SuccessfulModification =>
-        sm.result.allFiles.size should be(1)
+        assert(sm.result.allFiles.size === 1)
         val d = sm.result.allFiles.head
       case _ => ???
     }
@@ -51,7 +51,7 @@ class TypeDocTest extends FlatSpec with Matchers {
 
     output match {
       case sm: SuccessfulModification =>
-        sm.result.allFiles.size should be(1)
+        assert(sm.result.allFiles.size === 1)
         val d = sm.result.allFiles.head
         d.contentLength should be > (20)
       case _ => ???

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
@@ -13,9 +13,10 @@ class TypeScriptInterfaceGeneratorTest extends FlatSpec with Matchers {
   it should "generate compilable typescript file" in {
     val td = new TypeScriptInterfaceGenerator()
     // Make it put the generated files where our compiler will look for them
+    // Make it put the generated files where our compiler will look for them
     val output = td.generate("", SimpleProjectOperationArguments("",
       Map(td.OutputPathParam -> ".atomist/editors/Interfaces.ts")))
-    output.allFiles.size should be(1)
+    assert(output.allFiles.size === 1)
 
     // We need to get rid of the imports as they'll fail when we try to compile the file on its own
     val withoutImport = output ✎ new FileEditor {

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperationTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperationTest.scala
@@ -195,7 +195,7 @@ class JavaScriptInvokingProjectOperationTest extends FlatSpec with Matchers {
     val tsf = StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleEditorWithDefaultParameterValue)
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsed.modify(target, SimpleProjectOperationArguments.Empty)
   }
@@ -245,35 +245,38 @@ class JavaScriptInvokingProjectOperationTest extends FlatSpec with Matchers {
     jsed.jsVar.get("name") should be ("Simple")
   }
 
-  private def invokeAndVerifySimpleEditor(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
+  private  def invokeAndVerifySimpleEditor(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsed.modify(target, SimpleProjectOperationArguments("", Map("content" -> "http://blah.com"))) match {
       case _ =>
+    
     }
     jsed
   }
 
-  private def invokeAndVerifySimpleReviewer(tsf: FileArtifact): JavaScriptInvokingProjectReviewer = {
+  private  def invokeAndVerifySimpleReviewer(tsf: FileArtifact): JavaScriptInvokingProjectReviewer = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsr = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectReviewer]
-    jsr.name should be("Simple")
+    assert(jsr.name === "Simple")
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsr.review(target, SimpleProjectOperationArguments("", Map("content" -> "http://blah.com"))) match {
       case _ =>
+    
     }
     jsr
   }
 
-  private def invokeAndVerifyEditorWithDefaults(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
+  private  def invokeAndVerifyEditorWithDefaults(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsed.modify(target, SimpleProjectOperationArguments("", Map[String,String]())) match {
       case _ =>
+    
     }
     jsed
   }

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptOperationFinderTest.scala
@@ -58,15 +58,15 @@ class JavaScriptOperationFinderTest  extends FlatSpec with Matchers {
 
   it should "find an editor with a parameters list" in {
     val eds = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleProjectEditorWithParametersArray))
-    eds.parameters.size should be(1)
+    assert(eds.parameters.size === 1)
   }
 
   it should "find an editor using annotated parameters" in {
     val eds = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleProjectEditorWithAnnotatedParameters))
-    eds.parameters.size should be(3)
-    eds.parameters(0).getDefaultValue should be("Test String")
-    eds.parameters(1).getDefaultValue should be("10")
-    eds.parameters(2).getDefaultValue should be("")
+    assert(eds.parameters.size === 3)
+    assert(eds.parameters(0).getDefaultValue === "Test String")
+    assert(eds.parameters(1).getDefaultValue === "10")
+    assert(eds.parameters(2).getDefaultValue === "")
 
   }
 
@@ -74,7 +74,7 @@ class JavaScriptOperationFinderTest  extends FlatSpec with Matchers {
     //runPerfTest()
   }
 
-  private def runPerfTest(): Unit = {
+  private  def runPerfTest(): Unit = {
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     val (as, compileTime) = time {
       val tsf = StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleProjectEditorWithAnnotatedParameters)
@@ -119,10 +119,10 @@ class JavaScriptOperationFinderTest  extends FlatSpec with Matchers {
   }
 
 
-  private def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
+  private  def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsed.modify(target,SimpleProjectOperationArguments("", Map("content" -> "woot")))
     jsed

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
@@ -398,7 +398,7 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
   }
 
   val otherEditor: ProjectEditor = new ProjectEditorSupport {
-    override protected def modifyInternal(as: ArtifactSource, pmi: ProjectOperationArguments): ModificationAttempt = {
+    override protected  def modifyInternal(as: ArtifactSource, pmi: ProjectOperationArguments): ModificationAttempt = {
       SuccessfulModification(as + StringFileArtifact("src/from/typescript", pmi.stringParamValue("otherParam")))
     }
 
@@ -411,15 +411,15 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
     val jsed = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters), Seq(otherEditor))
     val p = jsed.parameters.head
-    p.getTags should be(ListBuffer(Tag("foo","foo"),Tag("bar","bar")))
-    p.isDisplayable should be(true)
+    assert(p.getTags === ListBuffer(Tag("foo","foo"),Tag("bar","bar")))
+    assert(p.isDisplayable === true)
   }
 
   it should "find tags" in {
     val ed = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       SimpleEditorTaggedAndMeta))
-    ed.tags.size should be(2)
-    ed.tags.map(_.name).toSet should equal(Set("java", "maven"))
+    assert(ed.tags.size === 2)
+    assert(ed.tags.map(_.name).toSet === Set("java", "maven"))
   }
 
   it should "find a dependency in the same artifact source after compilation" in {
@@ -433,49 +433,49 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
   it should "find parameter metadata" in {
     val ed = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       SimpleEditorTaggedAndMeta))
-    ed.parameters.size should be(2)
+    assert(ed.parameters.size === 2)
     val p = ed.parameters.head
-    p.name should be("content")
-    p.description should be("Content")
-    p.getDisplayName should be("content")
-    p.getPattern should be(ContentPattern)
-    p.getMaxLength should be(100)
-    p.getMinLength should be(-1)
-    p.isDisplayable should be(false)
+    assert(p.name === "content")
+    assert(p.description === "Content")
+    assert(p.getDisplayName === "content")
+    assert(p.getPattern === ContentPattern)
+    assert(p.getMaxLength === 100)
+    assert(p.getMinLength === -1)
+    assert(p.isDisplayable === false)
   }
 
   it should "default min/max length to -1 if not set" in {
     val ed = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       SimpleEditorWithBasicParameter))
-    ed.parameters.size should be(1)
+    assert(ed.parameters.size === 1)
     val p = ed.parameters.head
-    p.getMinLength should be(-1)
-    p.getMaxLength should be(-1)
+    assert(p.getMinLength === -1)
+    assert(p.getMaxLength === -1)
   }
 
   it should "find description" in {
     val ed = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       SimpleEditorTaggedAndMeta))
-    ed.description should be("A nice little editor")
+    assert(ed.description === "A nice little editor")
   }
 
   it should "have the PathExpressionEngine injected" in {
     val (ed, _) = invokeAndVerifyConstructed(StringFileArtifact(s".atomist/editors/ConstructedEditor.ts",
       EditorInjectedWithPathExpression))
-    ed.description should be ("A nice little editor")
+    assert(ed.description === "A nice little editor")
   }
 
   it should "have the PathExpressionEngine injected and use an object path expression" in {
     val (ed,sm) = invokeAndVerifyConstructed(StringFileArtifact(s".atomist/editors/ConstructedEditor.ts",
       EditorInjectedWithPathExpressionObject))
-    ed.description should be ("A nice little editor")
-    sm.changeLogEntries.size should be (1)
+    assert(ed.description === "A nice little editor")
+    assert(sm.changeLogEntries.size === 1)
   }
 
   it should "have the PathExpressionEngine injected using PathExpressionEngine.with" in {
     val (ed, _) = invokeAndVerifyConstructed(StringFileArtifact(s".atomist/editors/ConstructedEditor.ts",
       EditorInjectedWithPathExpressionUsingWith))
-    ed.description should be ("A nice little editor")
+    assert(ed.description === "A nice little editor")
   }
 
   it should "have the PathExpressionEngine injected using PathExpressionEngine.with type-jump" in {
@@ -487,7 +487,7 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
     val as = SimpleFileBasedArtifactSource(
       StringFileArtifact(".atomist/editors/Simple.ts", SimpleEditorTaggedAndMeta))
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(TypeScriptBuilder.compileWithModel(as)).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
 
@@ -498,20 +498,20 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
   it should "handle default parameter values" in {
     val ed = invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
       SimpleEditorTaggedAndMeta))
-    ed.parameters.size should be(2)
+    assert(ed.parameters.size === 2)
     val p = ed.parameters.head
-    p.name should be("content")
-    p.description should be("Content")
-    p.getDisplayName should be("content")
-    p.getPattern should be(ContentPattern)
-    p.getDefaultValue should be("Anders is ?")
-    p.getMaxLength should be(100)
+    assert(p.name === "content")
+    assert(p.description === "Content")
+    assert(p.getDisplayName === "content")
+    assert(p.getPattern === ContentPattern)
+    assert(p.getDefaultValue === "Anders is ?")
+    assert(p.getMaxLength === 100)
   }
 
-  private def invokeAndVerifyConstructed(tsf: FileArtifact): (JavaScriptInvokingProjectEditor, SuccessfulModification) = {
+  private  def invokeAndVerifyConstructed(tsf: FileArtifact): (JavaScriptInvokingProjectEditor, SuccessfulModification) = {
     val as = SimpleFileBasedArtifactSource(tsf)
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(TypeScriptBuilder.compileWithModel(as)).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Constructed")
+    assert(jsed.name === "Constructed")
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsed.modify(target, SimpleProjectOperationArguments("", Map("packageName" -> "com.atomist.crushed"))) match {
       case sm: SuccessfulModification =>
@@ -521,41 +521,41 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
       case _ => ???
     }
   }
-  private def invokeAndVerifySimpleGenerator(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptInvokingProjectGenerator = {
+  private  def invokeAndVerifySimpleGenerator(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptInvokingProjectGenerator = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectGenerator]
-    jsed.name should be("SimpleGenerator")
+    assert(jsed.name === "SimpleGenerator")
     jsed.setContext(others)
 
     val prj = jsed.generate("woot", SimpleProjectOperationArguments("", Map("content" -> "Anders Hjelsberg is God")))
-    prj.id.name should be("woot")
+    assert(prj.id.name === "woot")
 
     jsed
   }
 
-  private def invokeAndVerifySimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptInvokingProjectEditor = {
+  private  def invokeAndVerifySimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     jsed.setContext(others)
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
 
     jsed.modify(target, SimpleProjectOperationArguments("", Map("content" -> "Anders Hjelsberg is God"))) match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(2)
+        assert(sm.result.totalFileCount === 2)
         sm.result.findFile("src/from/typescript").get.content.contains("Anders") should be(true)
       case _ => ???
     }
     jsed
   }
 
-  private def invokeAndVerifyIdempotentSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptInvokingProjectEditor = {
+  private  def invokeAndVerifyIdempotentSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptInvokingProjectEditor = {
     val as = SimpleFileBasedArtifactSource(tsf)
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(TypeScriptBuilder.compileWithModel(as)).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     jsed.setContext(others)
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
@@ -563,11 +563,12 @@ class TypeScriptRugEditorTest extends FlatSpec with Matchers {
     val p = SimpleProjectOperationArguments("", Map("content" -> "Anders Hjelsberg is God"))
     jsed.modify(target, p) match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(2)
+        assert(sm.result.totalFileCount === 2)
         sm.result.findFile("src/from/typescript").get.content.contains("Anders") should be(true)
 
         jsed.modify(sm.result, p) match {
           case _: NoModificationNeeded => //yay
+           //yay
           case sm: SuccessfulModification =>
               fail("That should not have reported modification")
           case _ => ???

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugReviewerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugReviewerTest.scala
@@ -127,8 +127,8 @@ class TypeScriptRugReviewerTest extends FlatSpec with Matchers {
       StringFileArtifact(s".atomist/reviewers/SimpleReviewer.ts",
       SimpleReviewerWithoutParameters))
 
-    reviewResult.note should be("")
-    reviewResult.comments.isEmpty should be(true)
+    assert(reviewResult.note === "")
+    assert(reviewResult.comments.isEmpty === true)
   }
 
   it should "run simple reviewer compiled from TypeScript with parameters" in {
@@ -136,8 +136,8 @@ class TypeScriptRugReviewerTest extends FlatSpec with Matchers {
       s".atomist/reviewers/SimpleReviewer.ts",
       SimpleReviewerWithParameters))
 
-    reviewResult.note should be(ParameterContent)
-    reviewResult.comments.isEmpty should be(true)
+    assert(reviewResult.note === ParameterContent)
+    assert(reviewResult.comments.isEmpty === true)
   }
 
   it should "run simple reviewer compiled from TypeScript with parameters and populated single partial comment ReviewResult" in {
@@ -145,14 +145,14 @@ class TypeScriptRugReviewerTest extends FlatSpec with Matchers {
       s".atomist/reviewers/SimpleReviewer.ts",
       SimpleReviewerWithParametersSinglePartialCommentReviewResult))
 
-    reviewResult.note should be(ParameterContent)
-    reviewResult.comments.isEmpty should be(false)
+    assert(reviewResult.note === ParameterContent)
+    assert(reviewResult.comments.isEmpty === false)
     val singleComment = reviewResult.comments.head
-    singleComment.comment should be(ParameterContent)
-    singleComment.severity should be(Severity.BROKEN)
-    singleComment.fileName should be(None)
-    singleComment.line should be(None)
-    singleComment.column should be(None)
+    assert(singleComment.comment === ParameterContent)
+    assert(singleComment.severity === Severity.BROKEN)
+    assert(singleComment.fileName === None)
+    assert(singleComment.line === None)
+    assert(singleComment.column === None)
   }
 
   it should "run simple reviewer compiled from TypeScript with parameters and populated multiple partial comments in the ReviewResult" in {
@@ -160,23 +160,23 @@ class TypeScriptRugReviewerTest extends FlatSpec with Matchers {
       s".atomist/reviewers/SimpleReviewer.ts",
       SimpleReviewerWithParametersMultiPartialCommentsReviewResult))
 
-    reviewResult.note should be(ParameterContent)
-    reviewResult.comments.isEmpty should be(false)
-    reviewResult.comments.length should be(2)
+    assert(reviewResult.note === ParameterContent)
+    assert(reviewResult.comments.isEmpty === false)
+    assert(reviewResult.comments.length === 2)
 
     val firstComment = reviewResult.comments.head
-    firstComment.comment should be(ParameterContent)
-    firstComment.severity should be(Severity.BROKEN)
-    firstComment.fileName should be(None)
-    firstComment.line should be(None)
-    firstComment.column should be(None)
+    assert(firstComment.comment === ParameterContent)
+    assert(firstComment.severity === Severity.BROKEN)
+    assert(firstComment.fileName === None)
+    assert(firstComment.line === None)
+    assert(firstComment.column === None)
 
     val secondComment = reviewResult.comments.tail.head
-    secondComment.comment should be("something else")
-    secondComment.severity should be(Severity.FINE)
-    secondComment.fileName should be(None)
-    secondComment.line should be(None)
-    secondComment.column should be(None)
+    assert(secondComment.comment === "something else")
+    assert(secondComment.severity === Severity.FINE)
+    assert(secondComment.fileName === None)
+    assert(secondComment.line === None)
+    assert(secondComment.column === None)
   }
 
   it should "run simple reviewer compiled from TypeScript with parameters and populated complete comment ReviewResult" in {
@@ -184,21 +184,21 @@ class TypeScriptRugReviewerTest extends FlatSpec with Matchers {
       s".atomist/reviewers/SimpleReviewer.ts",
       SimpleReviewerWithParametersSingleCompleteCommentReviewResult))
 
-    reviewResult.note should be(ParameterContent)
-    reviewResult.comments.isEmpty should be(false)
+    assert(reviewResult.note === ParameterContent)
+    assert(reviewResult.comments.isEmpty === false)
     val singleComment = reviewResult.comments.head
-    singleComment.comment should be(ParameterContent)
-    singleComment.severity should be(Severity.BROKEN)
-    singleComment.fileName should be(Some("file.txt"))
-    singleComment.line should be(Some(1))
-    singleComment.column should be(Some(1))
+    assert(singleComment.comment === ParameterContent)
+    assert(singleComment.severity === Severity.BROKEN)
+    assert(singleComment.fileName === Some("file.txt"))
+    assert(singleComment.line === Some(1))
+    assert(singleComment.column === Some(1))
   }
 
-  private def invokeAndVerifySimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): ReviewResult = {
+  private  def invokeAndVerifySimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): ReviewResult = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectReviewer]
-    jsed.name should be("Simple")
+    assert(jsed.name === "Simple")
     jsed.setContext(others)
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/NamedJavaScriptEventHandlerTest.scala
@@ -113,9 +113,9 @@ class NamedJavaScriptEventHandlerTest extends FlatSpec with Matchers{
     val har = new HandlerArchiveReader(treeMaterializer, atomistConfig)
     val handlers = har.handlers("XX", TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(reOpenCloseIssueProgram,issuesStuff)), None, Nil,
       new ConsoleMessageBuilder("XX", SimpleActionRegistry))
-    handlers.size should be(1)
+    assert(handlers.size === 1)
     val handler = handlers.head
-    handler.rootNodeName should be("issue")
+    assert(handler.rootNodeName === "issue")
     handler.handle(SysEvent,null)
   }
 }
@@ -134,6 +134,7 @@ object SimpleActionRegistry extends ActionRegistry {
 }
 
 object SysEvent extends SystemEvent ("blah", "issue", 0l)
+
 
 class IssueTreeNode extends TerminalTreeNode {
 
@@ -154,6 +155,7 @@ class IssueTreeNode extends TerminalTreeNode {
 object TestTreeMaterializer extends TreeMaterializer {
 
   override def rootNodeFor(e: SystemEvent, pe: PathExpression): TreeNode = new IssueTreeNode()
+
 
   override def hydrate(teamId: String, rawRootNode: TreeNode, pe: PathExpression): TreeNode = rawRootNode
 }

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
@@ -35,7 +35,7 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
     val sc = new jsSafeCommittingProxy(fmv, new FakeCommandRegistry(fc))
     val ajs: AbstractJSObject = sc.getMember("execute").asInstanceOf[AbstractJSObject]
     val afc = ajs.call(fmv, null)
-    fc.fmv should be(fmv)
+    assert(fc.fmv === fmv)
     afc.asInstanceOf[AnotherFakeCommand].really("This is really working")
   }
 
@@ -70,6 +70,7 @@ class FakeCommand extends Command[FileMutableView] {
   override def invokeOn(treeNode: FileMutableView): AnyRef = {
     fmv = treeNode
     new AnotherFakeCommand
+  
   }
 }
 

--- a/src/test/scala/com/atomist/rug/runtime/rugdsl/RugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/rugdsl/RugEditorTest.scala
@@ -43,7 +43,7 @@ class RugEditorTest extends FlatSpec with Matchers {
   }
 
   val otherEditor: ProjectEditor = new ProjectEditorSupport {
-    override protected def modifyInternal(as: ArtifactSource, pmi: ProjectOperationArguments): ModificationAttempt = {
+    override protected  def modifyInternal(as: ArtifactSource, pmi: ProjectOperationArguments): ModificationAttempt = {
       SuccessfulModification(as + StringFileArtifact("src/from/typescript",
         pmi.stringParamValue("otherParam")))
     }
@@ -55,11 +55,11 @@ class RugEditorTest extends FlatSpec with Matchers {
     override def description: String = name
   }
 
-  private def invokeAndVerifyIdempotentSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil) = {
+  private  def invokeAndVerifyIdempotentSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil) = {
     val as = SimpleFileBasedArtifactSource(tsf)
     val ops = new DefaultRugPipeline(DefaultTypeRegistry).create(as, None)
     val red = ops.head.asInstanceOf[RugDrivenProjectEditor]
-    red.name should be("SimpleEditor")
+    assert(red.name === "SimpleEditor")
     red.setContext(others)
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
@@ -67,11 +67,12 @@ class RugEditorTest extends FlatSpec with Matchers {
     val p = SimpleProjectOperationArguments("", Map[String, Object]())
     red.modify(target, p) match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(2)
+        assert(sm.result.totalFileCount === 2)
         sm.result.findFile("src/from/typescript").get.content.contains("Anders") should be(true)
 
         red.modify(sm.result, p) match {
           case _: NoModificationNeeded => //yay
+           //yay
           case sm: SuccessfulModification =>
             fail("That should not have reported modification")
           case _ => ???
@@ -85,11 +86,11 @@ class RugEditorTest extends FlatSpec with Matchers {
     invokeAndVerifySomethingChanged(StringFileArtifact(".atomist/editors/TwoStepEditor.rug", TwoStepEditor))
   }
 
-  private def invokeAndVerifySomethingChanged(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil) = {
+  private  def invokeAndVerifySomethingChanged(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil) = {
     val as = SimpleFileBasedArtifactSource(tsf)
     val ops = new DefaultRugPipeline(DefaultTypeRegistry).create(as, None)
     val red = ops.head.asInstanceOf[RugDrivenProjectEditor]
-    red.name should be("TwoStepEditor")
+    assert(red.name === "TwoStepEditor")
     red.setContext(others)
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("README", "I dub thee... Flounder"))
@@ -97,7 +98,7 @@ class RugEditorTest extends FlatSpec with Matchers {
     val p = SimpleProjectOperationArguments("", Map[String, Object]())
     red.modify(target, p) match {
       case sm: SuccessfulModification =>
-        sm.result.totalFileCount should be(2)
+        assert(sm.result.totalFileCount === 2)
         sm.result.findFile("DoubleSecretFile").get.content.contains("Probation") should be(true)
         sm.result.findFile("README").get.content.contains("Flounder") should be(true)
         sm.result.findFile("README").get.content.contains("Pledge") should be(false)
@@ -120,7 +121,7 @@ class RugExecutorIsNoLongerSupportedTest extends FlatSpec with Matchers {
       new DefaultRugPipeline(DefaultTypeRegistry).create(as, None)
       fail("that should fail")
     } catch {
-      case bre: BadRugException => bre.getMessage should be("The Rug DSL no longer supports executors. Try writing it in TypeScript!")
+      case bre: BadRugException => assert(bre.getMessage === "The Rug DSL no longer supports executors. Try writing it in TypeScript!")
     }
   }
 

--- a/src/test/scala/com/atomist/rug/test/TestLoaderTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestLoaderTest.scala
@@ -9,8 +9,9 @@ class TestLoaderTest extends FlatSpec with Matchers {
   val ac = DefaultAtomistConfig
   val testLoader = new TestLoader(ac)
 
+
   it should "not find scenarios in empty ArtifactSource" in {
-    testLoader.loadTestScenarios(EmptyArtifactSource("")).size should be (0)
+    assert(testLoader.loadTestScenarios(EmptyArtifactSource("")).size === 0)
   }
 
   val foobarScenario =
@@ -40,11 +41,12 @@ class TestLoaderTest extends FlatSpec with Matchers {
     """.stripMargin
 
   it should "ignore test scenarios in root" in {
-    testLoader.loadTestScenarios(new SimpleFileBasedArtifactSource("",
+    assert(testLoader.loadTestScenarios(new SimpleFileBasedArtifactSource("",
       Seq(
         StringFileArtifact("foo.rt", foobarScenario),
         StringFileArtifact("baz.rt", bazScenario)))
-    ).size should be (0)
+    
+    ).size === 0)
   }
 
   it should s"find test scenarios under ${ac.testsRoot}" in {
@@ -52,9 +54,10 @@ class TestLoaderTest extends FlatSpec with Matchers {
       Seq(
         StringFileArtifact(s"${ac.testsRoot}/foo.rt", foobarScenario),
         StringFileArtifact(s"${ac.testsRoot}/deeper/baz.rt", bazScenario)))
+    
     )
-    scenarios.size should be (2)
-    scenarios.map(sc => sc.name).toSet should equal (Set("Foobar", "Baz"))
+    assert(scenarios.size === 2)
+    assert(scenarios.map(sc => sc.name).toSet === Set("Foobar", "Baz"))
   }
 
   it should s"find test scenarios under ${DefaultAtomistConfig.testsDirectory}" in {
@@ -62,8 +65,9 @@ class TestLoaderTest extends FlatSpec with Matchers {
       Seq(
         StringFileArtifact(s"${ac.testsDirectory}/foo.rt", foobarScenario),
         StringFileArtifact(s"${ac.testsDirectory}/deeper/baz.rt", bazScenario)))
+    
     )
-    scenarios.size should be (2)
-    scenarios.map(sc => sc.name).toSet should equal (Set("Foobar", "Baz"))
+    assert(scenarios.size === 2)
+    assert(scenarios.map(sc => sc.name).toSet === Set("Foobar", "Baz"))
   }
 }

--- a/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestRunnerTest.scala
@@ -13,6 +13,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
 
   val testRunner = new TestRunner
 
+
   it should "fail when not finding editor" in {
     val f = StringFileArtifact("src/main/java/Dog.java", "class Dog {}")
     val prog =
@@ -33,8 +34,8 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), Nil)
-    executedTests.tests.size should be(1)
-    executedTests.tests.head.passed should be(false)
+    assert(executedTests.tests.size === 1)
+    assert(executedTests.tests.head.passed === false)
   }
 
   it should "test a generator with parameters" in {
@@ -65,9 +66,9 @@ class TestRunnerTest extends FlatSpec with Matchers {
     val parsedTest = RugTestParser.parse(generatorTest)
     val executedTests = testRunner.run(parsedTest, rugArchive, parsedGenerator)
 
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     val testResult = executedTests.tests.head
-    testResult.passed should be(true)
+    assert(testResult.passed === true)
   }
 
   it should "test a generator" in {
@@ -94,9 +95,9 @@ class TestRunnerTest extends FlatSpec with Matchers {
     val parsedTest = RugTestParser.parse(generatorTest)
     val executedTests = testRunner.run(parsedTest, rugArchive, parsedGenerator)
 
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     val testResult = executedTests.tests.head
-    testResult.passed should be(true)
+    assert(testResult.passed === true)
   }
 
   it should "pass with passing editor and file created inline" in {
@@ -167,6 +168,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |  fileCount = 1
          |  and fileContains "src/main/java/Cat.java" "class Cat"
       """.stripMargin, rugAs = new SimpleFileBasedArtifactSource("", StringFileArtifact("resources/foobar", f.content))
+    
     )
   }
 
@@ -187,6 +189,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
          |  fileCount = 1
          |  and fileContains "src/main/java/Cat.java" "class Cat"
       """.stripMargin, rugAs = new SimpleFileBasedArtifactSource("", StringFileArtifact("resources/" + f.path, f.content))
+    
     )
   }
 
@@ -251,7 +254,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin, Some("testnamespace"))
   }
 
-  private def shouldPass(prog: String, namespace: Option[String] = None, rugAs: ArtifactSource = EmptyArtifactSource("")) = {
+  private  def shouldPass(prog: String, namespace: Option[String] = None, rugAs: ArtifactSource = EmptyArtifactSource("")) = {
     val edProg =
       """
         |editor Rename
@@ -265,13 +268,15 @@ class TestRunnerTest extends FlatSpec with Matchers {
 
     val rp = new DefaultRugPipeline()
 
+
     val as = new SimpleFileBasedArtifactSource(DefaultRugArchive, StringFileArtifact(rp.defaultFilenameFor(edProg), edProg))
     val eds = rp.create(as, namespace)
     val testProg = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(testProg, rugAs, eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+    
     }
   }
 
@@ -306,9 +311,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if !t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -339,9 +346,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if !t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -374,9 +383,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
 
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -409,10 +420,12 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head.eventLog.input.shouldBe(defined)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -445,9 +458,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -480,9 +495,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin
     val test = RugTestParser.parse(StringFileArtifact("x.rt", prog))
     val executedTests = testRunner.run(test, EmptyArtifactSource(""), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -493,7 +510,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
   it should "test edit README omitting default parameter" in
     testEditReadMe(false)
 
-  private def testEditReadMe(includeSecondParameter: Boolean) = {
+  private  def testEditReadMe(includeSecondParameter: Boolean) = {
     val prog =
       """
         |editor UpdateReadme
@@ -535,9 +552,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
       """.stripMargin)
     val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, new SimpleFileBasedArtifactSource("", readme), eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -571,9 +590,11 @@ class TestRunnerTest extends FlatSpec with Matchers {
     val eds = new DefaultRugPipeline().create(editorBackingArchive, None, Nil)
     val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, editorBackingArchive, eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -582,6 +603,7 @@ class TestRunnerTest extends FlatSpec with Matchers {
 
 class MoreTestRunnerTest extends FlatSpec with Matchers {
   val testRunner = new TestRunner
+
 
   it should "pass the assertion when a precondition restricts an editor from running" in {
     val prog =
@@ -621,9 +643,11 @@ class MoreTestRunnerTest extends FlatSpec with Matchers {
     val eds = new DefaultRugPipeline().create(editorBackingArchive, None, Nil)
     val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, editorBackingArchive, eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }
@@ -631,6 +655,7 @@ class MoreTestRunnerTest extends FlatSpec with Matchers {
 
 class EvenMoreTestRunnerTest extends FlatSpec with Matchers {
   val testRunner = new TestRunner
+
 
   it should "pass the assertion when preconditions restrict an editor from running" in {
     val prog =
@@ -670,9 +695,11 @@ class EvenMoreTestRunnerTest extends FlatSpec with Matchers {
     val eds = new DefaultRugPipeline().create(editorBackingArchive, None, Nil)
     val test = RugTestParser.parse(StringFileArtifact("x.rt", scenario))
     val executedTests = testRunner.run(test, editorBackingArchive, eds)
-    executedTests.tests.size should be(1)
+    assert(executedTests.tests.size === 1)
     executedTests.tests.head match {
       case t if t.passed =>
+      // Ok
+    
       // Ok
     }
   }

--- a/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
@@ -28,11 +28,11 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.name should be(scenarioName)
-    test.computations.size should be(1)
-    test.computations.head.name should be("cat")
+    assert(test.name === scenarioName)
+    assert(test.computations.size === 1)
+    assert(test.computations.head.name === "cat")
   }
 
   it should "parse single file assertion" in
@@ -40,17 +40,17 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
 
   it should "default debug flag to false" in {
     val scenario = parseSingleFileAssertion("src/main/java/Dog.java")
-    scenario.debug should be(false)
+    assert(scenario.debug === false)
   }
 
   it should "set debug flag explicitly to false" in {
     val scenario = parseSingleFileAssertion("src/main/java/Dog.java", Some(false))
-    scenario.debug should be(false)
+    assert(scenario.debug === false)
   }
 
   it should "set debug flag explicitly to true" in {
     val scenario = parseSingleFileAssertion("src/main/java/Dog.java", Some(true))
-    scenario.debug should be(true)
+    assert(scenario.debug === true)
   }
 
   it should "parse single file assertion with unusual characters besides space in filename" in {
@@ -58,7 +58,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
     strangeContent.foreach(c => parseSingleFileAssertion(s"src/${c}main/java/Dog.java"))
   }
 
-  private def parseSingleFileAssertion(filepath: String, debug: Option[Boolean] = None): TestScenario = {
+  private  def parseSingleFileAssertion(filepath: String, debug: Option[Boolean] = None): TestScenario = {
     val f = InlineFileSpec(filepath, "class Dog {}")
     val scenarioName = "Class rename should work"
     val prog =
@@ -78,12 +78,12 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.name should be(scenarioName)
-    test.computations.size should be(0)
-    test.givenFiles.fileSpecs should equal(Seq(f))
-    test.outcome.assertions should equal(Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
+    assert(test.name === scenarioName)
+    assert(test.computations.size === 0)
+    assert(test.givenFiles.fileSpecs === Seq(f))
+    assert(test.outcome.assertions === Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
       Seq(WrappedFunctionArg(SimpleLiteral(filepath.replace("Dog", "Cat"))),
         WrappedFunctionArg(SimpleLiteral("class Cat {}"))
       )))))
@@ -96,7 +96,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
   it should "accept open when" in
     parseLoadFile(true)
 
-  private def parseLoadFile(useWhen: Boolean = false) {
+  private  def parseLoadFile(useWhen: Boolean = false) {
     val f = LoadedFileSpec("src/main/java/Dog.java", "resources/Dog.java")
     val scenarioName = "Class rename should work"
     val prog =
@@ -114,11 +114,11 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.name should be(scenarioName)
-    test.givenFiles.fileSpecs should equal(Seq(f))
-    test.outcome.assertions should equal(Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
+    assert(test.name === scenarioName)
+    assert(test.givenFiles.fileSpecs === Seq(f))
+    assert(test.outcome.assertions === Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
       Seq(WrappedFunctionArg(SimpleLiteral("src/main/java/Cat.java")),
         WrappedFunctionArg(SimpleLiteral("class Cat {}")))))
     ))
@@ -141,16 +141,16 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.name should be(scenarioName)
-    test.givenFiles.fileSpecs should equal(Seq(f))
+    assert(test.name === scenarioName)
+    assert(test.givenFiles.fileSpecs === Seq(f))
     val poa = test.args
     poa.parameterValues.size should be >= 2
     poa.paramValue("old_class") should equal("Dog")
     poa.paramValue("new_class") should equal("Cat")
 
-    test.outcome.assertions should equal(Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
+    assert(test.outcome.assertions === Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
       Seq(WrappedFunctionArg(SimpleLiteral("src/main/java/Cat.java")),
         WrappedFunctionArg(SimpleLiteral("class Cat {}")))))
     ))
@@ -173,9 +173,9 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.givenFiles.fileSpecs should equal(Seq(EmptyArchiveFileSpec))
+    assert(test.givenFiles.fileSpecs === Seq(EmptyArchiveFileSpec))
   }
 
   it should "parse load archive root" in {
@@ -194,9 +194,9 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.givenFiles.fileSpecs should equal(Seq(ArchiveRootFileSpec))
+    assert(test.givenFiles.fileSpecs === Seq(ArchiveRootFileSpec))
   }
 
   it should "parse file load assertion" in {
@@ -216,11 +216,11 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.name should be(scenarioName)
-    test.givenFiles.fileSpecs should equal(Seq(f))
-    test.outcome.assertions should equal(Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
+    assert(test.name === scenarioName)
+    assert(test.givenFiles.fileSpecs === Seq(f))
+    assert(test.outcome.assertions === Seq(PredicateAssertion(ParsedRegisteredFunctionPredicate("contentEquals",
       Seq(WrappedFunctionArg(SimpleLiteral("src/main/java/Cat.java")),
         WrappedFunctionArg(SimpleLiteral("class Cat {}")))))
     ))
@@ -244,10 +244,10 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.givenFiles.fileSpecs should equal(Seq(f, f))
-    test.outcome.assertions.size should be(2)
+    assert(test.givenFiles.fileSpecs === Seq(f, f))
+    assert(test.outcome.assertions.size === 2)
     //    test.outcome.assertions should equal(Seq(PredicateAssertion(
     //      ParsedRegisteredFunctionPredicate("contentEquals",
     //        Seq(StringLiteralFunctionArg("src/main/java/Cat.java"),
@@ -279,9 +279,9 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.size should be(1)
+    assert(tp.size === 1)
     val test = tp.head
-    test.givenFiles.fileSpecs should equal(Seq(f, f))
+    assert(test.givenFiles.fileSpecs === Seq(f, f))
     //    test.outcome.assertions should equal(Seq(PredicateAssertion(
     //      ParsedRegisteredFunctionPredicate("contentEquals",
     //        Seq(StringLiteralFunctionArg("src/main/java/Cat.java"),
@@ -308,7 +308,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.head.outcome.assertions should equal(Seq(NoChangeAssertion))
+    assert(tp.head.outcome.assertions === Seq(NoChangeAssertion))
   }
 
   it should "accept NotApplicable keyword" in {
@@ -326,7 +326,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.head.outcome.assertions should equal(Seq(NotApplicableAssertion))
+    assert(tp.head.outcome.assertions === Seq(NotApplicableAssertion))
   }
 
   it should "accept ShouldFail keyword" in {
@@ -344,7 +344,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
       """.stripMargin
 
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.head.outcome.assertions should equal(Seq(ShouldFailAssertion))
+    assert(tp.head.outcome.assertions === Seq(ShouldFailAssertion))
   }
 
   // TODO "and" gets run into preceding "v".
@@ -380,7 +380,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
         |  and fileContains readmePath project_name
       """.stripMargin
     val tp = parser.parse(StringFileArtifact("x.rt", prog))
-    tp.head.outcome.assertions.size should be(6)
+    assert(tp.head.outcome.assertions.size === 6)
   }
 
   it.should("allow operations in the given clause").in {
@@ -398,7 +398,7 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
         |  NoChange""".stripMargin
     val parsed = parser.parse(StringFileArtifact("IdempotencyTest.rt", prog))
     val myTest = parsed.head
-    myTest.givenInvocations.size should be(1)
+    assert(myTest.givenInvocations.size === 1)
   }
 
   it should "allow multiple operations in the given clause" in {
@@ -417,6 +417,6 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
         |  NoChange""".stripMargin
     val parsed = parser.parse(StringFileArtifact("IdempotencyTest.rt", prog))
     val myTest = parsed.head
-    myTest.givenInvocations.size should be(2)
+    assert(myTest.givenInvocations.size === 2)
   }
 }

--- a/src/test/scala/com/atomist/tree/content/text/FormatInfoTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/FormatInfoTest.scala
@@ -8,26 +8,26 @@ class FormatInfoTest extends FlatSpec with Matchers {
 
   it should "find position at start of file" in {
     val fi = contextInfo("")
-    fi.offset should be (0)
-    fi.columnNumberFrom1 should be (1)
-    fi.lineNumberFrom1 should be (1)
-    fi.indentDepth should be (0)
+    assert(fi.offset === 0)
+    assert(fi.columnNumberFrom1 === 1)
+    assert(fi.lineNumberFrom1 === 1)
+    assert(fi.indentDepth === 0)
   }
 
   it should "find position within first line of file" in {
     val input = "The quick brown"
     val fi = contextInfo(input)
-    fi.columnNumberFrom1 should be (input.length + 1)
-    fi.lineNumberFrom1 should be (1)
-    fi.indentDepth should be (0)
+    assert(fi.columnNumberFrom1 === input.length + 1)
+    assert(fi.lineNumberFrom1 === 1)
+    assert(fi.indentDepth === 0)
   }
 
   it should "find position in second line of file" in {
     val input = "The\n "
     val fi = contextInfo(input)
-    fi.columnNumberFrom1 should be (2)
-    fi.lineNumberFrom1 should be (2)
-    fi.indentDepth should be (1)
+    assert(fi.columnNumberFrom1 === 2)
+    assert(fi.lineNumberFrom1 === 2)
+    assert(fi.indentDepth === 1)
   }
 
   it should "recognize indent depth of 4 with spaces" in
@@ -35,16 +35,16 @@ class FormatInfoTest extends FlatSpec with Matchers {
 
   it should "recognize indent depth of 3 with spaces" in {
     val fi = testIndent("   ")
-    fi.usesTabs should be (false)
+    assert(fi.usesTabs === false)
 
   }
 
   it should "recognize indent depth of 1 with tabs" in {
     val fi = testIndent("\t")
-    fi.usesTabs should be (true)
+    assert(fi.usesTabs === true)
   }
 
-  private def testIndent(indent: String): PointFormatInfo = {
+  private  def testIndent(indent: String): PointFormatInfo = {
     val input =
       s"""
         |public class Foobar {
@@ -53,10 +53,10 @@ class FormatInfoTest extends FlatSpec with Matchers {
         |${indent}void doSomething() {
         |${indent}${indent}doIt();""".stripMargin
     val fi = contextInfo(input)
-    fi.columnNumberFrom1 should be (2 * indent.length + 8)
-    fi.lineNumberFrom1 should be (6)
-    fi.indentDepth should be (2)
-    fi.indent should be (indent)
+    assert(fi.columnNumberFrom1 === 2 * indent.length + 8)
+    assert(fi.lineNumberFrom1 === 6)
+    assert(fi.indentDepth === 2)
+    assert(fi.indent === indent)
     fi
   }
 
@@ -66,7 +66,7 @@ class FormatInfoTest extends FlatSpec with Matchers {
   it should "add indented content with tab" in
     testAddContent("\t", "Whatever")
 
-  private def testAddContent(indent: String, content: String): String = {
+  private  def testAddContent(indent: String, content: String): String = {
     val input =
       s"""
          |public class Foobar {
@@ -75,8 +75,8 @@ class FormatInfoTest extends FlatSpec with Matchers {
         |${indent}void doSomething() {
          |${indent}${indent}doIt();""".stripMargin
     val fi = contextInfo(input)
-    fi.indent should be (indent)
-    fi.indentDepth should be (2)
+    assert(fi.indent === indent)
+    assert(fi.indentDepth === 2)
     val indented = fi.indented(content)
     indented.take(indent.length + 1) should equal ("\n" + indent)
     val r = input + fi.indented(content)
@@ -97,8 +97,8 @@ class FormatInfoTest extends FlatSpec with Matchers {
          |${indent}void doSomething() {
          |${indent}${indent}doIt();""".stripMargin
     val fi = contextInfo(input)
-    fi.indent should be (indent)
-    fi.indentDepth should be (2)
+    assert(fi.indent === indent)
+    assert(fi.indentDepth === 2)
     val indented = fi.indented(content)
     indented.contains("\t") should be (false)
     indented.take(indent.length + 1) should equal ("\n" + indent)

--- a/src/test/scala/com/atomist/tree/content/text/LineInputPositionImplTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/LineInputPositionImplTest.scala
@@ -7,25 +7,25 @@ class LineInputPositionImplTest extends FlatSpec with Matchers {
   it should "find position at start of single line" in {
     val input = "The quick brown fox jumped over the lazy dog"
     val p = LineInputPositionImpl(input, 1, 1)
-    p.offset should be (0)
+    assert(p.offset === 0)
   }
 
   it should "find position within single line" in {
     val input = "The quick brown fox jumped over the lazy dog"
     val p = LineInputPositionImpl(input, 1, 5)
-    p.offset should be (4)
+    assert(p.offset === 4)
   }
 
   it should "find position at beginning of second line" in {
     val input = "The\nAnd this is a test"
     val p = LineInputPositionImpl(input, 2, 1)
-    p.offset should be (4)
+    assert(p.offset === 4)
   }
 
   it should "show marker" in {
     val input = "The\nAnd this is a test"
     val p = LineInputPositionImpl(input, 2, 1)
-    p.offset should be (4)
+    assert(p.offset === 4)
     p.show.contains("And this") should be (true)
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/MutableTerminalTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/MutableTerminalTreeNodeTest.scala
@@ -8,21 +8,21 @@ class MutableTerminalTreeNodeTest extends FlatSpec with Matchers {
     val initialInput = "Cats are cool"
     val sm = new MutableTerminalTreeNode("animal", "Cat", LineInputPositionImpl(initialInput, 1, 1))
     sm.update("Dog")
-    sm.value should equal("Dog")
+    assert(sm.value === "Dog")
   }
 
   it should "update in line" in {
     val initialInput = "Some cats are cool"
     val sm = new MutableTerminalTreeNode("animal", "cat", LineInputPositionImpl(initialInput, 1, 6))
     sm.update("dog")
-    sm.value should equal("dog")
+    assert(sm.value === "dog")
   }
 
   it should "update empty string at end of input" in {
     val initialInput = "Some cats are cool"
     val sm = new MutableTerminalTreeNode("animal", "", LineInputPositionImpl(initialInput, 1, initialInput.length))
     sm.update("er than others")
-    sm.value should equal("er than others")
+    assert(sm.value === "er than others")
   }
 
 }

--- a/src/test/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNodeTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/PositionedMutableContainerTreeNodeTest.scala
@@ -15,10 +15,11 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length + padding.length))
 
+
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
     soo.pad(line)
 
-    soo.value should equal (line)
+    assert(soo.value === line)
   }
 
   it should "refuse to find format info for child node without pad" in {
@@ -29,7 +30,9 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
 
+
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
+
 
     an[IllegalStateException] should be thrownBy soo.formatInfo(f1)
   }
@@ -42,15 +45,16 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
 
+
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1, f2), startOf(line), endOf(line))
     soo.pad(line)
 
     soo.formatInfo(f1) match {
       case Some(fi) =>
-        fi.start.offset should be(f1.startPosition.offset)
-        fi.start.lineNumberFrom1 should be(1)
-        fi.end.offset should be(f1.endPosition.offset)
-        fi.end.lineNumberFrom1 should be(1)
+        assert(fi.start.offset === f1.startPosition.offset)
+        assert(fi.start.lineNumberFrom1 === 1)
+        assert(fi.end.offset === f1.endPosition.offset)
+        assert(fi.end.lineNumberFrom1 === 1)
       case _ => ???
     }
   }
@@ -62,6 +66,7 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
 
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length))
+
 
     val soo = new SimpleMutableContainerTreeNode("x", Seq(f1), startOf(line), endOf(line))
     soo.pad(line)
@@ -81,18 +86,21 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length))
 
+
     val ff1 = new MutableTerminalTreeNode("c1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
     val ff2 = new MutableTerminalTreeNode("c2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + bollocks2.length))
 
+
     val f3 = new SimpleMutableContainerTreeNode("c", Seq(ff1, ff2), ff1.startPosition, endOf(line))
+
 
     val soo = SimpleMutableContainerTreeNode.wholeInput("x", Seq(f1, f2, f3), line)
 
     soo.formatInfo(SimpleTerminalTreeNode("x", "y")) should be (empty)
 
-    soo.formatInfo(f1).get.start.offset should equal (f1.startPosition.offset)
-    soo.formatInfo(f2).get.start.offset should equal (f2.startPosition.offset)
-    soo.formatInfo(ff1).get.start.offset should equal (ff1.startPosition.offset)
+    assert(soo.formatInfo(f1).get.start.offset === f1.startPosition.offset)
+    assert(soo.formatInfo(f2).get.start.offset === f2.startPosition.offset)
+    assert(soo.formatInfo(ff1).get.start.offset === ff1.startPosition.offset)
   }
 
   it should "find format info from nested node in multiple lines" in {
@@ -107,18 +115,21 @@ class PositionedMutableContainerTreeNodeTest extends FlatSpec with Matchers {
     val f1 = new MutableTerminalTreeNode("a", inputA, LineHoldingOffsetInputPosition(line, 0))
     val f2 = new MutableTerminalTreeNode("b", inputB, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length))
 
+
     val ff1 = new MutableTerminalTreeNode("c1", inputC, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length))
     val ff2 = new MutableTerminalTreeNode("c2", inputD, LineHoldingOffsetInputPosition(line, inputA.length + unmatchedContent.length + inputB.length + inputC.length + bollocks2.length))
 
+
     val f3 = new SimpleMutableContainerTreeNode("c", Seq(ff1, ff2), ff1.startPosition, endOf(line))
+
 
     val soo = SimpleMutableContainerTreeNode.wholeInput("x", Seq(f1, f2, f3), line)
 
     soo.formatInfo(SimpleTerminalTreeNode("x", "y")) should be (empty)
 
-    soo.formatInfo(f1).get.start.offset should equal (f1.startPosition.offset)
-    soo.formatInfo(f2).get.start.offset should equal (f2.startPosition.offset)
-    soo.formatInfo(ff1).get.start.offset should equal (ff1.startPosition.offset)
+    assert(soo.formatInfo(f1).get.start.offset === f1.startPosition.offset)
+    assert(soo.formatInfo(f2).get.start.offset === f2.startPosition.offset)
+    assert(soo.formatInfo(ff1).get.start.offset === ff1.startPosition.offset)
     soo.formatInfo(ff1).get.start.lineNumberFrom1 should be > (1)
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarTest.scala
@@ -18,26 +18,26 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     m.count should be >= 1
     m.childrenNamed("thing").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.nodeName should equal("thing")
-        sm.value should equal(input)
+        assert(sm.nodeName === "thing")
+        assert(sm.value === input)
         val newContent = "This is the new content"
         sm.update(newContent)
-        sm.dirty should be(true)
-        m.dirty should be(true)
-        m.value should equal(newContent)
+        assert(sm.dirty === true)
+        assert(m.dirty === true)
+        assert(m.value === newContent)
     }
   }
 
   it should "parse 1 match of 2 parts in whole string" in {
     val Right(matches) = aWasaB.strictMatch("Henry was aged 19")
-    matches.count should be(2)
+    assert(matches.count === 2)
     matches.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Henry")
+        assert(sm.value === "Henry")
     }
     matches.childrenNamed("age").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("19")
+        assert(sm.value === "19")
     }
   }
 
@@ -50,20 +50,20 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     val g = aWasaB
     val input = "Henry was aged 19"
     val Right(matches) = g.strictMatch(input)
-    matches.value should equal(input)
+    assert(matches.value === input)
     matches.count should be >= 2
-    matches.dirty should be(false)
+    assert(matches.dirty === false)
     matches.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Henry")
+        assert(sm.value === "Henry")
         sm.update("Dave")
     }
     matches.childrenNamed("age").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("19")
+        assert(sm.value === "19")
         sm.update("40")
     }
-    matches.dirty should be(true)
+    assert(matches.dirty === true)
     val currentContent = matches.value
     currentContent should be("Dave was aged 40")
   }
@@ -72,16 +72,16 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     val g = aWasaB
     val input = "rubbish goes here. Henry was aged 12"
     val m = g.findMatches(input)
-    m.size should be(1)
+    assert(m.size === 1)
     m.head.count should be >= 2
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Henry")
+        assert(sm.value === "Henry")
       case _ => ???
     }
     m.head.childrenNamed("age").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("12")
+        assert(sm.value === "12")
       case _ => ???
     }
   }
@@ -89,16 +89,16 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
   it should "parse 1 match of 2 parts discarding suffix" in {
     val g = aWasaB
     val m = g.findMatches("Henry was aged 24. Blah blah")
-    m.size should be(1)
+    assert(m.size === 1)
     m.head.count should be >= 2
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Henry")
+        assert(sm.value === "Henry")
       case _ => ???
     }
     m.head.childrenNamed("age").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("24")
+        assert(sm.value === "24")
       case _ => ???
     }
   }
@@ -115,21 +115,21 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
       """.stripMargin
     )
 
-  private def twoMatchesSplit(input: String) {
+  private  def twoMatchesSplit(input: String) {
     val g = aWasaB
     val m = g.findMatches(input)
-    m.size should be(2)
+    assert(m.size === 2)
     m.head.count should be >= 2
     val t = m(1)
     t.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Alice")
+        assert(sm.value === "Alice")
         sm.startPosition != null should be(true)
       case _ => ???
     }
     t.childrenNamed("age").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("16")
+        assert(sm.value === "16")
       case _ => ???
     }
   }
@@ -143,15 +143,15 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
         |}
       """.stripMargin
     val m = g.findMatches(input)
-    m.size should be(1)
+    assert(m.size === 1)
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("foo")
+        assert(sm.value === "foo")
       case _ => ???
     }
     m.head.childrenNamed("type").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Int")
+        assert(sm.value === "Int")
       case _ => ???
     }
   }
@@ -165,7 +165,7 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
   //  param_def : name=IDENTIFIER ':' type=IDENTIFIER;
   //  params : param_def (',' param_def)*;
   //  method : 'def' name=IDENTIFIER LPAREN params? RPAREN ':' type=IDENTIFIER;
-  protected def matchScalaMethodHeaderRepsep: Microgrammar = {
+  protected  def matchScalaMethodHeaderRepsep: Microgrammar = {
     val identifier = Regex("[a-zA-Z0-9]+", Some("identifier"))
     val paramDef = Wrap(
       identifier.copy(givenName = Some("name")) ~? ":" ~? identifier.copy(givenName = Some("type")),
@@ -174,43 +174,44 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     val method = "def" ~~ identifier.copy(givenName = Some("name")) ~? "(" ~?
       Wrap(params, "params") ~? ")" ~? ":" ~? identifier.copy(givenName = Some("type"))
     new MatcherMicrogrammar(method)
+  
   }
 
-  private def matchScalaMethodHeaderUsing(mg: Microgrammar, ml: Option[MatchListener] = None) {
+  private  def matchScalaMethodHeaderUsing(mg: Microgrammar, ml: Option[MatchListener] = None) {
     val input =
       """
         |def bar(barParamName: String): Unit = {
         |}
       """.stripMargin
     val m = mg.findMatches(input, ml)
-    if (ml.isDefined) ml.get.matches should equal(1)
-    m.size should be(1)
+    if (ml.isDefined) assert(ml.get.matches === 1)
+    assert(m.size === 1)
     //println(TreeNodeUtils.toShortString(m.head))
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("bar")
+        assert(sm.value === "bar")
       case _ => ???
     }
     m.head.childrenNamed("type").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Unit")
+        assert(sm.value === "Unit")
       case _ => ???
     }
     val params = m.head.childrenNamed("params")
     val paramDef1 = params.head.asInstanceOf[ContainerTreeNode].childrenNamed("param_def")
-    paramDef1.size should be(1)
+    assert(paramDef1.size === 1)
     paramDef1.head match {
       case ov: ContainerTreeNode =>
         ov.childrenNamed("name").toList match {
           case (fv: TerminalTreeNode) :: Nil =>
-            fv.nodeName should equal("name")
-            fv.value should equal("barParamName")
+            assert(fv.nodeName === "name")
+            assert(fv.value === "barParamName")
           case _ => ???
         }
         ov.childrenNamed("type").toList match {
           case (fv: TerminalTreeNode) :: Nil =>
-            fv.nodeName should equal("type")
-            fv.value should equal("String")
+            assert(fv.nodeName === "type")
+            assert(fv.value === "String")
           case _ => ???
         }
       case _ => ???
@@ -226,14 +227,14 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
         |}
       """.stripMargin
     val m = matchScalaMethodHeaderRepsep.findMatches(input)
-    m.size should be(1)
+    assert(m.size === 1)
     val last: MutableContainerTreeNode = m.head
     val params = last.childrenNamed("params").head.asInstanceOf[ContainerTreeNode].childrenNamed("param_def")
     params.size should be >= 2
     params foreach {
       case pad: SimpleTerminalTreeNode => pad.nodeName.contains("pad") should be(true)
       case soo: MutableContainerTreeNode =>
-        soo.childrenNamed("type").head.asInstanceOf[TerminalTreeNode].value should be("Int")
+        assert(soo.childrenNamed("type").head.asInstanceOf[TerminalTreeNode].value === "Int")
         val value = soo.childrenNamed("name").head.asInstanceOf[TerminalTreeNode].value
         Set("a", "b").contains(value) should be(true)
       case _ => ???
@@ -249,7 +250,7 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
   it should "parse several scala method headers in other content with other whitespace" in
     parseSeveralScalaMethodHeadersInOtherContent(" ", " ")
 
-  private def parseSeveralScalaMethodHeadersInOtherContent(pad1: String, pad2: String) {
+  private  def parseSeveralScalaMethodHeadersInOtherContent(pad1: String, pad2: String) {
     val input =
       s"""
          |class Something {
@@ -263,15 +264,15 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
          |}
       """.stripMargin
     val m = matchScalaMethodHeaderRepsep.findMatches(input)
-    m.size should be(3)
+    assert(m.size === 3)
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("bar")
+        assert(sm.value === "bar")
       case _ => ???
     }
     m.head.childrenNamed("type").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Unit")
+        assert(sm.value === "Unit")
       case _ => ???
     }
     val last: MutableContainerTreeNode = m(2)
@@ -280,7 +281,7 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
     params foreach {
       case pad: SimpleTerminalTreeNode => pad.nodeName.contains("pad") should be(true)
       case soo: MutableContainerTreeNode =>
-        soo.childrenNamed("type").head.asInstanceOf[TerminalTreeNode].value should be("Int")
+        assert(soo.childrenNamed("type").head.asInstanceOf[TerminalTreeNode].value === "Int")
         val value = soo.childrenNamed("name").head.asInstanceOf[TerminalTreeNode].value
         Set("a", "b").contains(value) should be(true)
       case _ => ???
@@ -304,15 +305,15 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
         |}
       """.stripMargin
     val m = g.findMatches(input)
-    m.size should be(2)
+    assert(m.size === 2)
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("hippo")
+        assert(sm.value === "hippo")
       case _ => ???
     }
     m.head.childrenNamed("type").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Hippopotamus")
+        assert(sm.value === "Hippopotamus")
       case _ => ???
     }
   }
@@ -334,24 +335,24 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
         |}
       """.stripMargin
     val m = matchAnnotatedJavaFields.findMatches(input)
-    m.size should be(2)
+    assert(m.size === 2)
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("hippo")
+        assert(sm.value === "hippo")
     }
     m.head.childrenNamed("type").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Hippopotamus")
+        assert(sm.value === "Hippopotamus")
     }
     val m2 = matchPrivateJavaFields.findMatches(input)
-    m2.size should be(2)
+    assert(m2.size === 2)
   }
 
   class SavingMatchListener extends AbstractMatchListener("test") {
     var hits: List[TreeNode] = Nil
     var skipped: List[PositionalString] = Nil
 
-    override protected def onMatchInternal(m: PositionedTreeNode): Unit = {
+    override protected  def onMatchInternal(m: PositionedTreeNode): Unit = {
       hits = hits :+ m
     }
 
@@ -378,16 +379,16 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
       """.stripMargin
     val ml = new SavingMatchListener
     val m = g.findMatches(input, Some(ml))
-    m.size should be(2)
+    assert(m.size === 2)
     m.head.childrenNamed("name").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("hippo")
+        assert(sm.value === "hippo")
     }
     m.head.childrenNamed("type").head match {
       case sm: MutableTerminalTreeNode =>
-        sm.value should equal("Hippopotamus")
+        assert(sm.value === "Hippopotamus")
     }
-    ml.matches should be(2)
+    assert(ml.matches === 2)
     //ml.hits.foreach(_.asInstanceOf[MutableObjectFieldValueImpl].startPosition.asInstanceOf[LineInputPosition].lineFrom1 should be > (1))
     //ml.skipped.size should be > (0)
   }
@@ -411,24 +412,26 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
       val pair = "-" ~? key ~? Alternate(":", "=") ~? value
       val envList = "env:" ~~ "global:" ~~ Repsep(pair, WhitespaceOrNewLine, None) //"keys")
       new MatcherMicrogrammar(envList)
+    
     }
     val m = ymlKeys.findMatches(input)
-    m.size should be(1)
+    assert(m.size === 1)
     //    println(TreeNodeUtils.toShorterString(m.head))
     //    println(s"Has ${m.head.fieldValues.size} field values: ${m.head.fieldValues}")
     withClue(s"Didn't expect to find match ${TreeNodeUtils.toShorterString(m.head)} with ${m.head.childNodes.size} children and fields=${m.head.fieldValues}\n") {
       val keys = m.head.childrenNamed("key")
       val values = m.head.childrenNamed("value")
-      keys.size should be(2)
+      assert(keys.size === 2)
       val k1 = keys.head
-      k1.value should equal("CI_DEPLOY_USERNAME")
-      values.head.value should equal("travis-mvn-deploy")
+      assert(k1.value === "CI_DEPLOY_USERNAME")
+      assert(values.head.value === "travis-mvn-deploy")
     }
   }
 
-  private val printlns: MatcherMicrogrammar = {
+  private  val printlns: MatcherMicrogrammar = {
     val printlns = "println(" ~ Break(")", Some("content"))
     new MatcherMicrogrammar(printlns)
+  
   }
 
   it should "use println matcher directory" in {
@@ -444,7 +447,7 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
       """.stripMargin
     printlns.matcher.matchPrefix(InputState(input)) match {
       case Right(pm) =>
-        pm.matched should be(p1)
+        assert(pm.matched === p1)
         val positionedNode = pm.node
         val (hatched, _) = PositionedMutableContainerTreeNode.pad(positionedNode, input)
         p1.contains(hatched.value) should be(true)
@@ -467,36 +470,41 @@ class MatcherMicrogrammarTest extends FlatSpec with Matchers {
          |}
          |""".stripMargin
     val m = printlns.findMatches(input)
-    m.size should be(3)
+    assert(m.size === 3)
     //println(TreeNodeUtils.toShortString(m.head))
-    m.head.value should be(p1)
+    assert(m.head.value === p1)
     val newThing = s"""/* $p1 */"""
     m.head.update(newThing)
-    m.head.dirty should be(true)
-    m.head.value should be(newThing)
+    assert(m.head.dirty === true)
+    assert(m.head.value === newThing)
   }
 
-  protected def thingGrammar: MatcherMicrogrammar = {
+  protected  def thingGrammar: MatcherMicrogrammar = {
     val matcher = Regex(".*", Some("thing"))
     new MatcherMicrogrammar(matcher)
+  
   }
 
-  protected def matchPrivateJavaFields: Microgrammar = {
+  protected  def matchPrivateJavaFields: Microgrammar = {
     val field = "private" ~~ Regex("[a-zA-Z0-9]+", Some("type")) ~~ Regex("[a-zA-Z0-9]+", Some("name"))
     new MatcherMicrogrammar(field)
+  
   }
 
-  protected def aWasaB: MatcherMicrogrammar =
+  protected  def aWasaB: MatcherMicrogrammar =
     new MatcherMicrogrammar(
       Regex("[A-Z][a-z]+", Some("name")) ~? Literal("was aged") ~? Regex("[0-9]+", Some("age"))
     )
 
 
-  protected def matchAnnotatedJavaFields: Microgrammar = {
+
+
+  protected  def matchAnnotatedJavaFields: Microgrammar = {
     val visibility: Matcher = "public" | "private"
     val annotation = "@" ~ Regex("[a-zA-Z0-9]+", Some("annotationType"))
     val field = annotation ~~ visibility ~~ Regex("[a-zA-Z0-9]+", Some("type")) ~~ Regex("[a-zA-Z0-9]+", Some("name"))
     new MatcherMicrogrammar(field)
+  
   }
 
 }
@@ -508,6 +516,7 @@ class RepMatcherTest extends FlatSpec with Matchers {
       val key: Matcher = Regex("[A-Za-z_]+,", Some("key"))
       val sentence: Matcher = Literal("keys:", Some("prefix")) ~? Rep(key, None) //"keys")
       new MatcherMicrogrammar(sentence)
+    
     }
     val input =
       """
@@ -517,7 +526,7 @@ class RepMatcherTest extends FlatSpec with Matchers {
         |      keys: x,y,
       """.stripMargin
     val m = repTest.findMatches(input)
-    m.size should be(2)
+    assert(m.size === 2)
     val firstMatch = m.head
     //println(TreeNodeUtils.toShortString(firstMatch))
     //println(s"First match in its entirely was [${firstMatch.value}]")
@@ -525,7 +534,7 @@ class RepMatcherTest extends FlatSpec with Matchers {
     //println(s"The child names under firstMatch are ${firstMatch.childNodeNames.mkString(",")}")
     val keys: Seq[TreeNode] = m.head.childrenNamed("key")
     withClue(s"Didn't expect ${TreeNodeUtils.toShorterString(m.head)}") {
-      keys.size should be(4)
+      assert(keys.size === 4)
       keys.map(k => k.value) should equal(Seq("a,", "b,", "cde,", "f,"))
     }
   }
@@ -536,6 +545,7 @@ class RepMatcherTest extends FlatSpec with Matchers {
       val key: Matcher = Regex("[A-Za-z_]+,", Some("key"))
       val sentence: Matcher = Literal("keys:", Some("prefix")) ~? Wrap(Rep(key, None) /*"key")*/ , "feet")
       new MatcherMicrogrammar(sentence, "findKeys")
+    
     }
     val input =
       """
@@ -545,12 +555,12 @@ class RepMatcherTest extends FlatSpec with Matchers {
         |      keys: x,y,
       """.stripMargin
     val m = repTest.findMatches(input)
-    m.size should be(2)
+    assert(m.size === 2)
     val firstMatch = m.head
     val feet = firstMatch.childrenNamed("feet")
-    feet.size should be(1)
+    assert(feet.size === 1)
     val keys = feet.head.childrenNamed("key")
-    keys.size should be(4)
+    assert(keys.size === 4)
     keys.map(k => k.value) should equal(Seq("a,", "b,", "cde,", "f,"))
   }
 
@@ -559,6 +569,7 @@ class RepMatcherTest extends FlatSpec with Matchers {
       val key: Matcher = Regex("[A-Za-z_]+", Some("key"))
       val sentence: Matcher = Literal("keys:", Some("prefix")) ~? Repsep(key, Literal(","), None) //keys
       new MatcherMicrogrammar(sentence)
+    
     }
     val input =
       """
@@ -568,11 +579,11 @@ class RepMatcherTest extends FlatSpec with Matchers {
         |      keys: x,y
       """.stripMargin
     val m = repsep.findMatches(input)
-    m.size should be(2)
+    assert(m.size === 2)
     //println(s"Final match=\n${TreeNodeUtils.toShortString(m.head)}")
     //    m.head.childrenNamed("keys").size should be(1)
     val keys: Seq[TreeNode] = m.head.childrenNamed("key") //.head.asInstanceOf[ContainerTreeNode].childrenNamed("key")
-    keys.size should be(4)
+    assert(keys.size === 4)
     keys.map(k => k.value) should equal(Seq("a", "b", "cde", "f"))
   }
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherOperationsTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherOperationsTest.scala
@@ -10,8 +10,8 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val ls = l.toString
     l.matchPrefix(InputState("thing")) match {
       case Right(PatternMatch(tn, "thing", InputState("thing", _, _), `ls`)) =>
-        tn.nodeName should be ("x")
-        tn.value should be ("thing")
+        assert(tn.nodeName === "x")
+        assert(tn.value === "thing")
       case _ => ???
     }
   }
@@ -20,9 +20,9 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val l = Literal("thing")
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(node, "thing", is, value)) =>
-        node.significance should be(TreeNode.Noise)
+        assert(node.significance === TreeNode.Noise)
         value should be(l.toString)
-        is.offset should be(5)
+        assert(is.offset === 5)
       case _ => ???
     }
   }
@@ -33,6 +33,7 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val l = l1 ~ l2
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(tn, "thing2", InputState(thing2, _, _), _)) =>
+      
       case _ => ???
     }
   }
@@ -43,6 +44,7 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val l = l1 ~ l2
     l.matchPrefix(InputState("thing2")) match {
       case Left(_) =>
+      
       case _ => ???
     }
   }
@@ -53,18 +55,22 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val l = l1 | l2
     l.matchPrefix(InputState("thing")) match {
       case Right(PatternMatch(_, "thing", InputState("thing", _, _), _)) =>
+      
       case _ => ???
     }
     l2.matchPrefix(InputState("2")) match {
       case Right(PatternMatch(_, "2", InputState("2", _, 1), _)) =>
+      
       case _ => ???
     }
     l.matchPrefix(InputState("2")) match {
       case Right(PatternMatch(_, "2", InputState("2", _, 1), _)) =>
+      
       case _ => ???
     }
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(tn, "thing", InputState("thing2", _, _), _)) =>
+      
       case _ => ???
     }
   }
@@ -74,6 +80,7 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val l = l1.?
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(_, "thing", InputState("thing2", _, 5), _)) =>
+      
       case _ => ???
     }
   }
@@ -84,18 +91,22 @@ class MatcherOperationsTest extends FlatSpec with Matchers {
     val l = l1.? ~ l2
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(tn, "thing2", InputState("thing2", _, _), _)) =>
+      
       case _ => ???
     }
     l.matchPrefix(InputState("2")) match {
       case Right(PatternMatch(tn, "2", InputState("2", _, _), _)) =>
+      
       case _ => ???
     }
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(tn, "thing2", InputState("thing2", _, _), _)) =>
+      
       case _ => ???
     }
     l.matchPrefix(InputState("xthing2")) match {
       case Left(_) =>
+      
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/RegexTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/RegexTest.scala
@@ -9,7 +9,7 @@ class RegexTest extends FlatSpec with Matchers {
     val l = Regex("[a-zA-Z]+", Some(name))
     l.matchPrefix(InputState("thingxxxY")) match {
       case Right(PatternMatch(tn, "thingxxxY", InputState("thingxxxY", _, _), _)) =>
-        tn.nodeName should be (name)
+        assert(tn.nodeName === name)
       case _ => ???
     }
   }
@@ -19,7 +19,7 @@ class RegexTest extends FlatSpec with Matchers {
     val l = Regex("[a-zA-Z]+", Some(name))
     l.matchPrefix(InputState("thingxxxY0")) match {
       case Right(PatternMatch(tn, "thingxxxY", InputState("thingxxxY0", _, _), _)) =>
-        tn.nodeName should be (name)
+        assert(tn.nodeName === name)
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/RepTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/RepTest.scala
@@ -11,7 +11,7 @@ class RepTest extends FlatSpec with Matchers {
     val input = "woieurowieurowieur"
     l.matchPrefix(InputState(input)) match {
       case Right(PatternMatch(tn, "", InputState(input, _, _), _)) =>
-        tn.nodeName should be (".rep")
+        assert(tn.nodeName === ".rep")
       case _ => ???
     }
   }
@@ -21,8 +21,8 @@ class RepTest extends FlatSpec with Matchers {
     val l = Rep(l1)
     l.matchPrefix(InputState("thing2")) match {
       case Right(PatternMatch(tn: ContainerTreeNode, "thing", InputState(thing2, _, _), _)) =>
-        tn.nodeName should be (".rep")
-        tn.childNodes.size should be (1)
+        assert(tn.nodeName === ".rep")
+        assert(tn.childNodes.size === 1)
       case _ => ???
     }
   }
@@ -33,12 +33,12 @@ class RepTest extends FlatSpec with Matchers {
     val input = "thingthing2"
     l.matchPrefix(InputState(input)) match {
       case Right(pe: PatternMatch) =>
-        pe.matched should be ("thingthing")
-        pe.resultingInputState.input should be (input)
-        pe.resultingInputState.offset should be ("thingthing".length)
+        assert(pe.matched === "thingthing")
+        assert(pe.resultingInputState.input === input)
+        assert(pe.resultingInputState.offset === "thingthing".length)
         val tn = pe.node.asInstanceOf[ContainerTreeNode]
-        tn.nodeName should be (".rep")
-        tn.childNodes.size should be (2)
+        assert(tn.nodeName === ".rep")
+        assert(tn.childNodes.size === 2)
       case _ => ???
     }
   }
@@ -49,12 +49,12 @@ class RepTest extends FlatSpec with Matchers {
     val input = "thingthing2"
     namedRep.matchPrefix(InputState(input)) match {
       case Right(pe: PatternMatch) =>
-        pe.matched should be ("thingthing")
-        pe.resultingInputState.input should be (input)
-        pe.resultingInputState.offset should be ("thingthing".length)
+        assert(pe.matched === "thingthing")
+        assert(pe.resultingInputState.input === input)
+        assert(pe.resultingInputState.offset === "thingthing".length)
         val tn = pe.node.asInstanceOf[ContainerTreeNode]
-        tn.nodeName should be (namedRep.name)
-        tn.childNodes.size should be (2)
+        assert(tn.nodeName === namedRep.name)
+        assert(tn.childNodes.size === 2)
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/SecretsTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/SecretsTest.scala
@@ -66,6 +66,6 @@ class SecretsTest extends FlatSpec with Matchers with LazyLogging {
     val target = new SimpleFileBasedArtifactSource("",
       StringFileArtifact("application.yml", inYml))
     val rr = ed.review(target, SimpleProjectOperationArguments.Empty)
-    rr.comments.size should be(3)
+    assert(rr.comments.size === 3)
   }
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/WrapTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/WrapTest.scala
@@ -13,12 +13,12 @@ class WrapTest extends FlatSpec with Matchers {
     val input = "thingthing2"
     l.matchPrefix(InputState(input)) match {
       case Right(pe: PatternMatch) =>
-        pe.matched should be ("thing")
-        pe.resultingInputState.input should be (input)
-        pe.resultingInputState.offset should be ("thing".length)
+        assert(pe.matched === "thing")
+        assert(pe.resultingInputState.input === input)
+        assert(pe.resultingInputState.offset === "thing".length)
         val tn = pe.node.asInstanceOf[ContainerTreeNode]
-        tn.nodeName should be ("higherLevel")
-        tn.childNodes.size should be (1)
+        assert(tn.nodeName === "higherLevel")
+        assert(tn.childNodes.size === 1)
       case _ => ???
     }
   }
@@ -31,17 +31,17 @@ class WrapTest extends FlatSpec with Matchers {
 
     l.matchPrefix(InputState(input)) match {
       case Right(pe: PatternMatch) =>
-        pe.matched should be ("thingthing")
-        pe.resultingInputState.input should be (input)
-        pe.resultingInputState.offset should be ("thingthing".length)
+        assert(pe.matched === "thingthing")
+        assert(pe.resultingInputState.input === input)
+        assert(pe.resultingInputState.offset === "thingthing".length)
         val tn = pe.node.asInstanceOf[PositionedMutableContainerTreeNode]
-        tn.nodeName should be (l.name)
+        assert(tn.nodeName === l.name)
 
         tn.pad(input)
 
         //println("After pad: " + TreeNodeUtils.toShortString(tn))
         //println(tn.childNodes)
-        tn.childNodes.size should be (2)
+        assert(tn.childNodes.size === 2)
        // tn.childNodes.head.nodeName should be (rl.name)
       case Left(dr) =>
         //println(DismatchReport.detailedReport(dr, input))

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionParserTest.scala
@@ -8,6 +8,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
 
   val mgp = new MatcherDefinitionParser
 
+
   import MatcherDefinitionParser._
 
   it should "reject null string" in {
@@ -22,6 +23,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     val validLiterals = Seq("a", "aa", "a&a", "woiurwieur", "def")
     for (v <- validLiterals) mgp.parseMatcher("v", v) match {
       case Literal(`v`, None) =>
+      
       case _ => fail(s"failed to parse $v")
     }
   }
@@ -33,6 +35,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
       s"$RegexpOpenToken[.]$RegexpCloseToken")
     for (v <- validLiterals) mgp.parseMatcher("y", v) match {
       case Regex(_, Some("y"), _) =>
+      
       case _ => fail(s"failed to parse $v")
     }
   }
@@ -57,6 +60,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     val validDescendantPhrases = Seq("▶$:cat", "▶$d:dog")
     for (v <- validDescendantPhrases) mgp.parseMatcher("v", v, mr) match {
       case w: Wrap =>
+      
       case _ => fail(s"failed to parse $v")
     }
   }
@@ -69,6 +73,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     for (v <- validDescendantPhrases) mgp.parseMatcher("v", v, mr) match {
       //case Literal(l, None) =>
       case _ =>
+    
     }
   }
 
@@ -81,6 +86,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     val validUseOfVars = Seq("$:OtherPattern", "def $:ScalaMethod", "def $theMethod:ScalaMethod")
     for (v <- validUseOfVars) mgp.parseMatcher("t", v, mr) match {
       case m: Matcher =>
+      
       case _ => fail(s"failed to parse $v")
     }
   }
@@ -110,6 +116,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
           case cat: Concat =>
             cat.matchPrefix(InputState(v)) match {
               case Right(PatternMatch(_, matched, InputState(`v`, _, _), _)) =>
+              
               case Left(report) => fail(s"Failed to match on [$v]" + report)
               case _ => fail(s"failed to parse/match $v")
             }
@@ -122,6 +129,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
     val f = s"""$BreakOpenToken<span data-original="$BreakCloseToken"""
     mgp.parseMatcher("f", f) match {
       case x =>
+    
     }
   }
 
@@ -139,6 +147,8 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
             InputState(in)) match {
             case Right(pe) =>
             //pe.matched should be ("foo\"")
+            
+            //pe.matched should be ("foo\"")
             case Left(report) => fail(s"[$in] didn't match and should have done: " + report)
             case _ => ???
           }
@@ -153,6 +163,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
         parsedMatcher.matchPrefix(
           InputState("""<tr class="emoji_row">THIS OTHER STUFF<span data-original="and now for something completely different""")) match {
           case Right(pe) =>
+          
           case _ => ???
         }
     }
@@ -161,9 +172,10 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
   it should "parse strict string literals" in {
     val f = s"""${StrictLiteralOpen}xxxx$StrictLiteralClose"""
     val parsed = mgp.parseMatcher("f", f)
-    parsed.name should be(".literal")
+    assert(parsed.name === ".literal")
     parsed match {
       case Literal("xxxx", _) =>
+      
       case _ => ???
     }
   }
@@ -175,6 +187,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
         parsedMatcher.matchPrefix(
           InputState("""<tr class="emoji_row">THIS OTHER STUFF<span data-original="and now for something completely different""")) match {
           case Right(pe) =>
+          
           case _ => ???
         }
     }
@@ -200,6 +213,7 @@ class MatcherDefinitionParserTest extends FlatSpec with Matchers {
           parsedMatcher.matchPrefix(
             InputState(s"""<tr class="emoji_row">THIS OTHER STUFF<span data-original="${suffix}$postsuffix""")) match {
             case Right(pe) =>
+            
             case Left(report) => fail(s"Expected to match with suffix of [$suffix] and postsuffix of [$postsuffix] but did not: " + report)
             case _ => ???
           }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MatcherDefinitionUsageTest.scala
@@ -8,10 +8,12 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
 
   val mgp = new MatcherDefinitionParser
 
+
   it should "match literal" in {
     val matcher = mgp.parseMatcher("foo", "def foo")
     matcher.matchPrefix(InputState("def foo thing")) match {
       case Right(pm) =>
+      
       case _ => ???
     }
   }
@@ -19,7 +21,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
   it should "match literal using microgrammar" in {
     val matcher = mgp.parseMatcher("lit", "def foo")
     val mg = new MatcherMicrogrammar(matcher)
-    mg.findMatches("def foo bar").size should be(1)
+    assert(mg.findMatches("def foo bar").size === 1)
   }
 
   it should "match regex using microgrammar" in {
@@ -28,9 +30,10 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
     val input = "def foo bar"
     matcher.matchPrefix(InputState(input)) match {
       case Right(pm) =>
+      
       case _ => ???
     }
-    mg.findMatches(input).size should be(1)
+    assert(mg.findMatches(input).size === 1)
   }
 
   it should "match regex in Maven POM" in {
@@ -39,7 +42,7 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
       mgp.parseMatcher("m", "<modelVersion>$modelVersion:§[a-zA-Z0-9_\\.]+§</modelVersion>"))
     val pom = proj.findFile("pom.xml").get.content
     val matches = mg.findMatches(pom)
-    matches.size should be(1)
+    assert(matches.size === 1)
   }
 
   it should "parse Slack emoji html" in {
@@ -65,12 +68,13 @@ class MatcherDefinitionUsageTest extends FlatSpec with Matchers {
         """<tr class="emoji_row">¡<span data-original="¡$emojiUrl:§https://[^\"]+§" class="$name:§[\sa-zA-Z0-9_\-]*§"""
       ))
 
+
     val matches = mg.findMatches(html)
-    matches.size should be(1)
+    assert(matches.size === 1)
 
     withClue(matches) {
-      matches.head.childNodes.head.value should be("https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
-      matches.head.childNodes(1).value should be("lazy emoji-wrapper")
+      assert(matches.head.childNodes.head.value === "https://emoji.slack-edge.com/T024F4A92/666/5b9d8b4d571e51c5.jpg")
+      assert(matches.head.childNodes(1).value === "lazy emoji-wrapper")
     }
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarPathExpressionTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarPathExpressionTest.scala
@@ -23,7 +23,7 @@ class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
 
     val result = exercisePathExpression(microgrammar, pathExpression, input)
 
-    result.size should be(0)
+    assert(result.size === 0)
   }
 
   it should "Let give 0 matches when I access something deep that might exist but does not" in {
@@ -36,7 +36,7 @@ class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
 
     val result = exercisePathExpression(microgrammar, pathExpression, input)
 
-    result.size should be(0)
+    assert(result.size === 0)
   }
 
   it should "Fail when I name a node that can't possibly exist" in pendingUntilFixed {
@@ -62,11 +62,13 @@ class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
     }
   }
 
-  private def exercisePathExpressionInternal(microgrammar: Microgrammar, pathExpressionString: String, input: String) = {
+  private  def exercisePathExpressionInternal(microgrammar: Microgrammar, pathExpressionString: String, input: String) = {
 
     /* Construct a root node */
     val as = SimpleFileBasedArtifactSource(StringFileArtifact("banana.txt", input))
     val pmv = new ProjectMutableView(as /* cheating */ , as, DefaultAtomistConfig)
+
+    /* Parse the path expression */
 
     /* Parse the path expression */
     val pathExpression = PathExpressionParser.parseString(pathExpressionString)
@@ -75,6 +77,7 @@ class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
     val typeRegistryWithMicrogrammar =
       new UsageSpecificTypeRegistry(DefaultTypeRegistry,
         Seq(new MicrogrammarTypeProvider(microgrammar)))
+
 
     new PathExpressionEngine().evaluate(pmv, pathExpression, typeRegistryWithMicrogrammar)
   }
@@ -101,7 +104,7 @@ class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
 
     val result = exercisePathExpression(microgrammar, pathExpression, input)
 
-    result.size should be(2)
+    assert(result.size === 2)
   }
 
   it should "match a named node" in {
@@ -114,6 +117,6 @@ class OptionalFieldMicrogrammarTest extends FlatSpec with Matchers {
 
     val result = exercisePathExpression(microgrammar, pathExpression, input)
 
-    result.size should be(1)
+    assert(result.size === 1)
   }
 }

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarUsageInPathExpressionTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/MicrogrammarUsageInPathExpressionTest.scala
@@ -21,7 +21,9 @@ class MicrogrammarUsageInPathExpressionTest extends FlatSpec with Matchers {
 
   val ee: ExpressionEngine = new PathExpressionEngine
 
+
   val mgp = new MatcherDefinitionParser
+
 
   it should "use simple microgrammar to match in single file" in
     useSimpleMicrogrammarAgainstSingleFile
@@ -29,7 +31,7 @@ class MicrogrammarUsageInPathExpressionTest extends FlatSpec with Matchers {
   it should "use simple microgrammar in a single file and modify content" in {
     val (pmv, nodes) = useSimpleMicrogrammarAgainstSingleFile
     val highlyImprobableValue = "woieurowiuroepqirupoqwieur"
-    nodes.size should be(1)
+    assert(nodes.size === 1)
     withClue(s"Type was ${nodes.head.nodeTags}") {
       nodes.head.nodeTags.contains("modelVersion") should be(true)
     }
@@ -45,7 +47,7 @@ class MicrogrammarUsageInPathExpressionTest extends FlatSpec with Matchers {
   }
 
   // Return the project and matched nodes
-  private def useSimpleMicrogrammarAgainstSingleFile: (ProjectMutableView, Seq[TreeNode]) = {
+  private  def useSimpleMicrogrammarAgainstSingleFile: (ProjectMutableView, Seq[TreeNode]) = {
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val findFile = "/File()[@name='pom.xml']"
@@ -54,19 +56,20 @@ class MicrogrammarUsageInPathExpressionTest extends FlatSpec with Matchers {
       mgp.parseMatcher("pom",
         "<modelVersion>$modelVersion:§[a-zA-Z0-9_\\.]+§</modelVersion>"), "pom")
 
+
     val matches = mg.findMatches(proj.findFile("pom.xml").get.content)
-    matches.length should be(1)
+    assert(matches.length === 1)
 
     val tr = new UsageSpecificTypeRegistry(DefaultTypeRegistry,
       Seq(new MicrogrammarTypeProvider(mg))
     )
     val rtn = ee.evaluate(pmv, findFile, tr)
-    rtn.right.get.size should be(1)
+    assert(rtn.right.get.size === 1)
 
     val modelVersion = findFile + "/pom()/modelVersion()"
 
     val grtn = ee.evaluate(pmv, modelVersion, tr)
-    grtn.right.get.size should be(1)
+    assert(grtn.right.get.size === 1)
     (pmv, grtn.right.get)
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/matchers/BreakTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/matchers/BreakTest.scala
@@ -9,6 +9,7 @@ class BreakTest extends FlatSpec with Matchers {
     val l = Literal("thing") ~ Break(Literal("Y"))
     l.matchPrefix(InputState("thingxxxY")) match {
       case Right(PatternMatch(tn, "thingxxxY", InputState("thingxxxY", _, _), _)) =>
+      
       case _ => ???
     }
   }
@@ -17,8 +18,8 @@ class BreakTest extends FlatSpec with Matchers {
     val l = Literal("thing") ~ Break(Literal("Y"))
     l.matchPrefix(InputState("thingxxxYzzz--")) match {
       case Right(pe: PatternMatch) =>
-        pe.matched should be ("thingxxxY")
-        pe.resultingInputState.input should equal("thingxxxYzzz--")
+        assert(pe.matched === "thingxxxY")
+        assert(pe.resultingInputState.input === "thingxxxYzzz--")
       case _ => ???
     }
   }
@@ -27,6 +28,7 @@ class BreakTest extends FlatSpec with Matchers {
     val l = Literal("thing") ~ Break(Literal("Y"))
     l.matchPrefix(InputState("thingxxx")) match {
       case Left(_) =>
+      
       case _ => ???
     }
   }
@@ -37,7 +39,7 @@ class BreakTest extends FlatSpec with Matchers {
     val l = Literal(s1) ~ Break(Literal(s2))
     l.matchPrefix(InputState(s"$s1 and all this nonsense and then $s2 and more garbage")) match {
       case Right(pm) =>
-        pm.matched should be (s"$s1 and all this nonsense and then $s2")
+        assert(pm.matched === s"$s1 and all this nonsense and then $s2")
       case _ => ???
     }
   }

--- a/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
@@ -150,18 +150,18 @@ class LinkedJsonTreeDeserializerTest extends FlatSpec with Matchers {
 
   it should "deserialize simple tree" in {
     val node = LinkedJsonTreeDeserializer.fromJson(t1)
-    node.nodeTags should be (Set("Issue", TreeNode.Dynamic))
-    node.childrenNamed("number").size should be (1)
+    assert(node.nodeTags === Set("Issue", TreeNode.Dynamic))
+    assert(node.childrenNamed("number").size === 1)
   }
 
   it should "deserialize a tree of n depth" in {
     val node = LinkedJsonTreeDeserializer.fromJson(t2)
-    node.nodeTags should be (Set("Build", TreeNode.Dynamic))
-    node.childrenNamed("status").head.value should be ("Passed")
+    assert(node.nodeTags === Set("Build", TreeNode.Dynamic))
+    assert(node.childrenNamed("status").head.value === "Passed")
     val repo = node.childrenNamed("ON").head
-    repo.childrenNamed("owner").size should be (1)
+    assert(repo.childrenNamed("owner").size === 1)
     val chatChannel = repo.childrenNamed("CHANNEL").head
-    chatChannel.childrenNamed("name").size should be (1)
-    chatChannel.childrenNamed("id").head.value should be ("channel-id")
+    assert(chatChannel.childrenNamed("name").size === 1)
+    assert(chatChannel.childrenNamed("id").head.value === "channel-id")
   }
 }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
@@ -11,6 +11,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
   val ee: ExpressionEngine = new PathExpressionEngine
 
+
   it should "return root node with / expression" in {
     val tn = new ParsedMutableContainerTreeNode("name")
     val fooNode = SimpleTerminalTreeNode("foo", "foo")
@@ -18,7 +19,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     tn.appendField(SimpleTerminalTreeNode("bar", "bar"))
     val expr = "/"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(tn))
+    assert(rtn.right.get === Seq(tn))
   }
 
   it should "find property in container tree node" in {
@@ -29,7 +30,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/foo"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(fooNode))
+    assert(rtn.right.get === Seq(fooNode))
   }
 
   it should "find property in container tree node 2 levels deep" in {
@@ -41,7 +42,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     tn.appendField(SimpleTerminalTreeNode("bar", "bar"))
     val expr = "/nested/foo"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(fooNode))
+    assert(rtn.right.get === Seq(fooNode))
   }
 
   it should "follow //" in {
@@ -60,7 +61,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/nested//*[@name='foo']"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(fooNode1, fooNode2))
+    assert(rtn.right.get === Seq(fooNode1, fooNode2))
   }
 
   it should "match on node name" in {
@@ -76,7 +77,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     tn.appendField(SimpleTerminalTreeNode("bar", "bar"))
     val expr = "/nested/level2/*[@name='foo']"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(fooNode1, fooNode2))
+    assert(rtn.right.get === Seq(fooNode1, fooNode2))
   }
 
   it should "match on node name with /@name" in
@@ -94,7 +95,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
   it should "match on node name with //foo and or predicate" in
     matchOnNodeName("/nested/level2//*[@value='foo1' or @value='foo2']")
 
-  private def matchOnNodeName(expr: String) {
+  private  def matchOnNodeName(expr: String) {
     val tn = new ParsedMutableContainerTreeNode("name")
     val prop1 = new ParsedMutableContainerTreeNode("nested")
     val prop11 = new ParsedMutableContainerTreeNode("level2")
@@ -106,7 +107,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     tn.appendField(prop1)
     tn.appendField(SimpleTerminalTreeNode("bar", "bar"))
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(fooNode1, fooNode2))
+    assert(rtn.right.get === Seq(fooNode1, fooNode2))
   }
 
   it should "match on node index" in {
@@ -125,11 +126,11 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/nested/level2/*[1]"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(fooNode1))
+    assert(rtn.right.get === Seq(fooNode1))
 
     val expr2 = "/nested/level2/*[2]"
     val rtn2 = ee.evaluate(tn, expr2, DefaultTypeRegistry)
-    rtn2.right.get should equal (Seq(fooNode2))
+    assert(rtn2.right.get === Seq(fooNode2))
   }
 
   it should "preparing nodes in path" in {
@@ -151,7 +152,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     })
     val s = rtn.right.get
     s should equal (Seq(tn))
-    tn.touched should be (true)
+    assert(tn.touched === true)
   }
 
   it should "compare value to null" in {
@@ -163,11 +164,11 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/*[.foo()=null]"
     val rtn = ee.evaluate(rn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(tn))
+    assert(rtn.right.get === Seq(tn))
 
     val expr2 = "/*[not(.foo()=null)]"
     val rtn2 = ee.evaluate(rn, expr2, DefaultTypeRegistry)
-    rtn2.right.get should equal (Nil)
+    assert(rtn2.right.get === Nil)
   }
 
   it should "compare method value to int with method" in {
@@ -179,11 +180,11 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/*[.age()=25]"
     val rtn = ee.evaluate(rn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(tn))
+    assert(rtn.right.get === Seq(tn))
 
     val expr2 = "/*[.age()=26]"
     val rtn2 = ee.evaluate(rn, expr2, DefaultTypeRegistry)
-    rtn2.right.get should equal (Nil)
+    assert(rtn2.right.get === Nil)
   }
 
   it should "compare method value to int with property" in {
@@ -194,11 +195,11 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/*[@age='25']"
     val rtn = ee.evaluate(rn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(tn))
+    assert(rtn.right.get === Seq(tn))
 
     val expr2 = "/*[@age='26']"
     val rtn2 = ee.evaluate(rn, expr2, DefaultTypeRegistry)
-    rtn2.right.get should equal (Nil)
+    assert(rtn2.right.get === Nil)
   }
 
   it should "descend to scalar property" in {
@@ -209,7 +210,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     val expr = "/thing"
     val rtn = ee.evaluate(tn, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(kid))
+    assert(rtn.right.get === Seq(kid))
   }
 
   it should "handle a property name axis specifier and Object type" in {
@@ -223,7 +224,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(tn)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(repo))
+    assert(rtn.right.get === Seq(repo))
   }
 
   it should "handle a property name axis specifier" in {
@@ -236,7 +237,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(tn)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(repo))
+    assert(rtn.right.get === Seq(repo))
   }
 
   it should "handle a property name axis specifier nested predicate with Object type" in {
@@ -249,7 +250,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 
   it should "not match due to unsatisfied nested predicate" in {
@@ -262,7 +263,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Nil)
+    assert(rtn.right.get === Nil)
   }
 
   it should "match with an optional predicate" in {
@@ -272,7 +273,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 
   it should "match with a non-matching optional predicate" in {
@@ -282,7 +283,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 
   it should "match with a required and an optional predicate" in {
@@ -295,7 +296,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 
   it should "match with a required and a non-matching optional predicate" in {
@@ -308,7 +309,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 
   it should "match with an optional nested predicate" in {
@@ -321,7 +322,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 
   it should "match with a non-matching optional nested predicate that does not" in {
@@ -334,6 +335,6 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
     val parent = new ContainerTreeNodeImpl("root", "root")
     parent.addField(issue)
     val rtn = ee.evaluate(parent, expr, DefaultTypeRegistry)
-    rtn.right.get should equal (Seq(issue))
+    assert(rtn.right.get === Seq(issue))
   }
 }

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionParserTest.scala
@@ -10,7 +10,7 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse a bare root node" in {
     val pe = "/"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.isEmpty should be(true)
+    assert(parsed.locationSteps.isEmpty === true)
   }
 
   it should "failed to parse an unanchored path expression" in {
@@ -21,12 +21,12 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse a child axis" in {
     val pe = "/child::src"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be(1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be (Child)
-    ls.predicateToEvaluate should be (TruePredicate)
+    assert(ls.axis === Child)
+    assert(ls.predicateToEvaluate === TruePredicate)
     ls.test match {
-      case nnt: NamedNodeTest => nnt.name should be ("src")
+      case nnt: NamedNodeTest => assert(nnt.name === "src")
       case x => fail(s"node test is not a NamedNodeTest: $x")
     }
   }
@@ -34,12 +34,12 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse an abbreviated child axis with node name" in {
     val pe = "/src"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be(1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be(Child)
-    ls.predicateToEvaluate should be(TruePredicate)
+    assert(ls.axis === Child)
+    assert(ls.predicateToEvaluate === TruePredicate)
     ls.test match {
-      case nnt: NamedNodeTest => nnt.name should be ("src")
+      case nnt: NamedNodeTest => assert(nnt.name === "src")
       case x => fail(s"node test is not a NamedNodeTest: $x")
     }
   }
@@ -49,24 +49,24 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     val parsed = pep.parsePathExpression(pe)
     val pe1 = "/src"
     val parsed1 = pep.parsePathExpression(pe1)
-    parsed.locationSteps.size should be(1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    parsed1.locationSteps.size should be(1)
+    assert(parsed1.locationSteps.size === 1)
     val ls1 = parsed.locationSteps.head
-    ls1.axis should be(ls.axis)
-    ls1.predicateToEvaluate should be(ls.predicateToEvaluate)
-    ls1.test should be(ls.test)
+    assert(ls1.axis === ls.axis)
+    assert(ls1.predicateToEvaluate === ls.predicateToEvaluate)
+    assert(ls1.test === ls.test)
   }
 
   it should "parse a descendant axis" in {
     val pe = "/descendant::src"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be(1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be (Descendant)
-    ls.predicateToEvaluate should be (TruePredicate)
+    assert(ls.axis === Descendant)
+    assert(ls.predicateToEvaluate === TruePredicate)
     ls.test match {
-      case nnt: NamedNodeTest => nnt.name should be ("src")
+      case nnt: NamedNodeTest => assert(nnt.name === "src")
       case x => fail(s"node test is not a NamedNodeTest: $x")
     }
   }
@@ -74,12 +74,12 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse an abbreviated descendant axis with node name" in {
     val pe = "//src"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be(1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be(Descendant)
-    ls.predicateToEvaluate should be(TruePredicate)
+    assert(ls.axis === Descendant)
+    assert(ls.predicateToEvaluate === TruePredicate)
     ls.test match {
-      case nnt: NamedNodeTest => nnt.name should be ("src")
+      case nnt: NamedNodeTest => assert(nnt.name === "src")
       case x => fail(s"node test is not a NamedNodeTest: $x")
     }
   }
@@ -89,37 +89,38 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
     val parsed = pep.parsePathExpression(pe)
     val pe1 = "//src"
     val parsed1 = pep.parsePathExpression(pe1)
-    parsed.locationSteps.size should be(1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    parsed1.locationSteps.size should be(1)
+    assert(parsed1.locationSteps.size === 1)
     val ls1 = parsed.locationSteps.head
-    ls1.axis should be(ls.axis)
-    ls1.predicateToEvaluate should be(ls.predicateToEvaluate)
-    ls1.test should be(ls.test)
+    assert(ls1.axis === ls.axis)
+    assert(ls1.predicateToEvaluate === ls.predicateToEvaluate)
+    assert(ls1.test === ls.test)
   }
 
   it should "parse a node object type" in {
     val pe = "/Issue()"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be(Child)
-    ls.predicateToEvaluate should be(TruePredicate)
-    ls.test should be(NodesWithTag("Issue"))
+    assert(ls.axis === Child)
+    assert(ls.predicateToEvaluate === TruePredicate)
+    assert(ls.test === NodesWithTag("Issue"))
   }
 
   it should "parse an index predicate" in {
     val pe = "/dude[4]"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be(Child)
+    assert(ls.axis === Child)
     ls.predicateToEvaluate match {
       case p@IndexPredicate(4) =>
+      
       case x => fail(s"predicate did not match expected type: $x")
     }
     ls.test match {
-      case nnt: NamedNodeTest => nnt.name should be ("dude")
+      case nnt: NamedNodeTest => assert(nnt.name === "dude")
       case x => fail(s"node test is not a NamedNodeTest: $x")
     }
   }
@@ -127,17 +128,17 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse a simple predicate" in {
     val pe = "/dude[@size='large']"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
+    assert(parsed.locationSteps.size === 1)
     val ls = parsed.locationSteps.head
-    ls.axis should be(Child)
+    assert(ls.axis === Child)
     ls.predicateToEvaluate match {
       case np: PropertyValuePredicate =>
-        np.property should be ("size")
-        np.expectedValue should be ("large")
+        assert(np.property === "size")
+        assert(np.expectedValue === "large")
       case x => fail(s"predicate did not match expected type: $x")
     }
     ls.test match {
-      case nnt: NamedNodeTest => nnt.name should be ("dude")
+      case nnt: NamedNodeTest => assert(nnt.name === "dude")
       case x => fail(s"node test is not a NamedNodeTest: $x")
     }
   }
@@ -145,60 +146,65 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse into json" in {
     val pe = "/*[@name='elm-package.json']/Json()/summary"
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (3)
+    assert(parsed.locationSteps.size === 3)
   }
 
   it should "parse a property name axis specifier" in {
     val pe = """/Issue()[@state='open']/belongsTo::Repo()[@name='rug-cli']"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (2)
+    assert(parsed.locationSteps.size === 2)
     parsed.locationSteps(1).axis match {
       case NavigationAxis("belongsTo") =>
+    
     }
   }
 
   it should "parse a property name axis specifier using double quoted strings" in {
     val pe = """/Issue()[@state="open"]/belongsTo::Repo()[@name="rug-cli"]"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (2)
+    assert(parsed.locationSteps.size === 2)
     parsed.locationSteps(1).axis match {
       case NavigationAxis("belongsTo") =>
+    
     }
   }
 
   it should "parse predicate to understandable repo" in {
     val pe = """/Issue()[@state='open']/belongsTo::Repo()[@name='rug-cli']"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (2)
+    assert(parsed.locationSteps.size === 2)
     parsed.locationSteps.head.predicates.head match {
       case PropertyValuePredicate("state", "open") =>
+    
     }
   }
 
   it should "parse nested predicate" in {
     val pe = """/Issue()[@state='open'][/belongsTo::Repo()[@name='rug-cli']]"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
+    assert(parsed.locationSteps.size === 1)
     parsed.locationSteps.head.predicates(1) match {
       case _: NestedPathExpressionPredicate =>
+    
     }
   }
 
   it should "parse an optional predicate" in {
     val pe = """/Push()[contains::Commit()]?"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
-    parsed.locationSteps.head.predicates.size should be (1)
+    assert(parsed.locationSteps.size === 1)
+    assert(parsed.locationSteps.head.predicates.size === 1)
     parsed.locationSteps.head.predicates.head match {
       case _: OptionalPredicate =>
+    
     }
   }
 
   it should "parse required and optional predicates" in {
     val pe = """/Push()[@name='brainiac'][contains::Commit()]?"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
-    parsed.locationSteps.head.predicates.size should be (2)
+    assert(parsed.locationSteps.size === 1)
+    assert(parsed.locationSteps.head.predicates.size === 2)
     parsed.locationSteps.head.predicates.count {
       case _: OptionalPredicate => true
       case _ => false
@@ -208,8 +214,8 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse optional and required predicates" in {
     val pe = """/Push()[contains::Commit()]?[@name='brainiac']"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
-    parsed.locationSteps.head.predicates.size should be (2)
+    assert(parsed.locationSteps.size === 1)
+    assert(parsed.locationSteps.head.predicates.size === 2)
     parsed.locationSteps.head.predicates.count {
       case _: OptionalPredicate => true
       case _ => false
@@ -219,15 +225,16 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
   it should "parse a nested optional predicate" in {
     val pe = """/Push()[contains::Commit()[belongsTo::Repo()]?]"""
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (1)
-    parsed.locationSteps.head.predicates.size should be (1)
+    assert(parsed.locationSteps.size === 1)
+    assert(parsed.locationSteps.head.predicates.size === 1)
     parsed.locationSteps.head.predicates.head match {
       case npep: NestedPathExpressionPredicate =>
         val npepSteps = npep.expression.locationSteps
-        npepSteps.size should be (1)
-        npepSteps.head.predicates.size should be (1)
+        assert(npepSteps.size === 1)
+        assert(npepSteps.head.predicates.size === 1)
         npepSteps.head.predicates.head match {
           case _: OptionalPredicate =>
+        
         }
     }
   }
@@ -238,8 +245,8 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
                |[triggeredBy::Push()/contains::Commit()/author::GitHubId()/hasGithubIdentity::Person()/hasChatIdentity::ChatId()]
                |/hasBuild::Commit()/author::GitHubId()/hasGithubIdentity::Person()/hasChatIdentity::ChatId()""".stripMargin
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (5)
-    parsed.locationSteps.head.predicates.size should be (2)
+    assert(parsed.locationSteps.size === 5)
+    assert(parsed.locationSteps.head.predicates.size === 2)
     parsed.locationSteps.head.predicates.count {
       case _: NestedPathExpressionPredicate => true
       case _ => false
@@ -252,8 +259,8 @@ class PathExpressionParserTest extends FlatSpec with Matchers {
                |[triggeredBy::Push()/contains::Commit()/author::GitHubId()/hasGithubIdentity::Person()/hasChatIdentity::ChatId()]?
                |/hasBuild::Commit()/author::GitHubId()/hasGithubIdentity::Person()/hasChatIdentity::ChatId()""".stripMargin
     val parsed = pep.parsePathExpression(pe)
-    parsed.locationSteps.size should be (5)
-    parsed.locationSteps.head.predicates.size should be (2)
+    assert(parsed.locationSteps.size === 5)
+    assert(parsed.locationSteps.head.predicates.size === 2)
     parsed.locationSteps.head.predicates.count {
       case _: OptionalPredicate => true
       case _ => false

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionsAgainstProjectTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionsAgainstProjectTest.scala
@@ -20,12 +20,13 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
 
   val ee: ExpressionEngine = new PathExpressionEngine
 
+
   it should "not find missing property in project" in {
     val proj = ParsingTargets.NonSpringBootMavenProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val expr = "/foo"
     val rtn = ee.evaluate(pmv, expr, DefaultTypeRegistry)
-    rtn.right.get should equal(Seq())
+    assert(rtn.right.get === Seq())
   }
 
   it should "find directory contents in project" in {
@@ -33,10 +34,10 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val expr = "/src"
     val rtn = ee.evaluate(pmv, expr, DefaultTypeRegistry)
-    rtn.right.get.nonEmpty should be(true)
+    assert(rtn.right.get.nonEmpty === true)
     val expr2 = "/src/main/java"
     val rtn2 = ee.evaluate(pmv, expr2, DefaultTypeRegistry)
-    rtn2.right.get.nonEmpty should be(true)
+    assert(rtn2.right.get.nonEmpty === true)
   }
 
   it should "drill into lines inside project" in {
@@ -44,7 +45,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     val expr = "/File()[@name='pom.xml']/Line()"
     val rtn = ee.evaluate(pmv, expr, DefaultTypeRegistry)
-    rtn.right.get.nonEmpty should be(true)
+    assert(rtn.right.get.nonEmpty === true)
     assert(rtn.right.get.size === proj.findFile("pom.xml").get.content.count(_ == '\n'))
   }
 
@@ -58,7 +59,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(pomFile.nodeTags.contains("File"))
     val expr2 = "//Line()"
     val rtn2 = ee.evaluate(pomFile, expr2, DefaultTypeRegistry)
-    rtn2.right.get.nonEmpty should be(true)
+    assert(rtn2.right.get.nonEmpty === true)
     assert(rtn2.right.get.size > 10)
   }
 
@@ -89,6 +90,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn3.right.get.size === 1)
     rtn3.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -100,7 +102,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     val expr3 = "/SpringBootProject()"
     val rtn3 = ee.evaluate(pmv, expr3, DefaultTypeRegistry)
     // We have left out test classes
-    rtn3.right.get.size should be(0)
+    assert(rtn3.right.get.size === 0)
     //    rtn3.right.get.foreach {
     //      case j: JavaClassOrInterfaceView =>
     //    }
@@ -115,6 +117,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -126,6 +129,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -137,6 +141,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 2)
     rtn.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -173,6 +178,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 2)
     rtn.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -184,6 +190,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -195,6 +202,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn2.right.get.size === 1)
     rtn2.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -206,6 +214,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn2.right.get.size === 1)
     rtn2.right.get.foreach {
       case j: JavaClassOrInterfaceView =>
+    
     }
   }
 
@@ -213,9 +222,10 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     // Second filter is really a no op
+    // Second filter is really a no op
     val expr2 = "/src//JavaType()/*[@type='JavaType' and .isAbstract()]"
     val rtn2 = ee.evaluate(pmv, expr2, DefaultTypeRegistry)
-    rtn2.right.get.size should be(0)
+    assert(rtn2.right.get.size === 0)
   }
 
   it should "handle OR" in {
@@ -223,6 +233,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
       StringFileArtifact("license.txt", "The blah blah license")
     )
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    // Second filter is really a no op
     // Second filter is really a no op
     val expr = "/*[@name='license.txt' or @name='foo']"
     val rtn = ee.evaluate(pmv, expr, DefaultTypeRegistry)
@@ -244,6 +255,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
   it should "jump into Java type and test on name" in {
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    // Second filter is really a no op
     // Second filter is really a no op
     val expr = "/src/main/java/com/example/JavaType()[@type='JavaType' and .pkg()='com.example']"
     val rtn = ee.evaluate(pmv, expr, DefaultTypeRegistry)
@@ -321,7 +333,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn2.right.get.size === 1)
     rtn2.right.get.head match {
       case em: ElmModuleMutableView =>
-        em.name should equal("Main")
+        assert(em.name === "Main")
     }
   }
 
@@ -329,6 +341,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     val types = Set("JavaType", "JavaSource")
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    // Second filter is really a no op
     // Second filter is really a no op
     for (nestedType <- types) {
       val expr2 = s"/src//File()[$nestedType()]"
@@ -343,10 +356,11 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     val proj = ParsingTargets.NewStartSpringIoProject
     val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
     // Second filter is really a no op
+    // Second filter is really a no op
     val expr2 = s"/src//File()[/ElmModule()]"
     val rtn2 = ee.evaluate(pmv, expr2, DefaultTypeRegistry)
     val nodes = rtn2.right.get
-    nodes.isEmpty should be(true)
+    assert(nodes.isEmpty === true)
   }
 
   it should "find all top-level file as descendant" in {
@@ -357,6 +371,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case _: FileArtifactBackedMutableView =>
+      
       case x => fail(s"failed to get FileArtifactBackedMutableView: ${x.getClass}")
     }
   }
@@ -369,6 +384,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case _: PomMutableView =>
+      
       case x => fail(s"failed to get PomMutableView: ${x.getClass}")
     }
   }
@@ -381,6 +397,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 3)
     rtn.right.get.foreach {
       case _: PomMutableView =>
+      
       case x => fail(s"failed to get PomMutableView: ${x.getClass}")
     }
   }
@@ -393,6 +410,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 3)
     rtn.right.get.foreach {
       case _: PomMutableView =>
+      
       case x => fail(s"failed to get PomMutableView: ${x.getClass}")
     }
   }
@@ -405,6 +423,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case _: ElmModuleMutableView =>
+      
       case x => fail(s"failed to get ElmModuleMutableView: ${x.getClass}")
     }
   }
@@ -417,6 +436,7 @@ class PathExpressionsAgainstProjectTest extends FlatSpec with Matchers with Asse
     assert(rtn.right.get.size === 1)
     rtn.right.get.foreach {
       case _: ElmModuleMutableView =>
+      
       case x => fail(s"failed to get ElmModuleMutableView: ${x.getClass}")
     }
   }

--- a/src/test/scala/com/atomist/util/lang/JavaHelpersTest.scala
+++ b/src/test/scala/com/atomist/util/lang/JavaHelpersTest.scala
@@ -57,7 +57,7 @@ class JavaHelpersTest extends FlatSpec with Matchers {
     val tests = Seq("a", "aa", "dude", "duder", "el duderino", "his dudeness")
     for (t <- tests) {
       val r = upperize(t)
-      r.charAt(0).isUpper should be (true)
+      assert(r.charAt(0).isUpper === true)
       r.substring(1) should equal (t.substring(1))
     }
 

--- a/src/test/scala/com/atomist/util/lang/JavaScriptArrayTest.scala
+++ b/src/test/scala/com/atomist/util/lang/JavaScriptArrayTest.scala
@@ -234,11 +234,11 @@ class JavaScriptArrayTest extends FlatSpec with Matchers {
       EditorWithFancyListArray))
   }
 
-  private def invokeAndVerifyConstructed(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
+  private  def invokeAndVerifyConstructed(tsf: FileArtifact): JavaScriptInvokingProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 
     val jsed = JavaScriptOperationFinder.fromJavaScriptArchive(as).head.asInstanceOf[JavaScriptInvokingProjectEditor]
-    jsed.name should be("Constructed")
+    assert(jsed.name === "Constructed")
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
 


### PR DESCRIPTION
```
---
kind: "operation"
client: "rug-cli 0.23.0-SNAPSHOT"
executor:
  name: "UpgradeScalaTestAssertions"
  group: "atomist-rugs"
  artifact: "scala-editors"
  version: "0.1.0"
  origin:
    repo: "n/a"
    branch: "n/a"
    sha: "n/a"

```