### PR TITLE
Better handling of Plan execution results.

### DIFF
--- a/src/main/scala/com/atomist/rug/runtime/execution/PlanExecutor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/execution/PlanExecutor.scala
@@ -1,8 +1,10 @@
 package com.atomist.rug.runtime.execution
 
 import com.atomist.rug.spi.Handlers
-import com.atomist.rug.spi.Handlers.PlanResponse
+import com.atomist.rug.spi.Handlers.PlanResult
+
+import scala.concurrent.Future
 
 trait PlanExecutor {
-  def execute(plan: Handlers.Plan, callbackInput: AnyRef): PlanResponse
+  def execute(plan: Handlers.Plan, callbackInput: AnyRef): Future[PlanResult]
 }

--- a/src/main/scala/com/atomist/rug/spi/JavaHandlers.scala
+++ b/src/main/scala/com/atomist/rug/spi/JavaHandlers.scala
@@ -2,8 +2,7 @@ package com.atomist.rug.spi
 
 import com.atomist.param.ParameterValue
 import com.atomist.rug.spi.Handlers.MessageBody
-
-import java.util.{List =>JList}
+import java.util.{List => JList}
 
 /**
   * Beans that map to the @atomist/rug/operations/operations/Handlers


### PR DESCRIPTION
Nothing changes here with the way that the plan executes, just what is returned.
Previously there was a poor attempt at keeping up with plan execution errors and instruction responses by storing them in Maps. There were several problems with this approach. The keys were not guaranteed to be unique which would allow data to be overwritten. Also, instruction executions can be done in parallel and might step on each other when updating the Maps.
A better way is to just keep a growing Seq of interesting events during the plan, and combine the events from the different futures.
Additionally, a PlanResult now keeps references to nested plan executions as Futures.