### PR TITLE
Add getters for DockerfileMutableView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Added `ScalaFileType` backed by ScalaMeta
 
+-   Getters for Dockerfile instructions in DockerFile extension type
+
 ### Fixed
 
 -   Elm parser failed on files with two multiline comments

--- a/src/main/scala/com/atomist/rug/kind/docker/DockerFileMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/docker/DockerFileMutableView.scala
@@ -20,9 +20,21 @@ class DockerFileMutableView(originalBackingObject: FileArtifact, pmv: ProjectMut
 
   override def childNodeNames: Set[String] = Set()
 
+  @ExportFunction(readOnly = true, description = "Return last FROM line in Dockerfile.  It returns the empty string if there is no FROM line.")
+  def getFrom: String = _content.getFrom match {
+    case Some(s) => s
+    case None => ""
+  }
+
+  @ExportFunction(readOnly = false, description = "Add or update FROM instruction")
+  def addOrUpdateFrom(@ExportFunctionParameterDescription(name = "fromContents",
+    description = "The contents of the FROM instruction") fromContents: String) {
+    _content.addOrUpdateFrom(fromContents)
+  }
+
   @ExportFunction(readOnly = true, description = "")
   def getExposedPorts: java.util.List[Int] = {
-    val exposePorts: Set[Int] = _content.getExposePorts()
+    val exposePorts: Set[Int] = _content.getExposePorts
     /*
     We have to export collections as Java collections, as these get passed into
     nashorn for the typescript stuff, and it doesn't understand scala.
@@ -32,109 +44,155 @@ class DockerFileMutableView(originalBackingObject: FileArtifact, pmv: ProjectMut
     exposePorts.toSeq.asJava
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update FROM directive")
-  def addOrUpdateFrom(@ExportFunctionParameterDescription(name = "fromContents",
-    description = "The contents of the FROM directive") fromContents: String) {
-    _content.addOrUpdateFrom(fromContents)
-  }
-
-  @ExportFunction(readOnly = false, description = "Add or update EXPOSE directive")
+  @ExportFunction(readOnly = false, description = "Add or update EXPOSE instruction")
   def addOrUpdateExpose(@ExportFunctionParameterDescription(name = "exposeContents",
-    description = "The contents of the EXPOSE directive") exposeContents: String) {
+    description = "The contents of the EXPOSE instruction") exposeContents: String) {
     _content.addOrUpdateExpose(exposeContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add EXPOSE directive")
+  @ExportFunction(readOnly = false, description = "Add EXPOSE instruction")
   def addExpose(@ExportFunctionParameterDescription(name = "exposeContents",
-    description = "The contents of the EXPOSE directive") exposeContents: String) {
+    description = "The contents of the EXPOSE instruction") exposeContents: String) {
     _content.addExpose(exposeContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update MAINTAINER directive")
+  @ExportFunction(readOnly = true, description = "Return last MAINTAINER line in Dockerfile.  It returns the empty string if there is no MAINTAINER line.")
+  def getMaintainer: String = _content.getMaintainer match {
+    case Some(s) => s
+    case None => ""
+  }
+
+  @ExportFunction(readOnly = false, description = "Add or update MAINTAINER instruction")
   def addOrUpdateMaintainer(@ExportFunctionParameterDescription(name = "maintainerName",
-    description = "The name of the MAINTAINER directive") maintainerName: String,
+    description = "The name of the MAINTAINER instruction") maintainerName: String,
                             @ExportFunctionParameterDescription(name = "maintainerEmail",
-                              description = "The email of the MAINTAINER directive") maintainerEmail: String) {
+                              description = "The email of the MAINTAINER instruction") maintainerEmail: String) {
     maintainerEmail match {
       case s: String => _content.addMaintainer(s"$maintainerName <$s>")
       case _ => _content.addMaintainer(maintainerName)
     }
   }
 
-  @ExportFunction(readOnly = false, description = "Add MAINTAINER directive")
+  @ExportFunction(readOnly = false, description = "Add MAINTAINER instruction")
   def addMaintainer(@ExportFunctionParameterDescription(name = "maintainerName",
-    description = "The name of the MAINTAINER directive") maintainerName: String,
+    description = "The name of the MAINTAINER instruction") maintainerName: String,
                     @ExportFunctionParameterDescription(name = "maintainerEmail",
-                      description = "The email of the MAINTAINER directive") maintainerEmail: String) {
+                      description = "The email of the MAINTAINER instruction") maintainerEmail: String) {
     maintainerEmail match {
       case s: String => _content.addMaintainer(s"$maintainerName <$s>")
       case _ => _content.addMaintainer(maintainerName)
     }
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update LABEL directive")
+  @ExportFunction(readOnly = true,
+    description = "Return map of labels.  If there are no labels, an empty map is returned.")
+  def getLabels: Map[String, String] = _content.getLabels
+
+  @ExportFunction(readOnly = false, description = "Add or update LABEL instruction")
   def addOrUpdateLabel(@ExportFunctionParameterDescription(name = "labelContents",
-    description = "The contents of the LABEL directive") labelContents: String) {
+    description = "The contents of the LABEL instruction") labelContents: String) {
     _content.addOrUpdateLabel(labelContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add LABEL directive")
+  @ExportFunction(readOnly = false, description = "Add LABEL instruction")
   def addLabel(@ExportFunctionParameterDescription(name = "labelContents",
-    description = "The contents of the LABEL directive") labelContents: String) {
+    description = "The contents of the LABEL instruction") labelContents: String) {
     _content.addLabel(labelContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add RUN directive")
+  @ExportFunction(readOnly = true,
+    description = "Return sequence of RUN instructions as strings. If the RUN instruction is an array, a string representation of the array is included. If there are no RUN instructions, an empty sequence is returned.")
+  def getRuns: Seq[String] = Dockerfile.seqStringOrArrayToString(_content.getRuns)
+
+  @ExportFunction(readOnly = false, description = "Add RUN instruction")
   def addRun(@ExportFunctionParameterDescription(name = "runContents",
-    description = "The contents of the RUN directive") runContents: String) {
+    description = "The contents of the RUN instruction") runContents: String) {
     _content.addRun(runContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add COPY directive")
+  @ExportFunction(readOnly = true,
+    description = "Return sequence of COPY instructions as a sequence of strings. If there are no COPY instructions, an empty sequence is returned.")
+  def getCopies: Seq[Seq[String]] = _content.getCopies
+
+  @ExportFunction(readOnly = false, description = "Add COPY instruction")
   def addCopy(@ExportFunctionParameterDescription(name = "copyContents",
-    description = "The contents of the COPY directive") copyContents: String) {
+    description = "The contents of the COPY instruction") copyContents: String) {
     _content.addCopy(copyContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add ADD directive")
+  @ExportFunction(readOnly = true,
+    description = "Return sequence of ADD instructions as a sequence of strings. If there are no ADD instructions, an empty sequence is returned.")
+  def getAdds: Seq[Seq[String]] = _content.getAdds
+
+  @ExportFunction(readOnly = false, description = "Add ADD instruction")
   def addAdd(@ExportFunctionParameterDescription(name = "addContents",
-    description = "The contents of the ADD directive") addContents: String) {
+    description = "The contents of the ADD instruction") addContents: String) {
     _content.addAdd(addContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add Env directive")
+  @ExportFunction(readOnly = true,
+    description = "Return map of environment variables.  If there are no environment variables, an empty map is returned.")
+  def getEnvs: Map[String, String] = _content.getEnvs
+
+  @ExportFunction(readOnly = false, description = "Add ENV instruction")
   def addEnv(@ExportFunctionParameterDescription(name = "envContents",
-    description = "The contents of the Env directive") envContents: String) {
+    description = "The contents of the Env instruction") envContents: String) {
     _content.addEnv(envContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add VOLUME directive")
+  @ExportFunction(readOnly = true,
+    description = "Return sequence of VOLUME instructions as a sequence of strings. If there are no VOLUME instructions, an empty sequence is returned.")
+  def getVolumes: Seq[Seq[String]] = _content.getVolumes
+
+  @ExportFunction(readOnly = false, description = "Add VOLUME instruction")
   def addVolume(@ExportFunctionParameterDescription(name = "volumeContents",
-    description = "The contents of the VOLUME directive") volumeContents: String) {
+    description = "The contents of the VOLUME instruction") volumeContents: String) {
     _content.addVolume(volumeContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update WORKDIR directive")
+  @ExportFunction(readOnly = true,
+    description = "Return last WORKDIR instruction in Dockerfile.  It returns the empty string if there is no WORKDIR line.")
+  def getWorkdir: String = _content.getWorkdir match {
+    case Some(s) => s
+    case None => ""
+  }
+
+  @ExportFunction(readOnly = false, description = "Add or update WORKDIR instruction")
   def addOrUpdateWorkdir(@ExportFunctionParameterDescription(name = "workdirContents",
-    description = "The contents of the WORKDIR directive") workdirContents: String) {
+    description = "The contents of the WORKDIR instruction") workdirContents: String) {
     _content.addOrUpdateWorkdir(workdirContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update ENTRYPOINT directive")
+  @ExportFunction(readOnly = true,
+    description = "Return last ENTRYPOINT instruction as a string. If the ENTRYPOINT instruction is an array, a string representation of the Dockerfile array is returned. If there are no ENTRYPOINT instructions, an empty string is returned.")
+  def getEntryPoint: String = Dockerfile.stringOrArrayToString(_content.getEntryPoint)
+
+  @ExportFunction(readOnly = false, description = "Add or update ENTRYPOINT instruction")
   def addOrUpdateEntryPoint(@ExportFunctionParameterDescription(name = "entrypointContent",
-    description = "The contents of the ENTRYPOINT directive") entrypointContent: String) {
+    description = "The contents of the ENTRYPOINT instruction") entrypointContent: String) {
     _content.addOrUpdateEntryPoint(entrypointContent)
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update CMD directive")
+  @ExportFunction(readOnly = true,
+    description = "Return last CMD instruction as a string. If the CMD instruction is an array, a string representation of the Dockerfile array is returned. If there are no CMD instructions, an empty string is returned.")
+  def getCmd: String = Dockerfile.stringOrArrayToString(_content.getCmd)
+
+  @ExportFunction(readOnly = false, description = "Add or update CMD instruction")
   def addOrUpdateCmd(@ExportFunctionParameterDescription(name = "cmdContents",
-    description = "The contents of the CMD directive") cmdContents: String) {
+    description = "The contents of the CMD instruction") cmdContents: String) {
     _content.addOrUpdateCmd(cmdContents)
   }
 
-  @ExportFunction(readOnly = false, description = "Add or update HEALTHCHECK directive")
+  @ExportFunction(readOnly = true,
+    description = "Return last HEALTHCHECK instruction in Dockerfile.  It returns the empty string if there is no HEALTCHCHECK line.")
+  def getHealthcheck: String = _content.getHealthCheck match {
+    case Some(s) => s
+    case None => ""
+  }
+
+  @ExportFunction(readOnly = false, description = "Add or update HEALTHCHECK instruction")
   def addOrUpdateHealthcheck(@ExportFunctionParameterDescription(name = "healthcheckContent",
-    description = "The contents of the HEALTHCHECK directive") healthcheckContent: String) {
+    description = "The contents of the HEALTHCHECK instruction") healthcheckContent: String) {
     _content.addOrUpdateHealthcheck(healthcheckContent)
   }
 }

--- a/src/main/scala/com/atomist/rug/kind/docker/Dockerfile.scala
+++ b/src/main/scala/com/atomist/rug/kind/docker/Dockerfile.scala
@@ -7,7 +7,7 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
 
   def this() = this(Seq())
 
-  var _lines = lines
+  var _lines: Seq[DockerfileLine] = lines
 
   object Command extends Enumeration(initial = 0) {
     type Command = Value
@@ -16,7 +16,14 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
 
   import Command._
 
-  def getExposePorts(): Set[Int] = {
+  def getFrom: Option[String] = getLastString(FROM)
+
+  def addOrUpdateFrom(arg: String): this.type = {
+    addOrUpdate(FROM, arg)
+    this
+  }
+
+  def getExposePorts: Set[Int] = {
     val matchingLines: Seq[DockerfileLine] = lines.filter(d => EXPOSE.toString.equals(d.name))
     val exposeLineToPorts: (DockerfileLine) => Set[Int] = l => {
       // This could be a single value, or a list of values. First trim off any extra whitespace
@@ -29,11 +36,6 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
     matchingLines.flatMap(exposeLineToPorts).toSet
   }
 
-  def addOrUpdateFrom(arg: String): this.type = {
-    addOrUpdate(FROM, arg)
-    this
-  }
-
   def addOrUpdateExpose(arg: String): this.type = {
     addOrUpdate(EXPOSE, arg)
     this
@@ -43,6 +45,8 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
     add(EXPOSE, arg)
     this
   }
+
+  def getMaintainer: Option[String] = getLastString(MAINTAINER)
 
   def addOrUpdateMaintainer(arg: String): this.type = {
     addOrUpdate(MAINTAINER, arg)
@@ -54,6 +58,8 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
     this
   }
 
+  def getLabels: Map[String, String] = getAllMap(LABEL)
+
   def addOrUpdateLabel(arg: String*): this.type = {
     addOrUpdate(LABEL, arg.mkString(" "))
     this
@@ -64,52 +70,70 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
     this
   }
 
+  def getRuns: Seq[Either[String, Seq[String]]] = getAllStringOrArray(RUN)
+
   def addRun(arg: String): this.type = {
     add(RUN, arg)
     this
   }
+
+  def getCopies: Seq[Seq[String]] = getAllArray(COPY)
 
   def addCopy(arg: String): this.type = {
     add(COPY, arg)
     this
   }
 
+  def getAdds: Seq[Seq[String]] = getAllArray(ADD)
+
   def addAdd(arg: String): this.type = {
     add(ADD, arg)
     this
   }
+
+  def getEnvs = getAllMap(ENV)
 
   def addEnv(arg: String): this.type = {
     add(ENV, arg)
     this
   }
 
+  def getVolumes: Seq[Seq[String]] = getAllArray(VOLUME)
+
   def addVolume(arg: String): this.type = {
     add(VOLUME, arg)
     this
   }
+
+  def getWorkdir: Option[String] = getLastString(WORKDIR)
 
   def addOrUpdateWorkdir(arg: String): this.type = {
     addOrUpdate(WORKDIR, arg)
     this
   }
 
+  def getEntryPoint: Either[String, Seq[String]] = getLastStringOrArray(ENTRYPOINT)
+
   def addOrUpdateEntryPoint(arg: String): this.type = {
     addOrUpdate(ENTRYPOINT, arg)
     this
   }
+
+  def getCmd: Either[String, Seq[String]] = getLastStringOrArray(CMD)
 
   def addOrUpdateCmd(arg: String): this.type = {
     addOrUpdate(CMD, arg)
     this
   }
 
+  def getHealthCheck: Option[String] = getLastString(HEALTHCHECK)
+
   def addOrUpdateHealthcheck(arg: String): this.type = {
     addOrUpdate(HEALTHCHECK, arg)
     this
   }
 
-  override def toString = {
+  override def toString: String = {
     val builder = new StringBuilder
     val ai = new AtomicInteger(1)
     _lines.foreach(d => {
@@ -118,13 +142,92 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
         builder.append("\n")
         ai.incrementAndGet()
       }
-      for (i <- 0 until lb) {
+      for (_ <- 0 until lb) {
         ai.incrementAndGet()
       }
       builder.append(d.getRaw)
     })
     builder.toString.toSystem
   }
+
+  /**
+    * Return the value of the last occurrence of Dockerfile command `c`.
+    *
+    * @param c Dockerfile command
+    * @return
+    */
+  private def getLastString(c: Command): Option[String] =
+    lines.reverse.find(d => c.toString.equals(d.name)) match {
+      case Some(d: DockerfileLine) => d.getArgs match {
+        case s: String => Some(s)
+        case _ => None
+      }
+      case None => None
+    }
+
+  /**
+    * Return a sequence of the array values of '''all'''
+    * occurrences of the Dockerfile command `c.`
+    *
+    * @param c Dockerfile command
+    * @return
+    */
+  private def getAllArray(c: Command): Seq[Seq[String]] =
+    lines.filter(d => c.toString.equals(d.name)).map(dl => dl.getArgs match {
+      case m: Map[String @unchecked, String @unchecked] =>
+        m.asInstanceOf[Map[String, String]].toSeq.sortBy(p => Integer.parseInt(p._1)).map(_._2)
+      case _ => Seq.empty[String]
+    })
+
+  /**
+    * Return the value of the last occurrence of the Dockerfile command
+    * `c` which could be either a string or array of strings.  Examples of
+    * such commands are `CMD` and `ENTRYPOINT`.  If the command does not
+    * appear in the Dockerfile, `Right(Seq.empty)` is returned.
+    *
+    * @param c Dockerfile command
+    * @return
+    */
+  private def getLastStringOrArray(c: Command): Either[String, Seq[String]] =
+    lines.reverse.find(d => c.toString.equals(d.name)) match {
+      case Some(d: DockerfileLine) => d.getArgs match {
+        case s: String => Left(s)
+        case m: Map[String @unchecked, String @unchecked] =>
+          Right(m.asInstanceOf[Map[String, String]].toSeq.sortBy(p => Integer.parseInt(p._1)).map(_._2))
+      }
+      case None => Right(Seq.empty[String])
+    }
+
+  /**
+    * Return the value of the all occurrences of the Dockerfile command
+    * `c`, each of which could be either a string or array of strings.  Examples of
+    * such commands are `RUN` and `VOLUME`.  If the command does not
+    * appear in the Dockerfile, `(Seq.empty)` is returned.
+    *
+    * @param c Dockerfile command
+    * @return
+    */
+  private def getAllStringOrArray(c: Command): Seq[Either[String, Seq[String]]] =
+    lines.filter(d => c.toString.equals(d.name)).map(dl => dl.getArgs match {
+      case s: String => Left(s)
+      case m: Map[String @unchecked, String @unchecked] =>
+        Right(m.asInstanceOf[Map[String, String]].toSeq.sortBy(p => Integer.parseInt(p._1)).map(_._2))
+    })
+
+  /**
+    * Return a single map that combines the key/value pair values of '''all'''
+    * occurrences of the Dockerfile command `c`.
+    *
+    * @param c Dockerfile command
+    * @return
+    */
+  private def getAllMap(c: Command): Map[String, String] =
+    lines.filter(d => c.toString.equals(d.name)).flatMap(dl => {
+      dl.getArgs match {
+        case m: Map[String @unchecked, String @unchecked] => m.asInstanceOf[Map[String, String]]
+        case _ => Map.empty[String, String]
+      }
+    }).toMap
 
   private def add(cmd: Command, arg: Any) = {
     val line: DockerfileLine = create(cmd)
@@ -199,4 +302,28 @@ class Dockerfile(val lines: Seq[DockerfileLine]) {
         }
       }
     }
+}
+
+object Dockerfile {
+  /**
+    * Convert an Either of String or Seq[String] to a String.  The Seq[String]
+    * is made to look like a Dockerfile array.
+    *
+    * @param es stringify target
+    * @return
+    */
+  def stringOrArrayToString(es: Either[String, Seq[String]]): String = es match {
+    case Left(s) => s
+    case Right(ss) => "[ \"" + ss.mkString("\", \"") + "\" ]"
+  }
+
+  /**
+    * Convert a sequence of Either[String, Seq[String] ] to a Seq[String] using
+    * stringOrArrayToString.
+    *
+    * @param ess sequence of things to stringify
+    * @return
+    */
+  def seqStringOrArrayToString(ess: Seq[Either[String, Seq[String]]]): Seq[String] =
+    ess map stringOrArrayToString
 }

