### PR TITLE
No longer use Scala manifest in Type. Pulled out PathAwareTreeNode

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/core/DirectoryType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/DirectoryType.scala
@@ -14,13 +14,11 @@ class DirectoryType(evaluator: Evaluator)
 
   override def description = "Type for a directory within a project."
 
-  override def viewManifest: Manifest[DirectoryMutableView] = manifest[DirectoryMutableView]
+  override def runtimeClass: Class[_] = classOf[DirectoryMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pmv: ProjectMutableView =>
         Some(pmv.currentBackingObject.allDirectories.map(d => new DirectoryMutableView(d, pmv)))
       case _ => None
     }
-
-  override type Self = this.type
 }

--- a/src/main/scala/com/atomist/rug/kind/core/FileArtifactBackedMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileArtifactBackedMutableView.scala
@@ -4,6 +4,7 @@ import com.atomist.project.review.ReviewComment
 import com.atomist.project.review.Severity.Severity
 import com.atomist.rug.spi._
 import com.atomist.source.{FileArtifact, StringFileArtifact}
+import com.atomist.tree.PathAwareTreeNode
 
 /**
   * Convenience class for MutableView implementations that are backed by a
@@ -20,7 +21,7 @@ abstract class FileArtifactBackedMutableView(originalBackingObject: FileArtifact
 
   override def childNodeNames: Set[String] = Set()
 
-  override def address = MutableView.address(this, s"path=${currentBackingObject.path}")
+  override def address = PathAwareTreeNode.address(this, s"path=${currentBackingObject.path}")
 
   override protected def toReviewComment(msg: String, severity: Severity): ReviewComment =
     ReviewComment(msg, severity, Some(currentBackingObject.path))

--- a/src/main/scala/com/atomist/rug/kind/core/FileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileType.scala
@@ -1,11 +1,8 @@
 package com.atomist.rug.kind.core
 
-import com.atomist.project.ProjectOperationArguments
 import com.atomist.rug.kind.dynamic.ChildResolver
-import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
-import com.atomist.rug.spi.{MutableView, ReflectivelyTypedType, Type}
-import com.atomist.source.ArtifactSource
+import com.atomist.rug.spi.{ReflectivelyTypedType, Type}
 import com.atomist.tree.TreeNode
 
 class FileType(
@@ -19,9 +16,7 @@ class FileType(
 
   override def description = "Type for a file within a project."
 
-  override def viewManifest: Manifest[FileMutableView] = manifest[FileMutableView]
-
-  override type Self = this.type
+  override def runtimeClass = classOf[FileMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = context match {
     case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/core/LineType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/LineType.scala
@@ -19,7 +19,7 @@ class LineType(
   override def description = "Represents a line within a text file"
 
   /** Describe the MutableView subclass to allow for reflective function export */
