### PR TITLE
Support for extracting rugs from exported TS classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   Rug TypeScript classes should be exported directly (rather than an instance on one)
+
 -   Upgrade TS compiler to 2.1.5
 
 -   `scalar` method on TypeScript `PathExpressionEngine` taking string is now called `scalarStr`. This

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugEditorTest.scala
@@ -29,7 +29,7 @@ object TypeScriptRugEditorTest {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
       |    }
       |}
-      |export let myeditor = new SimpleEditor();
+      |export {SimpleEditor}
     """.stripMargin
 
   val SimpleEditorWithBasicParameter =
@@ -47,7 +47,7 @@ object TypeScriptRugEditorTest {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God")
       |    }
       |}
-      |export let myeditor = new SimpleEditor()
+      |export {SimpleEditor}
     """.stripMargin
 
   val SimpleEditorWithBasicNameParameter =
@@ -70,7 +70,7 @@ object TypeScriptRugEditorTest {
        |        if(this.description !== "Not reserved") throw new Error("Darn - description is reserved it seems");
        |    }
        |}
-       |export let myeditor = new SimpleEditor()
+       |export {SimpleEditor}
     """.stripMargin
 
 
@@ -100,7 +100,7 @@ object TypeScriptRugEditorTest {
       |    }
       |}
       |
-      |export let myeditor = new SimpleEditor()
+      |export {SimpleEditor}
     """.stripMargin
 
   val SimpleEditorInvokingOtherEditor =
@@ -114,7 +114,7 @@ object TypeScriptRugEditorTest {
       |        project.editWith("other", { otherParam: "Anders Hjelsberg is God" });
       |    }
       |}
-      |export let myeditor = new SimpleEditor()
+      |export {SimpleEditor}
 
     """.stripMargin
 
@@ -135,7 +135,7 @@ object TypeScriptRugEditorTest {
        |      project.editWith("other", { otherParam: "Anders Hjelsberg is God" })
        |    }
        |  }
-       |export let myeditor = new SimpleEditor()
+       |export {SimpleEditor}
     """.stripMargin
 
   val SimpleGenerator =
@@ -156,7 +156,7 @@ object TypeScriptRugEditorTest {
       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
       |    }
       |}
-      |export let gen = new SimpleGenerator()
+      |export {SimpleGenerator}
     """.stripMargin
 
   val SimpleEditorTaggedAndMeta =
@@ -178,7 +178,7 @@ object TypeScriptRugEditorTest {
        |      project.addFile("src/from/typescript", this.content)
        |    }
        |  }
-       |export let myeditor = new SimpleEditor()
+       |export {SimpleEditor}
     """.stripMargin
 
     val SimpleTsUtil =
@@ -209,7 +209,7 @@ object TypeScriptRugEditorTest {
       |    }
       |}
       |
-      |export let myeditor = new SimpleEditor()
+      |export {SimpleEditor}
     """.stripMargin
 
     val EditorInjectedWithPathExpressionObject: String =
@@ -249,7 +249,7 @@ object TypeScriptRugEditorTest {
         |        `${t}\n\nEdited Project containing ${project.fileCount()} files: \n${s}`)
         |    }
         |  }
-        |  export let myeditor = new ConstructedEditor()
+        |export {SimpleEditor}
         | """.stripMargin
 
   val EditorInjectedWithPathExpression: String =
@@ -284,7 +284,7 @@ object TypeScriptRugEditorTest {
       |            s = s + `File [${f.path()}] containing [${f.content()}]\n`
       |    }
       |  }
-      |  export let myeditor = new ConstructedEditor()
+      |export {SimpleEditor}
       | """.stripMargin
 
   val EditorInjectedWithPathExpressionUsingWith: String =
@@ -323,7 +323,7 @@ object TypeScriptRugEditorTest {
       |    }
       |  }
       |
-      |  export let myeditor = new ConstructedEditor()
+      |export {SimpleEditor}
       | """.stripMargin
 
   val EditorInjectedWithPathExpressionUsingWithTypeJump: String =
@@ -360,7 +360,7 @@ object TypeScriptRugEditorTest {
       |        //`${t}\n\nEdited Project containing ${project.fileCount()} files: \n${s}`)
       |    }
       |  }
-      |  export let myeditor = new ConstructedEditor()
+      |export {SimpleEditor}
       | """.stripMargin
 
 }


### PR DESCRIPTION
This wasn't possible before because we were not enforcing a no-args constructors, but we do now anyway because we clone each editor for each request!

e.g.
```typescript
import {Project} from '@atomist/rug/model/Core';
import {Editor} from '@atomist/rug/operations/Decorators'
import {EditProject} from '@atomist/rug/operations/ProjectEditor'

@Editor("Simple", "My simple editor")
class SimpleEditor implements EditProject {
    edit(project: Project): void {
        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
    }
}
export {SimpleEditor}
```