--- a/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
@@ -46,6 +46,9 @@ class TypeScriptGenerationHelper(indent: String = "    ")
       case "scala.collection.immutable.Set<java.lang.String>" => "string[]" // Nasty
       case `pathExpressionEngineClassName` => "PathExpressionEngine"
       case "class com.atomist.tree.content.text.FormatInfo" => "FormatInfo"
+      case "scala.collection.Seq<java.lang.String>" => "string[]"
+      case "scala.collection.Seq<scala.collection.Seq<java.lang.String>>" => "string[][]"
+      case "scala.collection.immutable.Map<java.lang.String, java.lang.String>" => "any"
       case x => throw new UnsupportedOperationException(s"Unsupported type [$jt]")
     }
   }

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerFileMutableViewTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerFileMutableViewTest.scala
@@ -1,0 +1,135 @@
+package com.atomist.rug.kind.docker
+
+import com.atomist.rug.kind.core.ProjectMutableView
+import com.atomist.source.{EmptyArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+object DockerFileMutableViewTest {
+  val dockerFile =
+    """FROM java:8-jre
+      |MAINTAINER nobody@java.org
+      |WORKDIR /opt/hearts-and-bones
+      |FROM simon.garfunkel.org/central-park:1981
+      |MAINTAINER paul-simon@graceland.com
+      |WORKDIR /opt/graceland
+      |LABEL mississippi-delta="shining like a National guitar" \
+      |      traveling_companion="nine years old"
+      |RUN human trampoline
+      |LABEL following=theRiver
+      |EXPOSE 8080 9090
+      |EXPOSE 8081
+      |ENV GRACELAND Graceland
+      |ENV MEMPHIS=TN \
+      |    IM="going to Graceland"
+      |ADD poor boys
+      |COPY traveling companions
+      |COPY [ "ghosts", "and", "empty", "sockets" ]
+      |ADD [ "pilgrims", "with", "families" ]
+      |ENV WE="are going to Graceland" \
+      |    MEMPHIS=Tennessee
+      |VOLUME /losing /love
+      |VOLUME [ "/like/a/window", "/in/your/heart" ]
+      |HEALTHCHECK --interval=20s --timeout=10s CMD [ "everybody", "sees", "you're" ]
+      |HEALTHCHECK --retries=5 CMD blown apart
+      |RUN [ "falling", "tumbling", "turmoil" ]
+      |CMD [ "I've", "reason", "to", "believe" ]
+      |CMD we all will be received
+      |ENTRYPOINT in Graceland
+      |ENTRYPOINT [ "no", "not", "you", "my", "brother" ]
+      |""".stripMargin
+
+  val df = StringFileArtifact("docker/Dockerfile", dockerFile)
+
+  val as = new SimpleFileBasedArtifactSource("docker-project", Seq(df))
+
+  val pmv = new ProjectMutableView(EmptyArtifactSource(""), as)
+
+  val dfmv = new DockerFileMutableView(df, pmv)
+}
+
+class DockerFileMutableViewTest extends FlatSpec with Matchers {
+
+  import DockerFileMutableViewTest._
+
+  it should "return the right FROM" in {
+    assert(dfmv.getFrom === "simon.garfunkel.org/central-park:1981")
+  }
+
+  it should "return all the exposed ports" in {
+    val expected: java.util.List[Int] = Seq(8080, 9090, 8081).asJava
+    assert(dfmv.getExposedPorts === expected)
+  }
+
+  it should "return the right MAINTAINER" in {
+    assert(dfmv.getMaintainer === "paul-simon@graceland.com")
+  }
+
+  it should "return all the LABELs" in {
+    val expected: Map[String, String] = Map(
+      "mississippi-delta" -> "\"shining like a National guitar\"",
+      "traveling_companion" -> "\"nine years old\"",
+      "following" -> "theRiver"
+    )
+    assert(dfmv.getLabels === expected)
+  }
+
+  it should "return all the RUNs" in {
+    val expected: Seq[String] = Seq(
+      "human trampoline",
+      """[ "falling", "tumbling", "turmoil" ]"""
+    )
+    assert(dfmv.getRuns === expected)
+  }
+
+  it should "return all the COPYs" in {
+    val expected: Seq[Seq[String]] = Seq(
+      Seq("traveling", "companions"),
+      Seq("ghosts", "and", "empty", "sockets")
+    )
+    assert(dfmv.getCopies === expected)
+  }
+
+  it should "return all the ADDs" in {
+    val expected: Seq[Seq[String]] = Seq(
+      Seq("poor", "boys"),
+      Seq("pilgrims", "with", "families")
+    )
+    assert(dfmv.getAdds === expected)
+  }
+
+  it should "return all the environment variables" in {
+    val expected: Map[String, String] = Map(
+      "GRACELAND" -> "Graceland",
+      "IM" -> "\"going to Graceland\"",
+      "WE" -> "\"are going to Graceland\"",
+      "MEMPHIS" -> "Tennessee"
+    )
+    assert(dfmv.getEnvs === expected)
+  }
+
+  it should "return all the VOLUMEs" in {
+    val expected: Seq[Seq[String]] = Seq(
+      Seq("/losing", "/love"),
+      Seq("/like/a/window", "/in/your/heart")
+    )
+    assert(dfmv.getVolumes === expected)
+  }
+
+  it should "return the right WORKDIR" in {
+    assert(dfmv.getWorkdir === "/opt/graceland")
+  }
+
+  it should "return the right ENTRYPOINT" in {
+    assert(dfmv.getEntryPoint === """[ "no", "not", "you", "my", "brother" ]""")
+  }
+
+  it should "return the right CMD" in {
+    assert(dfmv.getCmd === "we all will be received")
+  }
+
+  it should "return the right HEALTHCHECK" in {
+    assert(dfmv.getHealthcheck === "--retries=5 CMD blown apart")
+  }
+}

--- a/src/test/scala/com/atomist/rug/kind/docker/DockerfileTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/docker/DockerfileTest.scala
@@ -4,7 +4,37 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class DockerfileTest extends FlatSpec with Matchers {
 
-  it should "parse new file" in {
+  import Dockerfile._
+
+  "stringOrArrayToString" should "do nothing to a string" in {
+    assert(stringOrArrayToString(Left("Paul Simon")) === "Paul Simon")
+  }
+
+  it should "do handle an empty string" in {
+    assert(stringOrArrayToString(Left("")) === "")
+  }
+
+  it should "do convert a sequence to a Dockerfile string" in {
+    assert(stringOrArrayToString(Right(Seq("Paul Simon", "Graceland", "1986"))) === """[ "Paul Simon", "Graceland", "1986" ]""")
+  }
+
+  "seqStringOrArrayToString" should "stringify a sequence of strings and seq of strings" in {
+    val ess: Seq[Either[String, Seq[String]]] = Seq(
+      Right(Seq("Paul", "Simon")),
+      Left("Graceland"),
+      Left("1986"),
+      Right(Seq("Warner", "Bros."))
+    )
+    val expected: Seq[String] = Seq(
+      """[ "Paul", "Simon" ]""",
+      "Graceland",
+      "1986",
+      """[ "Warner", "Bros." ]"""
+    )
+    assert(seqStringOrArrayToString(ess) === expected)
+  }
+
+  "Dockerfile" should "parse new file" in {
     val df = new Dockerfile
     df.addOrUpdateFrom("java:8-jre")
       .addMaintainer("cd@atomist.com")
@@ -61,7 +91,7 @@ class DockerfileTest extends FlatSpec with Matchers {
       |EXPOSE 8080""".stripMargin
 
     val df = DockerfileParser.parse(initialFile)
-    val ports = df.getExposePorts()
+    val ports = df.getExposePorts
     ports should equal(Set(8080))
   }
 
@@ -72,7 +102,7 @@ class DockerfileTest extends FlatSpec with Matchers {
         |EXPOSE  8080  """.stripMargin
 
     val df = DockerfileParser.parse(initialFile)
-    val ports = df.getExposePorts()
+    val ports = df.getExposePorts
     ports should equal(Set(8080))
   }
 
@@ -83,7 +113,7 @@ class DockerfileTest extends FlatSpec with Matchers {
         |EXPOSE 8080 9090""".stripMargin
 
     val df = DockerfileParser.parse(initialFile)
-    val ports = df.getExposePorts()
+    val ports = df.getExposePorts
     ports should equal(Set(8080, 9090))
   }
 
@@ -94,7 +124,7 @@ class DockerfileTest extends FlatSpec with Matchers {
         |EXPOSE 8080    9090  """.stripMargin
 
     val df = DockerfileParser.parse(initialFile)
-    val ports = df.getExposePorts()
+    val ports = df.getExposePorts
     ports should equal(Set(8080, 9090))
   }
 
@@ -106,7 +136,714 @@ class DockerfileTest extends FlatSpec with Matchers {
         |EXPOSE 9090""".stripMargin
 
     val df = DockerfileParser.parse(initialFile)
-    val ports = df.getExposePorts()
+    val ports = df.getExposePorts
     ports should equal(Set(8080, 9090))
+  }
+
+  it should "return the value of FROM" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER cd@atomist.com
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getFrom === Some("java:8-jre"))
+  }
+
+  it should "return the value of a complicated FROM" in {
+    val initialFile: String =
+      """FROM docker-registry.tool.com/undertow/sober:3
+        |MAINTAINER cd@atomist.com
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getFrom === Some("docker-registry.tool.com/undertow/sober:3"))
+  }
+
+  it should "return the value of a FROM with crazy whitespace" in {
+    val theFinalFrontier = "  	  "
+    val initialFile: String =
+      s"""FROM${theFinalFrontier}docker-registry.tool.com/undertow/sober:3$theFinalFrontier
+         |MAINTAINER cd@atomist.com
+         |EXPOSE 8080
+         |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getFrom === Some("docker-registry.tool.com/undertow/sober:3"))
+  }
+
+  it should "return the none if no FROM" in {
+    val initialFile: String =
+      """MAINTAINER cd@atomist.com
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getFrom === None)
+  }
+
+  it should "return the value of MAINTAINER" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getMaintainer === Some("paul-simon@graceland.com"))
+  }
+
+  it should "return the none if no MAINTAINER" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getMaintainer === None)
+  }
+
+  it should "return a None if no LABELs" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map())
+  }
+
+  it should "return a single LABEL" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map("mississippi-delta" -> """"shining like a National guitar""""))
+  }
+
+  it should "return a simple LABEL" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta=shining
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map("mississippi-delta" -> "shining"))
+  }
+
+  it should "return multiple LABELs" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar" traveling_companion="nine years old"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map("mississippi-delta" -> """"shining like a National guitar"""",
+      "traveling_companion" -> """"nine years old""""))
+  }
+
+  it should "return LABELs across line breaks" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar" \
+        |      traveling_companion="nine years old"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map("mississippi-delta" -> """"shining like a National guitar"""",
+      "traveling_companion" -> """"nine years old""""))
+  }
+
+  it should "return labels from multiple LABEL statements" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |LABEL traveling_companion="nine years old"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map("mississippi-delta" -> """"shining like a National guitar"""",
+      "traveling_companion" -> """"nine years old""""))
+  }
+
+  it should "return the value of the last LABEL" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a Mule guitar"
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getLabels === Map("mississippi-delta" -> """"shining like a National guitar""""))
+  }
+
+  it should "return an empty seq when there is no CMD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCmd === Right(Seq()))
+  }
+
+  it should "return the string value of CMD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCmd === Left("simple string cmd argument"))
+  }
+
+  it should "return the string value of CMD across two lines" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument \
+        |    that spans two lines
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    // unfortunate the parser does not retain formatting.
+    assert(df.getCmd === Left("simple string cmd argument     that spans two lines"))
+  }
+
+  it should "return the array value of CMD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCmd === Right(Seq("array", "of", "strings", "cmd", "argument")))
+  }
+
+  it should "return the very long array value of CMD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD [ "array", "of", "strings", "cmd", "argument", "that", "is", "long", "enough", "to", "make", "sure", "sorting", "is", "not", "using", "strings" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCmd === Right(Seq("array", "of", "strings", "cmd", "argument", "that", "is", "long", "enough", "to", "make", "sure", "sorting", "is", "not", "using", "strings")))
+  }
+
+  it should "return an empty seq when there is no ENTRYPOINT" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEntryPoint === Right(Seq()))
+  }
+
+  it should "return the string value of ENTRYPOINT" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |ENTRYPOINT simple string entry point argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEntryPoint === Left("simple string entry point argument"))
+  }
+
+  it should "return the array value of ENTRYPOINT" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEntryPoint === Right(Seq("array", "of", "strings", "entry", "point", "argument")))
+  }
+
+  it should "return the value of none HEALTHCHECK" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |HEALTHCHECK NONE
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getHealthCheck === Some("NONE"))
+  }
+
+  it should "return the value of simple HEALTHCHECK" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |HEALTHCHECK CMD run this
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getHealthCheck === Some("CMD run this"))
+  }
+
+  it should "return the value of HEALTHCHECK with options" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |HEALTHCHECK --interval=20s --timeout=10s CMD run this
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getHealthCheck === Some("--interval=20s --timeout=10s CMD run this"))
+  }
+
+  it should "return the value of HEALTHCHECK with command array" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |HEALTHCHECK --interval=5s CMD [ "run", "this" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getHealthCheck === Some("""--interval=5s CMD [ "run", "this" ]"""))
+  }
+
+  it should "return the none if no HEALTHCHECK" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getHealthCheck === None)
+  }
+
+  it should "return an empty seq when there is no RUN" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getRuns === Seq())
+  }
+
+  it should "return the string value of RUN" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |ENTRYPOINT simple string entry point argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getRuns === Seq(Left("human trampoline")))
+  }
+
+  it should "return the array value of RUN" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getRuns === Seq(Right(Seq("falling", "tumbling", "turmoil"))))
+  }
+
+  it should "return the all the right values of RUN" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getRuns === Seq(Left("human trampoline"), Right(Seq("falling", "tumbling", "turmoil"))))
+  }
+
+  it should "return an empty seq when there is no COPY" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCopies === Seq())
+  }
+
+  it should "return the string value of COPY" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |COPY traveling companions
+        |CMD simple string cmd argument
+        |ENTRYPOINT simple string entry point argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCopies === Seq(Seq("traveling", "companions")))
+  }
+
+  it should "return the array value of COPY" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |COPY [ "ghosts", "and", "empty", "sockets" ]
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCopies === Seq(Seq("ghosts", "and", "empty", "sockets")))
+  }
+
+  it should "return the all the right values of COPY" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |COPY traveling companions
+        |COPY [ "ghosts", "and", "empty", "sockets" ]
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getCopies === Seq(Seq("traveling", "companions"), Seq("ghosts", "and", "empty", "sockets")))
+  }
+
+  it should "return an empty seq when there is no ADD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getAdds === Seq())
+  }
+
+  it should "return the string value of ADD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |COPY traveling companions
+        |ADD poor boys
+        |CMD simple string cmd argument
+        |ENTRYPOINT simple string entry point argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getAdds === Seq(Seq("poor", "boys")))
+  }
+
+  it should "return the array value of ADD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |ADD [ "pilgrims", "with", "families" ]
+        |COPY [ "ghosts", "and", "empty", "sockets" ]
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getAdds === Seq(Seq("pilgrims", "with", "families")))
+  }
+
+  it should "return the all the right values of ADD" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |ADD poor boys
+        |COPY traveling companions
+        |COPY [ "ghosts", "and", "empty", "sockets" ]
+        |ADD [ "pilgrims", "with", "families" ]
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getAdds === Seq(Seq("poor", "boys"), Seq("pilgrims", "with", "families")))
+  }
+
+  it should "return an empty seq when there is no VOLUME" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |CMD simple string cmd argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getVolumes === Seq())
+  }
+
+  it should "return the string value of VOLUME" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |VOLUME /losing /love
+        |COPY traveling companions
+        |ADD poor boys
+        |CMD simple string cmd argument
+        |ENTRYPOINT simple string entry point argument
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getVolumes === Seq(Seq("/losing", "/love")))
+  }
+
+  it should "return the array value of VOLUME" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |ADD [ "pilgrims", "with", "families" ]
+        |COPY [ "ghosts", "and", "empty", "sockets" ]
+        |VOLUME [ "/like/a/window", "/in/your/heart" ]
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getVolumes === Seq(Seq("/like/a/window", "/in/your/heart")))
+  }
+
+  it should "return the all the right values of VOLUME" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |RUN human trampoline
+        |EXPOSE 8080
+        |ADD poor boys
+        |COPY traveling companions
+        |COPY [ "ghosts", "and", "empty", "sockets" ]
+        |ADD [ "pilgrims", "with", "families" ]
+        |VOLUME [ "/like/a/window", "/in/your/heart" ]
+        |VOLUME /losing /love
+        |RUN [ "falling", "tumbling", "turmoil" ]
+        |CMD [ "array", "of", "strings", "cmd", "argument" ]
+        |ENTRYPOINT [ "array", "of", "strings", "entry", "point", "argument" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getVolumes === Seq(Seq("/like/a/window", "/in/your/heart"), Seq("/losing", "/love")))
+  }
+
+  it should "return the value of simple WORKDIR" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |WORKDIR /opt/graceland
+        |EXPOSE 8080
+        |HEALTHCHECK CMD run this
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getWorkdir === Some("/opt/graceland"))
+  }
+
+  it should "return the value of the last WORKDIR" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |WORKDIR /opt/hearts-and-bones
+        |WORKDIR /opt/graceland
+        |EXPOSE 8080
+        |HEALTHCHECK --interval=5s CMD [ "run", "this" ]
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getWorkdir === Some("/opt/graceland"))
+  }
+
+  it should "return the none if no WORKDIR" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getWorkdir === None)
+  }
+
+  it should "return a None if no ENVs" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map())
+  }
+
+  it should "return a single ENV" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar"
+        |EXPOSE 8080
+        |ENV MEMPHIS TN
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map("MEMPHIS" -> "TN"))
+  }
+
+  it should "return a simple ENV" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta=shining
+        |EXPOSE 8080
+        |ENV MEMPHIS=TN
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map("MEMPHIS" -> "TN"))
+  }
+
+  it should "return multiple ENVs" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar" traveling_companion="nine years old"
+        |EXPOSE 8080
+        |ENV MEMPHIS=TN GRACELAND=GRACELAND
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map("MEMPHIS" -> "TN", "GRACELAND" -> "GRACELAND"))
+  }
+
+  it should "return ENVs across line breaks" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |LABEL mississippi-delta="shining like a National guitar" \
+        |      traveling_companion="nine years old"
+        |EXPOSE 8080
+        |ENV MEMPHIS=TN \
+        |    WE="are going to Graceland"
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map("MEMPHIS" -> "TN", "WE" -> """"are going to Graceland""""))
+  }
+
+  it should "return variables from multiple ENV statements" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |ENV MEMPHIS=TN
+        |ENV WE="are going to Graceland"
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map("MEMPHIS" -> "TN", "WE" -> """"are going to Graceland""""))
+  }
+
+  it should "return the value of the last ENV" in {
+    val initialFile: String =
+      """FROM java:8-jre
+        |MAINTAINER paul-simon@graceland.com
+        |ENV MEMPHIS=EGYPT
+        |ENV MEMPHIS=TN
+        |EXPOSE 8080
+        |""".stripMargin
+
+    val df = DockerfileParser.parse(initialFile)
+    assert(df.getEnvs === Map("MEMPHIS" -> "TN"))
   }
 }


### PR DESCRIPTION
First question, should this be merged in or should we break the Dockerfile extension out into its own repo?

Implement getters for the various Dockerfile instructions.  Since many
can return strings or arrays and some instructions can be legitimately
used more than once, the typefoolery is a bit much.

It seems no other mutable view operators have returned Maps, Seqs of
Seqs of Strings, or Seqs of Strings (although List of Strings was
accounted for), so those mappings were added to the
javaTypeToTypeScriptType match.

Closes #315