### PR TITLE
Parse Rug C-style comments properly

### DIFF
--- a/src/main/scala/com/atomist/util/scalaparsing/CommonTypesParser.scala
+++ b/src/main/scala/com/atomist/util/scalaparsing/CommonTypesParser.scala
@@ -24,7 +24,7 @@ import scala.util.parsing.input.{CharSequenceReader, OffsetPosition, Positional}
   */
 abstract class CommonTypesParser extends JavaTokenParsers with LazyLogging {
 
-  val CComment = """/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/"""
+  val CComment = """/\*[\S\s]*?\*/"""
 
   val HashLineComment = """\#.*[\n|\r\n]"""
 


### PR DESCRIPTION
The previous regex was provoking a stackoverflow on a JVM 32 bits.
The regex proposed by @ddgenome does do the trick without
breaking existing Rugs as far the tests tell us.

Closes #337.