### PR TITLE
Configure ScalaTest to dump short account of failed tests at end of build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,8 @@
                     <junitxml>.</junitxml>
                     <filereports>WDF TestSuite.txt</filereports>
                     <logForkedProcessCommand>true</logForkedProcessCommand>
+                    <!-- T: Failed test reminders with short stack traces -->
+                    <stdout>T</stdout>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This makes it easy to find the failed tests when building on console.

Example,

![show-failed-tests](https://cloud.githubusercontent.com/assets/1123855/22835552/186a6318-efb1-11e6-8589-44fbb488d1d7.png)

I feel this would be a benefit to future contributors.