### PR TITLE
Apply Intellij code analysis fixes

### DIFF
--- a/src/main/scala/com/atomist/param/Parameter.scala
+++ b/src/main/scala/com/atomist/param/Parameter.scala
@@ -181,7 +181,7 @@ class Parameter @JsonCreator()(@JsonProperty("name") val name: String) {
     */
   def isValidValue(obj: Any): Boolean = obj match {
     case s: String =>
-      if (allowedValues.size > 0) allowedValues.exists(_.value == s)
+      if (allowedValues.nonEmpty) allowedValues.exists(_.value == s)
       else ((minLength < 0 || s.length >= minLength) &&
         (maxLength < 0 || s.length <= maxLength) &&
         pattern.r.findAllMatchIn(s).nonEmpty)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperation.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptInvokingProjectOperation.scala
@@ -68,7 +68,7 @@ abstract class JavaScriptInvokingProjectOperation(
 
 
   /**
-    * Convenience method that will try __name first for decorated things
+    * Convenience method that will try `__name` first for decorated things
     */
   protected def getMember(name: String, someVar: ScriptObjectMirror = jsVar) : AnyRef = {
     val decorated = s"__$name"

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/DismatchReport.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/DismatchReport.scala
@@ -61,7 +61,7 @@ object DismatchReport {
         case ctn: ContainerTreeNode =>
           val childrenByStartOffset = ctn.childNodes.map(_.asInstanceOf[PositionedTreeNode]).sortBy(_.startPosition.offset)
           val pf: String => String = {
-            case input =>
+            input =>
               childrenByStartOffset.reverse.foldLeft(input) { (inp: String, child: PositionedTreeNode) =>
                 printMatching(child, inp)
               }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/Matcher.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/Matcher.scala
@@ -94,15 +94,15 @@ object Matcher {
           prettyPrintLines(left) ++
             prettyPrintLines(right))
       case Discard(m, name) =>
-        mkSeq(s"Discard($name", prettyPrintLines(m), ")")
+        mkSeq(s"Discard($name", prettyPrintLines(m))
       case Wrap(m, name) =>
-        mkSeq(s"Wrap($name", prettyPrintLines(m), ")")
+        mkSeq(s"Wrap($name", prettyPrintLines(m))
       case RestOfLine(name) =>
         Seq(s"RestOfLine($name)")
       case Optional(m, name) =>
-        mkSeq(s"Optional($name", prettyPrintLines(m), ")")
+        mkSeq(s"Optional($name", prettyPrintLines(m))
       case Reference(delegate, name) =>
-        mkSeq(s"Reference($name", prettyPrintLines(delegate), ")")
+        mkSeq(s"Reference($name", prettyPrintLines(delegate))
       case other =>
         Seq(other.toString)
     }

--- a/src/test/scala/com/atomist/event/archive/HandlerArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/event/archive/HandlerArchiveReaderTest.scala
@@ -3,11 +3,11 @@ package com.atomist.event.archive
 import com.atomist.event.SystemEvent
 import com.atomist.plan.TreeMaterializer
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
-import com.atomist.rug.kind.service.{ConsoleMessageBuilder}
+import com.atomist.rug.kind.service.ConsoleMessageBuilder
 import com.atomist.rug.runtime.js.interop.NamedJavaScriptEventHandlerTest
 import com.atomist.rug.ts.TypeScriptBuilder
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
-import com.atomist.tree.{TreeNode}
+import com.atomist.tree.TreeNode
 import com.atomist.tree.pathexpression.PathExpression
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
+++ b/src/test/scala/com/atomist/project/archive/ProjectOperationArchiveReaderTest.scala
@@ -267,7 +267,8 @@ class FakeServiceSource(val projects: Seq[ArtifactSource]) extends ServiceSource
     new ConsoleMessageBuilder(teamId, EmptyActionRegistry)
 
 
-  var issues = ListBuffer.empty[Issue]
+  val issues = ListBuffer.empty[Issue]
+
 
   override def services: Seq[Service] =
     projects.map(proj => Service(proj, updatePersister, issueRouter = this, messageBuilder = messageBuilder))

--- a/src/test/scala/com/atomist/rug/kind/elm/ElmUpgradeProgramTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/elm/ElmUpgradeProgramTest.scala
@@ -27,7 +27,7 @@ class ElmUpgradeProgramTest extends FlatSpec with Matchers {
       StringFileArtifact("Main.elm", elm)
     val r = elmExecute(new SimpleFileBasedArtifactSource("", source), editor)
 
-    assert(r.findFile("Main.elm").value.content.lines.find(_.contains("import Foo")).headOption.value === "import Foo exposing (fooFunction)")
+    assert(r.findFile("Main.elm").value.content.lines.find(_.contains("import Foo")).value === "import Foo exposing (fooFunction)")
 
   }
 

--- a/src/test/scala/com/atomist/tree/content/text/PadPropertyTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/PadPropertyTest.scala
@@ -150,7 +150,7 @@ object PositionedTreeNodeGenerators {
         }
       case ctn: ContainerTreeNode =>
         (for {
-          goodbyeChildIndex <- Range(0, ctn.childNodes.length)
+          goodbyeChildIndex <- ctn.childNodes.indices
         } yield {
           val before = ctn.childNodes.slice(0, goodbyeChildIndex)
           val goodbyeChild = ctn.childNodes(goodbyeChildIndex)

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/RepTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/RepTest.scala
@@ -44,7 +44,7 @@ class RepTest extends FlatSpec with Matchers {
   }
 
   it should "handle rep of regex with two instances" in {
-    val l1 = new Regex("thing", Some("t...g"))
+    val l1 = Regex("thing", Some("t...g"))
     val namedRep = Rep(l1, None)//"myReppyName")
     val input = "thingthing2"
     namedRep.matchPrefix(InputState(input)) match {


### PR DESCRIPTION
 - Replace x.size > 0 with x.nonEmpty

 - Prevent Scaladoc unbalanced tag warning by using code formatting ``

 - Avoid PartialFunction when anonymous function sufficient

 - Extend reliance on parameter default instead of supplying ")"

 - Remove superfluous braces in imports

 - Use val when var was set to mutable type

 - Remove superfluous headOption (which I added earlier)

 - Use x.indices instead of Range(0, x.length)

 - Drop new when creating a case class instance