### PR TITLE
Fix "pattern type is incompatible with expected type"

### DIFF
--- a/src/main/scala/com/atomist/util/lang/JavaScriptArray.scala
+++ b/src/main/scala/com/atomist/util/lang/JavaScriptArray.scala
@@ -222,13 +222,10 @@ class JavaScriptArray[T](val toProxy: java.util.List[T])
               lyst.sort(new Comparator[T] {
                 override def compare(t: T, t1: T): Int = {
                   val ret = filterfn.call(thiz, t.asInstanceOf[Object], t1.asInstanceOf[Object])
-                  // TODO - why does replacing this with matching fail to compile?
-                  if (ret.isInstanceOf[Double]) {
-                    ret.asInstanceOf[Double].toInt
-                  } else if(ret.isInstanceOf[Integer]){
-                    ret.asInstanceOf[Integer].toInt
-                  } else {
-                    throw new RuntimeException("Unrecognised return type from comparator: " + ret.getClass.getName)
+                  ret match {
+                    case d: java.lang.Double => d.toInt
+                    case i: Integer => i.toInt
+                    case _ => throw new RuntimeException("Unrecognised return type from comparator: " + ret.getClass.getName)
                   }
                 }
               })


### PR DESCRIPTION
Whereas Scala `Int` and Java `Integer` have different names, Scala `Double`
and Java `Double` have the same name so this,

    d: Double => ...

is a typed pattern requiring `scala.Double` a subclass of `AnyVal` which `ret` as `AnyRef` cannot satisfy.

Credit to IntelliJ,

![double-means-double](https://cloud.githubusercontent.com/assets/1123855/22803783/45bbc670-ef0e-11e6-93b2-dcf4e5f40652.png)

