### PR TITLE
Map common production names to friendlier aliases

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/csharp/CSharpFileType.scala
@@ -2,8 +2,27 @@ package com.atomist.rug.kind.csharp
 
 import com.atomist.rug.kind.grammar.AntlrRawFileType
 import com.atomist.source.FileArtifact
-import com.atomist.tree.content.text.grammar.antlr.FromGrammarAstNodeCreationStrategy
+import com.atomist.tree.TreeNode
+import com.atomist.tree.content.text.grammar.antlr.{AstNodeCreationStrategy, FromGrammarAstNodeCreationStrategy}
 import com.atomist.tree.pathexpression.{PathExpression, PathExpressionParser}
+
+object FromCSharpGrammarAstNodeCreationStrategy extends AstNodeCreationStrategy {
+
+  override def nameForContainer(rule: String, fields: Seq[TreeNode]): String = rule
+
+  override def tagsForContainer(rule: String, fields: Seq[TreeNode]): Set[String] = rule match {
+    case "class_definition" => Set("Class", "class_definition")
+    case "method_declaration" => Set("Method", "method_declaration")
+    case "using_directive" => Set("Using", "using_directive", "Import")
+    case "lambda_expression" => Set("Lambda", "lambda_expression")
+    case "fixed_parameter" => Set("Args", "fixed_parameter")
+    case "parameter_array" => Set("VarArgs", "parameter_array")
+    case r => Set(r)
+  }
+
+  override def significance(rule: String, fields: Seq[TreeNode]): TreeNode.Significance =
+    TreeNode.Signal
+}
 
 object CSharpFileType {
 
@@ -12,7 +31,7 @@ object CSharpFileType {
 
 class CSharpFileType
   extends AntlrRawFileType(topLevelProduction = "compilation_unit",
-    FromGrammarAstNodeCreationStrategy,
+    FromCSharpGrammarAstNodeCreationStrategy,
     "classpath:grammars/antlr/CSharpLexer.g4",
     "classpath:grammars/antlr/CSharpParser.g4"
   ) {

--- a/src/main/scala/com/atomist/rug/kind/java/path/JavaFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/java/path/JavaFileType.scala
@@ -2,14 +2,34 @@ package com.atomist.rug.kind.java.path
 
 import com.atomist.rug.kind.grammar.AntlrRawFileType
 import com.atomist.source.FileArtifact
-import com.atomist.tree.content.text.grammar.antlr.FromGrammarAstNodeCreationStrategy
+import com.atomist.tree.TreeNode
+import com.atomist.tree.content.text.grammar.antlr.{AstNodeCreationStrategy, FromGrammarAstNodeCreationStrategy}
+
+
+object FromJavaGrammarAstNodeCreationStrategy extends AstNodeCreationStrategy {
+
+  override def nameForContainer(rule: String, fields: Seq[TreeNode]): String = rule
+
+  override def tagsForContainer(rule: String, fields: Seq[TreeNode]): Set[String] = rule match {
+    case "classDeclaration" => Set("Class", "classDeclaration")
+    case "methodDeclaration" => Set("Method", "methodDeclaration")
+    case "importDeclaration" => Set("Import", "importDeclaration")
+    case "lambdaExpression" => Set("Lambda", "lambdaExpression")
+    case "formalParameter" => Set("Args", "formalParameter")
+    case "lastFormalParameter" => Set("VarArgs", "lastFormalParameter")
+    case r => Set(r)
+  }
+
+  override def significance(rule: String, fields: Seq[TreeNode]): TreeNode.Significance =
+    TreeNode.Signal
+}
 
 /**
   * Path-expression oriented Java type built on JavaParser
   */
 class JavaFileType
   extends AntlrRawFileType("compilationUnit",
-    FromGrammarAstNodeCreationStrategy,
+    FromJavaGrammarAstNodeCreationStrategy,
     "classpath:grammars/antlr/Java8.g4") {
 
   override def description = "Java file"

--- a/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
+++ b/src/main/scala/com/atomist/rug/kind/python3/PythonFileType.scala
@@ -2,7 +2,9 @@ package com.atomist.rug.kind.python3
 
 import com.atomist.rug.kind.grammar.AntlrRawFileType
 import com.atomist.source.FileArtifact
-import com.atomist.tree.content.text.grammar.antlr.FromGrammarAstNodeCreationStrategy
+import com.atomist.tree.{ContainerTreeNode, TreeNode}
+import com.atomist.tree.TreeNode.Significance
+import com.atomist.tree.content.text.grammar.antlr.AstNodeCreationStrategy
 
 object PythonFileType {
 
@@ -10,9 +12,27 @@ object PythonFileType {
 
 }
 
+object FromPythonGrammarAstNodeCreationStrategy extends AstNodeCreationStrategy {
+
+  override def nameForContainer(rule: String, fields: Seq[TreeNode]): String = rule
+
+  override def tagsForContainer(rule: String, fields: Seq[TreeNode]): Set[String] = rule match {
+    case "classdef" => Set("Class", "classdef")
+    case "funcdef" => Set("Func", "funcdef")
+    case "import_stmt" => Set("Import", "import_stmt")
+    case "lambdef" => Set("Lambda", "lambdef")
+    case "tfpdef" => Set("Args", "tfpdef")
+    case r => Set(r)
+  }
+
+  override def significance(rule: String, fields: Seq[TreeNode]): TreeNode.Significance =
+    TreeNode.Signal
+}
+
+
 class PythonFileType
   extends AntlrRawFileType("file_input",
-    FromGrammarAstNodeCreationStrategy,
+    FromPythonGrammarAstNodeCreationStrategy,
     "classpath:grammars/antlr/Python3.g4") {
 
   import PythonFileType._

--- a/src/test/scala/com/atomist/rug/kind/python3/Python3ParserTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/Python3ParserTest.scala
@@ -72,4 +72,44 @@ object Python3ParserTest {
       |if __name__ == "__main__":
       |    app.run()
     """.stripMargin
+
+  val pythonClasses =
+    """
+      | class MyClass:
+      |   pass
+      |
+      | class MySubClass(MyClass):
+      |   pass
+      |
+      | class OtherDeprecatedClass(object):
+      |   pass
+    """.stripMargin
+
+  val pythonFunctions =
+    """
+      | def echo(value_without_a_type, *args, **kwargs):
+      |   pass
+      |
+      | def say_colour(no_type_defined, colour: str) -> str:
+      |   return "This is %s" % colour
+      |
+      | class AClass:
+      |   def __init__(self):
+      |     pass
+      |
+      |   def make_noise(self, sound: str):
+      |     print(sound)
+      |
+      | lambda x, y: x if y == 0 else 1
+    """.stripMargin
+
+  val importStmts =
+    """
+      | import os, os.path
+      | from itertools import *
+      | from functools import (cmp_to_key, \
+      |   lru_cache)
+      | from base64 import b64encode as encode
+    """.stripMargin
+
 }

--- a/src/test/scala/com/atomist/rug/kind/python3/PythonFileTypeTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/python3/PythonFileTypeTest.scala
@@ -10,6 +10,7 @@ import com.atomist.tree.content.text.MutableContainerTreeNode
 import com.atomist.tree.pathexpression.{PathExpression, PathExpressionEngine, PathExpressionParser}
 import com.atomist.tree.utils.TreeNodeUtils
 import org.scalatest.{FlatSpec, Matchers}
+import com.atomist.tree.utils.TreeNodeUtils
 
 class PythonFileTypeTest extends FlatSpec with Matchers {
 
@@ -84,5 +85,92 @@ class PythonFileTypeTest extends FlatSpec with Matchers {
     }
 
     inner(Seq(), None, pathExpression).mkString("\n")
+  }
+
+  it should "map classdef to Class" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/mymod.py", pythonClasses))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr1 = "/src/File()/PythonFile()//Class()"
+    val rtn1 = pex.evaluate(pmv, PathExpressionParser.parseString(expr1), DefaultTypeRegistry)
+    assert(rtn1.right.get.size === 3)
+
+    val expr2 = "/src/File()/PythonFile()//classdef()"
+    val rtn2 = pex.evaluate(pmv, PathExpressionParser.parseString(expr2), DefaultTypeRegistry)
+    assert(rtn2.right.get.size === 3)
+
+    assert(rtn1.right.get.size === rtn2.right.get.size)
+
+  }
+
+  it should "map funcdef to Func" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/mymod.py", pythonFunctions))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr1 = "/src/File()/PythonFile()//Func()"
+    val rtn1 = pex.evaluate(pmv, PathExpressionParser.parseString(expr1), DefaultTypeRegistry)
+    assert(rtn1.right.get.size === 4)
+
+    val expr2 = "/src/File()/PythonFile()//funcdef()"
+    val rtn2 = pex.evaluate(pmv, PathExpressionParser.parseString(expr2), DefaultTypeRegistry)
+    assert(rtn2.right.get.size === 4)
+
+    assert(rtn1.right.get.size === rtn2.right.get.size)
+  }
+
+  it should "map tfpdef to Args" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/mymod.py", pythonFunctions))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr1 = "/src/File()/PythonFile()//Func()[/NAME[@value='say_colour']]//Args()"
+    val rtn1 = pex.evaluate(pmv, PathExpressionParser.parseString(expr1), DefaultTypeRegistry)
+    assert(rtn1.right.get.size === 2)
+
+    val expr2 = "/src/File()/PythonFile()//funcdef()[/NAME[@value='say_colour']]//Args()"
+    val rtn2 = pex.evaluate(pmv, PathExpressionParser.parseString(expr2), DefaultTypeRegistry)
+    assert(rtn2.right.get.size === 2)
+
+    val expr3 = "/src/File()/PythonFile()//funcdef()[/NAME[@value='say_colour']]//tfpdef()"
+    val rtn3 = pex.evaluate(pmv, PathExpressionParser.parseString(expr3), DefaultTypeRegistry)
+    assert(rtn3.right.get.size === 2)
+  }
+
+  it should "map lambdadef to Lambda" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/mymod.py", pythonFunctions))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr1 = "/src/File()/PythonFile()//Lambda()"
+    val rtn1 = pex.evaluate(pmv, PathExpressionParser.parseString(expr1), DefaultTypeRegistry)
+    assert(rtn1.right.get.size === 1)
+
+    val expr2 = "/src/File()/PythonFile()//lambdef()"
+    val rtn2 = pex.evaluate(pmv, PathExpressionParser.parseString(expr2), DefaultTypeRegistry)
+    assert(rtn2.right.get.size === 1)
+
+    assert(rtn1.right.get.size === rtn2.right.get.size)
+  }
+
+  it should "map classdef and funcdef to Class and Func" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/mymod.py", pythonFunctions))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr1 = "/src/File()/PythonFile()//Class()//Func()"
+    val rtn1 = pex.evaluate(pmv, PathExpressionParser.parseString(expr1), DefaultTypeRegistry)
+    assert(rtn1.right.get.size === 2)
+
+    val expr2 = "/src/File()/PythonFile()//Class()//funcdef()"
+    val rtn2 = pex.evaluate(pmv, PathExpressionParser.parseString(expr2), DefaultTypeRegistry)
+    assert(rtn2.right.get.size === 2)
+
+    assert(rtn1.right.get.size === rtn2.right.get.size)
+  }
+
+  it should "map import_stmt to Import" in {
+    val proj = SimpleFileBasedArtifactSource(StringFileArtifact("src/mymod.py", importStmts))
+    val pmv = new ProjectMutableView(EmptyArtifactSource(""), proj, DefaultAtomistConfig)
+    val expr1 = "/src/File()/PythonFile()//Import()"
+    val rtn1 = pex.evaluate(pmv, PathExpressionParser.parseString(expr1), DefaultTypeRegistry)
+    assert(rtn1.right.get.size === 4)
+
+    val expr2 = "/src/File()/PythonFile()//import_stmt()"
+    val rtn2 = pex.evaluate(pmv, PathExpressionParser.parseString(expr2), DefaultTypeRegistry)
+    assert(rtn2.right.get.size === 4)
+
+    assert(rtn1.right.get.size === rtn2.right.get.size)
   }
 }


### PR DESCRIPTION
As per #246, writing path expressions against ANTLR backed language extensions isn't thet friendly. It requires the user knows the grammar to navigate. Providing aliases for common perations is a rather nice way to write clear and readable path expressions.

Thanks to the `AstNodeCreationStrategy` trait, it's actually rather straigtforward to achieve. But there is a catch. Grammars aren't all equal in the granularity they expose. For instance, the Python grammar doesn't differentiate between methods and functions (methods are bindable functions). Probably, we could simply expose a Func alias on the Python side of course.

Now, let's assume we want to write a predicate for the function's name, this cannot be easily shared because, in Python this looks like this
`/PythonFile()//Func()[/NAME[@value='echo']]`, while in Java it looks like this
`/JavaFile()//Func()[/methodHeader/methodDeclarator/Identifier[@value='twoArgs']]`.
I'm not sure how we could map those location paths in the predicate so they become generic.

Not, there is also the question of natural ordering of the grammar vs what you'd write in a path expression. For instance, in the C# grammar, the visibility of a method or a class is set before the definition of the class itself so you can't write this expression:

`/File()/CSharpFile()//class_definition//method_declaration()[/all_member_modifier[@value="private"]]`

because `all_member_modifier` is not a child of `method_declaration` in the tree.

Instead, you run this one:

̀`/File()/CSharpFile()[//class_member_declaration/all_member_modifiers/all_member_modifier[@value='private']]//method_declaration()`

But that doesn't really do what intuitively you think. Indeed, this one tells us: "list all methods in any classes that has a private identifier somewhere". This could be a private variable. And it would list all methods whether they are public or private.

Finally, I wanted to map the `ScalaFileType` because I didn't know where to declare that mapping.

Overall, this is a little more limited than expected but there is promise if we can make the aliasing more intelligent about the structure, not just the local node.