### PR TITLE
Raise an InvalidRugTestScenarioName when scenario name is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Fix: Elm parser failed on files with two multiline comments
      https://github.com/atomist/rug/issues/268 
      
+-   Raise an `InvalidRugTestScenarioName` when a Rug test scenario is missing a name #71
+     
 ### Changed
 
 -   Upgrade TS compiler to 2.1.5

--- a/src/main/scala/com/atomist/rug/BadRugException.scala
+++ b/src/main/scala/com/atomist/rug/BadRugException.scala
@@ -68,3 +68,6 @@ class InvalidRugParameterDefaultValue(msg: String)
 
 class RugJavaScriptException(msg: String, rootCause: ScriptException)
    extends BadRugException(msg,rootCause)
+
+class InvalidRugTestScenarioName(msg: String)
+  extends BadRugException(msg)

--- a/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
+++ b/src/test/scala/com/atomist/rug/test/TestScriptParserRugTest.scala
@@ -1,5 +1,6 @@
 package com.atomist.rug.test
 
+import com.atomist.rug.InvalidRugTestScenarioName
 import com.atomist.util.scalaparsing.SimpleLiteral
 import com.atomist.rug.parser.{ParsedRegisteredFunctionPredicate, WrappedFunctionArg}
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
@@ -418,5 +419,20 @@ class TestScriptParserRugTest extends FlatSpec with Matchers {
     val parsed = parser.parse(StringFileArtifact("IdempotencyTest.rt", prog))
     val myTest = parsed.head
     assert(myTest.givenInvocations.size === 2)
+  }
+
+  it should "disallow empty scenario name" in {
+    val prog =
+      """scenario
+        |
+        |given
+        |  ArchiveRoot
+        |
+        |then
+        |  NoChange""".stripMargin
+
+    assertThrows[InvalidRugTestScenarioName] {
+      parser.parse(StringFileArtifact("InvalidScenarioName.rt", prog))
+    }
   }
 }


### PR DESCRIPTION
This should address #71 when the scenario name is not set.
By raising that specific error, the user gets a message that
the name is invalid (since an empty name is considered as such).
This was much trickier than expected because scala Combinators regex
used before wasn't stopping at the end of the scenario line but
would swallow everythong down to the next production. David and I
figured we'd need to be a little more explicit about the actual
parsing rule.