-  override def viewManifest: Manifest[_] = manifest[LineMutableView]
+  override def runtimeClass = classOf[LineMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/core/ProjectType.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/ProjectType.scala
@@ -16,7 +16,7 @@ class ProjectType(
     "Consider using file and other lower types by preference as project" +
     "operations can be inefficient."
 
-  override def viewManifest: Manifest[ProjectMutableView] = manifest[ProjectMutableView]
+  override def runtimeClass = classOf[ProjectMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = {
     // Special case where we want only one

--- a/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
@@ -23,8 +23,7 @@ class CSharpFileType
 
   import CSharpFileType._
 
-  override def viewManifest: Manifest[CSharpFileMutableView] =
-    manifest[CSharpFileMutableView]
+  override def runtimeClass = classOf[CSharpFileMutableView]
 
   override def description = "C# file"
 

--- a/src/main/scala/com/atomist/rug/kind/docker/DockerFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/docker/DockerFileType.scala
@@ -17,7 +17,7 @@ class DockerFileType(
 
   def description: String = "Docker file type"
 
-  override def viewManifest: Manifest[DockerMutableView] = manifest[DockerMutableView]
+  override def runtimeClass = classOf[DockerMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = context match {
       case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/elm/ElmModuleType.scala
+++ b/src/main/scala/com/atomist/rug/kind/elm/ElmModuleType.scala
@@ -17,7 +17,7 @@ class ElmModuleType(
 
   override def description = "Elm module"
 
-  override def viewManifest: Manifest[ElmModuleMutableView] = manifest[ElmModuleMutableView]
+  override def runtimeClass = classOf[ElmModuleMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/grammar/TypeUnderFile.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/TypeUnderFile.scala
@@ -27,7 +27,7 @@ abstract class TypeUnderFile
     */
   def isOfType(f: FileArtifact): Boolean
 
-  override def viewManifest: Manifest[_] = manifest[MutableContainerMutableView]
+  override def runtimeClass: Class[_] = classOf[MutableContainerMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[TreeNode]] = context match {
       case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/java/JavaProjectMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/JavaProjectMutableView.scala
@@ -25,7 +25,7 @@ class JavaProjectType(
 
   override def description = "Java project"
 
-  override def viewManifest: Manifest[JavaProjectMutableView] = manifest[JavaProjectMutableView]
+  override def runtimeClass = classOf[JavaProjectMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/java/JavaSourceType.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/JavaSourceType.scala
@@ -20,7 +20,7 @@ class JavaSourceType(evaluator: Evaluator)
 
   override def description = "Java source file"
 
-  override def viewManifest: Manifest[JavaSourceMutableView] = manifest[JavaSourceMutableView]
+  override def runtimeClass = classOf[JavaSourceMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/java/JavaTypeType.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/JavaTypeType.scala
@@ -24,7 +24,7 @@ class JavaTypeType(evaluator: Evaluator)
 
   override def description = "Java class"
 
-  override def viewManifest: Manifest[JavaClassOrInterfaceView] = manifest[JavaClassOrInterfaceView]
+  override def runtimeClass = classOf[JavaClassOrInterfaceView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/java/SpringBootProjectMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/SpringBootProjectMutableView.scala
@@ -23,7 +23,7 @@ class SpringBootProjectType(
 
   override def description = "Spring Boot project"
 
-  override def viewManifest: Manifest[SpringBootProjectMutableView] = manifest[SpringBootProjectMutableView]
+  override def runtimeClass = classOf[SpringBootProjectMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case jpv: JavaProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/js/PackageJsonType.scala
+++ b/src/main/scala/com/atomist/rug/kind/js/PackageJsonType.scala
@@ -15,7 +15,7 @@ class PackageJsonType(
 
   override def description = "package.json configuration file"
 
-  override def viewManifest: Manifest[PackageJsonMutableView] = manifest[PackageJsonMutableView]
+  override def runtimeClass = classOf[PackageJsonMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/json/JsonType.scala
+++ b/src/main/scala/com/atomist/rug/kind/json/JsonType.scala
@@ -22,7 +22,7 @@ class JsonType
 
   override def description = "JSON file"
 
-  override def viewManifest: Manifest[JsonMutableView] = manifest[JsonMutableView]
+  override def runtimeClass = classOf[JsonMutableView]
 
   override def isOfType(f: FileArtifact): Boolean = f.name.endsWith(Extension)
 

--- a/src/main/scala/com/atomist/rug/kind/pom/EveryPomType.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/EveryPomType.scala
@@ -20,7 +20,7 @@ class EveryPomType(
 
   override def description = "POM XML file"
 
-  override def viewManifest: Manifest[PomMutableView] = manifest[PomMutableView]
+  override def runtimeClass = classOf[PomMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/pom/PomMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/PomMutableView.scala
@@ -348,8 +348,8 @@ trait PomMutableViewMutatingFunctions extends BuildViewMutatingFunctions {
     deleteNode(s"/project/dependencies/dependency/artifactId[text()='$artifactId' and ../groupId[text() = '$groupId']]/../$subnode")
 
   private def addOrReplaceDependencySubNode(artifactId: String, groupId: String, subnode: String, content: String): Unit =
-    addOrReplaceNode(s"/project/dependencies/dependency/artifactId [text()='$artifactId' and ../groupId [text() = '$groupId']]/..",
-      s"/project/dependencies/dependency/artifactId [text()='$artifactId' and ../groupId [text() = '$groupId']]/../$subnode",
+    addOrReplaceNode(dependencyBaseXPath,
+      s"/project/dependencies/dependency/artifactId[text()='$artifactId' and ../groupId[text() = '$groupId']]/../$subnode",
       subnode,
       s"""<$subnode>$content</$subnode>""")
 

--- a/src/main/scala/com/atomist/rug/kind/pom/PomType.scala
+++ b/src/main/scala/com/atomist/rug/kind/pom/PomType.scala
@@ -22,7 +22,7 @@ class PomType(
 
   override def description = "POM XML file"
 
-  override def viewManifest: Manifest[PomMutableView] = manifest[PomMutableView]
+  override def runtimeClass = classOf[PomMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/kind/properties/PropertiesType.scala
+++ b/src/main/scala/com/atomist/rug/kind/properties/PropertiesType.scala
@@ -15,7 +15,7 @@ class PropertiesType(
 
   override def description = "Java properties file"
 
-  override def viewManifest: Manifest[PropertiesMutableView] = manifest[PropertiesMutableView]
+  override def runtimeClass = classOf[PropertiesMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonRequirementsTxtType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonRequirementsTxtType.scala
@@ -1,13 +1,11 @@
 package com.atomist.rug.kind.python3
 
-import com.atomist.project.ProjectOperationArguments
 import com.atomist.rug.RugRuntimeException
 import com.atomist.rug.kind.core.{LazyFileArtifactBackedMutableView, ProjectMutableView}
 import com.atomist.rug.kind.dynamic.MutableContainerMutableView
-import com.atomist.rug.parser.Selected
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
 import com.atomist.rug.spi._
-import com.atomist.source.{ArtifactSource, FileArtifact}
+import com.atomist.source.FileArtifact
 import com.atomist.tree.TreeNode
 
 class RequirementsType(
@@ -20,7 +18,7 @@ class RequirementsType(
 
   override def description = "Python requirements file"
 
-  override def viewManifest: Manifest[MutableContainerMutableView] = manifest[MutableContainerMutableView]
+  override def runtimeClass = classOf[MutableContainerMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pmv: ProjectMutableView =>
@@ -52,7 +50,7 @@ object PythonRequirementsTxtType {
 
 }
 
-import PythonRequirementsTxtType._
+import com.atomist.rug.kind.python3.PythonRequirementsTxtType._
 
 /**
   * Type for Python requirements.txt

--- a/src/main/scala/com/atomist/rug/kind/rug/archive/RugArchiveProjectType.scala
+++ b/src/main/scala/com/atomist/rug/kind/rug/archive/RugArchiveProjectType.scala
@@ -8,7 +8,8 @@ import com.atomist.tree.TreeNode
 class RugArchiveProjectType
   extends Type(DefaultEvaluator)
   with ReflectivelyTypedType {
-  def viewManifest: Manifest[_] = manifest[RugArchiveProjectMutableView]
+
+  def runtimeClass = classOf[RugArchiveProjectMutableView]
 
   // Members declared in com.atomist.rug.spi.Typed
   def description: String = "Rug archive"

--- a/src/main/scala/com/atomist/rug/kind/rug/dsl/EditorType.scala
+++ b/src/main/scala/com/atomist/rug/kind/rug/dsl/EditorType.scala
@@ -8,7 +8,7 @@ import com.atomist.tree.TreeNode
 class EditorType(evaluator: Evaluator) extends Type(evaluator) with ReflectivelyTypedType {
   /** Describe the MutableView subclass to allow for reflective function export */
 
-  override def viewManifest: Manifest[_] = manifest[EditorMutableView]
+  override def runtimeClass = classOf[EditorMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pmv: ProjectMutableView => ???

--- a/src/main/scala/com/atomist/rug/kind/service/ServicesType.scala
+++ b/src/main/scala/com/atomist/rug/kind/service/ServicesType.scala
@@ -18,7 +18,7 @@ class ServicesType(
 
   override def description: String = "Type for services. Used in executors"
 
-  override def viewManifest: Manifest[ServicesMutableView] = manifest[ServicesMutableView]
+  override def runtimeClass = classOf[ServicesMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case s: ServicesMutableView => Some(s.childrenNamed("service"))

--- a/src/main/scala/com/atomist/rug/kind/xml/XmlType.scala
+++ b/src/main/scala/com/atomist/rug/kind/xml/XmlType.scala
@@ -15,7 +15,7 @@ class XmlType(
 
   override def description = "XML"
 
-  override def viewManifest: Manifest[XmlMutableView] = manifest[XmlMutableView]
+  override def runtimeClass = classOf[XmlMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = {
     context match {

--- a/src/main/scala/com/atomist/rug/kind/yml/YmlType.scala
+++ b/src/main/scala/com/atomist/rug/kind/yml/YmlType.scala
@@ -22,7 +22,7 @@ class YmlType(
 
   override def description = "YAML file.  If the file contains multiple YAML documents, only the first is parsed and addressable."
 
-  override def viewManifest: Manifest[YmlMutableView] = manifest[YmlMutableView]
+  override def runtimeClass = classOf[YmlMutableView]
 
   override def findAllIn(context: TreeNode): Option[Seq[MutableView[_]]] = context match {
       case pmv: ProjectMutableView =>

--- a/src/main/scala/com/atomist/rug/spi/MutableView.scala
+++ b/src/main/scala/com/atomist/rug/spi/MutableView.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.spi
 
 import com.atomist.rug.runtime.rugdsl.Evaluator
-import com.atomist.tree.ContainerTreeNode
+import com.atomist.tree.{ContainerTreeNode, PathAwareTreeNode}
 
 
 /**
@@ -20,13 +20,7 @@ import com.atomist.tree.ContainerTreeNode
   *
   * @tparam  T type of the underlying object
   */
-trait MutableView[T] extends ContainerTreeNode {
-
-  /**
-    * Nullable if at the top level, as we don't want to complicate
-    * use from JavaScript by using Option.
-    */
-  def parent: MutableView[_]
+trait MutableView[T] extends PathAwareTreeNode with ContainerTreeNode {
 
   def originalBackingObject: T
 
@@ -37,6 +31,8 @@ trait MutableView[T] extends ContainerTreeNode {
   def dirty: Boolean
 
   def currentBackingObject: T
+
+  override def parent: MutableView[_]
 
   /**
     * Subclasses can call this to update the state of this object.
@@ -57,19 +53,6 @@ trait MutableView[T] extends ContainerTreeNode {
     */
   def commit(): Unit
 
-  /* really this should be a path expression but let's start somewhere */
-  def address: String = MutableView.address(this, s"name=$nodeName")
-
-}
-
-object MutableView {
-  def address(nodeOfInterest: MutableView[_], test: String): String = {
-    val myType = nodeOfInterest.nodeTags.mkString(",")
-    if (nodeOfInterest.parent == null)
-      s"$myType()$test"
-    else
-      s"${nodeOfInterest.parent.address}/$myType()[$test]"
-  }
 }
 
 /**

--- a/src/main/scala/com/atomist/rug/spi/ReflectiveStaticTypeInformation.scala
+++ b/src/main/scala/com/atomist/rug/spi/ReflectiveStaticTypeInformation.scala
@@ -16,11 +16,7 @@ class ReflectiveStaticTypeInformation(classToExamine: Class[_]) extends StaticTy
   }
 }
 
-trait ReflectivelyTypedType extends Typed {
-
-  type Self <: Type
-
-  def self = this.asInstanceOf[Self]
+trait ReflectivelyTypedType extends Type {
 
   /**
     * Expose type information. Return an instance of StaticTypeInformation if
@@ -29,7 +25,7 @@ trait ReflectivelyTypedType extends Typed {
     * @return type information.
     */
   final override val typeInformation: TypeInformation =
-    new ReflectiveStaticTypeInformation(self.viewManifest.runtimeClass)
+    new ReflectiveStaticTypeInformation(runtimeClass)
 }
 
 /**

--- a/src/main/scala/com/atomist/rug/spi/Type.scala
+++ b/src/main/scala/com/atomist/rug/spi/Type.scala
@@ -15,6 +15,6 @@ abstract class Type(evaluator: Evaluator)
   extends ChildResolver with Typed {
 
   /** Describe the MutableView subclass to allow for reflective function export */
-  def viewManifest: Manifest[_]
+  def runtimeClass:Class[_]
 
 }

--- a/src/main/scala/com/atomist/tree/PathAwareTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/PathAwareTreeNode.scala
@@ -1,0 +1,27 @@
+package com.atomist.tree
+
+/**
+  * Tree node aware of its parentage and path
+  */
+trait PathAwareTreeNode extends TreeNode {
+
+  /**
+    * Nullable if at the top level, as we don't want to complicate
+    * use from JavaScript by using Option.
+    */
+  def parent: PathAwareTreeNode
+
+  /* really this should be a path expression but let's start somewhere */
+  def address: String = PathAwareTreeNode.address(this, s"name=$nodeName")
+}
+
+object PathAwareTreeNode {
+
+  def address(nodeOfInterest: PathAwareTreeNode, test: String): String = {
+    val myType = nodeOfInterest.nodeTags.mkString(",")
+    if (nodeOfInterest.parent == null)
+      s"$myType()$test"
+    else
+      s"${nodeOfInterest.parent.address}/$myType()[$test]"
+  }
+}

--- a/src/main/scala/com/atomist/tree/pathexpression/NodesWithTag.scala
+++ b/src/main/scala/com/atomist/tree/pathexpression/NodesWithTag.scala
@@ -53,7 +53,7 @@ case class NodesWithTag(tag: String)
         var toReturn = List.empty[TreeNode]
         found.foreach {
           case mv: MutableView[_] =>
-            println(s"I see a node at ${mv.address}")
+            //println(s"I see a node at ${mv.address}")
             if (!nodeAddressesSeen.contains(mv.address)) {
               nodeAddressesSeen = nodeAddressesSeen + mv.address
               toReturn = toReturn :+ mv

--- a/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/pom/PomMutableViewTest.scala
@@ -463,23 +463,6 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
     validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (newScope)
   }
 
-  it should "add a scope to a new dependency: https://github.com/atomist/rug/issues/194" in {
-    val dependencyArtifactId = "junit"
-    val dependencyGroupId = "org.junit"
-    val dependencyVersion = "1.2.3"
-
-    val newScope = "test"
-
-    validPomUut.addOrReplaceDependencyOfVersion(dependencyGroupId, dependencyArtifactId, dependencyVersion)
-    validPomUut.addOrReplaceDependencyScope(dependencyGroupId, dependencyArtifactId, newScope)
-
-    println(validPomUut.content)
-
-    validPomUut.dirty should be (true)
-    validPomUut.dependencyVersion(dependencyGroupId, dependencyArtifactId) should be (dependencyVersion)
-    validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (newScope)
-  }
-
   it should "remove an existing dependency's existing scope" in {
     val dependencyArtifactId = "spring-boot-starter-test"
     val dependencyGroupId = "org.springframework.boot"
@@ -493,7 +476,6 @@ class PomMutableViewTest extends FlatSpec with Matchers with BeforeAndAfterEach 
     assert(validPomUut.dirty === true)
 
     validPomUut.dependencyScope(dependencyGroupId, dependencyArtifactId) should be (expectedOutcomeScope)
-
   }
 
   it should "sensibly not remove an existing dependency's scope when it doesn't have one" in {

--- a/src/test/scala/com/atomist/rug/kind/test/ReplacerCljType.scala
+++ b/src/test/scala/com/atomist/rug/kind/test/ReplacerCljType.scala
@@ -2,22 +2,16 @@ package com.atomist.rug.kind.test
 
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
-import com.atomist.rug.spi.{MutableView, ReflectiveStaticTypeInformation, Type, TypeInformation}
+import com.atomist.rug.spi._
 import com.atomist.tree.TreeNode
 
-import scala.reflect.ManifestFactory
-
-class ReplacerCljType(ev: Evaluator) extends Type(ev) {
+class ReplacerCljType(ev: Evaluator) extends Type(ev) with ReflectivelyTypedType {
 
   def this() = this(DefaultEvaluator)
 
-  def viewManifest: Manifest[_] = ManifestFactory.classType(viewClass)
-
-  def typeInformation: TypeInformation = new ReflectiveStaticTypeInformation(viewClass)
-
   def description = "Test type for replacing the content of clojure files"
 
-  protected def viewClass: Class[StringReplacingMutableView] = classOf[StringReplacingMutableView]
+  override def runtimeClass: Class[StringReplacingMutableView] = classOf[StringReplacingMutableView]
 
   protected def listViews(context: TreeNode): Seq[MutableView[_]] = context match {
     case pmv: ProjectMutableView =>

--- a/src/test/scala/com/atomist/rug/kind/test/ReplacerType.scala
+++ b/src/test/scala/com/atomist/rug/kind/test/ReplacerType.scala
@@ -2,21 +2,17 @@ package com.atomist.rug.kind.test
 
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.runtime.rugdsl.{DefaultEvaluator, Evaluator}
-import com.atomist.rug.spi.{MutableView, ReflectiveStaticTypeInformation, Type, TypeInformation}
+import com.atomist.rug.spi._
 import com.atomist.tree.TreeNode
 import org.springframework.beans.factory.annotation.Autowired
 
-import scala.reflect.ManifestFactory
-
 // Only used in tests
-class ReplacerType(ev: Evaluator) extends Type(ev) {
+class ReplacerType(ev: Evaluator) extends Type(ev) with ReflectivelyTypedType {
 
   def this() = this(DefaultEvaluator)
 
-  def viewManifest: Manifest[_] = ManifestFactory.classType(viewClass)
+  def runtimeClass = viewClass
 
-  def typeInformation: TypeInformation = new ReflectiveStaticTypeInformation(viewClass)
-  
   def description = "Test type for replacing the content of files"
 
   @Autowired


### PR DESCRIPTION
- Use Java class instead of Scala manifest in `Type`: Simpler and easier for Java subclasses
- Pulled out `PathAwareTreeNode` as this is a separate concern from `MutableView`