### PR TITLE
Print event logs

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -69,3 +69,18 @@ editor:
   parameters:
     - "class_under_test": "com.atomist.tree.content.text.OverwriteableTextTreeNode"
 
+---
+kind: "operation"
+client: "rug-cli 0.23.1-SNAPSHOT"
+editor:
+  name: "jessitron.microlib-TreeNodePrinter.BringIn"
+  group: "jessitron"
+  artifact: "microlib-TreeNodePrinter"
+  version: "0.1.0"
+  origin:
+    repo: "n/a"
+    branch: "n/a"
+    sha: "n/a"
+  parameters:
+    - "package": "com.atomist.rug.tree.utils"
+

--- a/src/main/scala/com/atomist/rug/spi/HandlerUtil.scala
+++ b/src/main/scala/com/atomist/rug/spi/HandlerUtil.scala
@@ -1,0 +1,88 @@
+package com.atomist.rug.spi
+
+import Handlers._
+import Instruction._
+import com.atomist.rug.tree.utils.TreeNodePrinter
+import com.atomist.rug.tree.utils.TreeNodePrinter.BabyTree
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+object HandlerUtil {
+
+  import com.atomist.rug.spi.Handlers._
+
+  private def instructionToString(i: Instruction) = {
+    val op = i match {
+      case Generate(detail) => "Generate"
+      case Edit(detail) => "Edit"
+      case Review(detail) => "Review"
+      case Execute(detail) => "Execute"
+      case Command(detail) => "Command"
+      case Respond(detail) => "Respond"
+    }
+    s"${op} ${i.detail.name} ${i.detail.coordinates} ${i.detail.parameters}"
+  }
+
+  private def messageToTree(m: Message) = {
+    val messageString = s"Message: ${m.body}${m.channelId.map(" to " + _).getOrElse("")}, like ${m.instructions}"
+    BabyTree(messageString)
+  }
+  private def callbackToTree(name: String, c: Callback): BabyTree = BabyTree(name, Seq(c match {
+    case p: Plan => planToTree(p)
+    case m: Message => messageToTree(m)
+    case r: Respond => BabyTree(instructionToString(r))
+  }))
+
+  def planToTree(plan: Plan): BabyTree = {
+
+
+
+    def respondableToTree(respondable: Respondable): BabyTree = {
+      val i = instructionToString(respondable.instruction)
+
+      val onSuccessChild = respondable.onSuccess.map(callbackToTree("onSuccess", _))
+      val onFailureChild = respondable.onFailure.map(callbackToTree("onFailure", _))
+
+      BabyTree(i, onSuccessChild.toSeq ++ onFailureChild)
+    }
+
+    BabyTree("Plan",
+      plan.instructions.sortBy(_.toString).map(respondableToTree) ++
+        plan.messages.sortBy(_.toString).map(messageToTree))
+  }
+
+  def printPlan(plan: Plan): String = {
+    val tree: BabyTree = planToTree(plan)
+    TreeNodePrinter.draw[BabyTree](_.children, _.print)(tree)
+  }
+
+  private def awaitAndTreeLogEvents(name: String, events: Seq[PlanLogEvent]): BabyTree = {
+    def logEventToTree(one: PlanLogEvent): BabyTree = {
+      def nullSafeMessage(x: Throwable) = s"Error: ${Option(x).map(_.getMessage).getOrElse("null exception")}"
+
+      one match {
+        case InstructionError(i, x) => BabyTree(nullSafeMessage(x), Seq(BabyTree(instructionToString(i))))
+        case MessageDeliveryError(m, x) => BabyTree(nullSafeMessage(x), Seq(messageToTree(m)))
+        case CallbackError(c, x) => BabyTree(nullSafeMessage(x), Seq(callbackToTree("failed callback", c)))
+        case InstructionResponse(instruction, response) =>
+          BabyTree(s"Received $response back from ${instructionToString(instruction)}")
+        case NestedPlanRun(plan, planResult) =>
+          Await.ready(planResult, 10.seconds)
+          val result = planResult.value.get match {
+            case Failure(exception) => BabyTree(s"Future failed with ${exception.getMessage}")
+            case Success(value) => awaitAndTreeLogEvents(s"Future completed", value.log)
+          }
+          val planChild = planToTree(plan)
+          BabyTree("Nested plan run", Seq(planChild, result))
+      }
+    }
+
+    val children = events.map(logEventToTree)
+    BabyTree(name, children.sortBy(_.print))
+  }
+
+  def drawEventLogs(name: String, events: Seq[PlanLogEvent]) =
+    TreeNodePrinter.drawTree(awaitAndTreeLogEvents(name, events))
+}

--- a/src/main/scala/com/atomist/rug/spi/HandlerUtil.scala
+++ b/src/main/scala/com/atomist/rug/spi/HandlerUtil.scala
@@ -13,6 +13,14 @@ object HandlerUtil {
 
   import com.atomist.rug.spi.Handlers._
 
+  def drawPlan(plan: Plan): String = {
+    val tree: BabyTree = planToTree(plan)
+    TreeNodePrinter.draw[BabyTree](_.children, _.print)(tree)
+  }
+
+  def drawEventLogs(name: String, events: Seq[PlanLogEvent]) =
+    TreeNodePrinter.drawTree(awaitAndTreeLogEvents(name, events))
+
   private def instructionToString(i: Instruction) = {
     val op = i match {
       case Generate(detail) => "Generate"
@@ -35,9 +43,7 @@ object HandlerUtil {
     case r: Respond => BabyTree(instructionToString(r))
   }))
 
-  def planToTree(plan: Plan): BabyTree = {
-
-
+  private def planToTree(plan: Plan): BabyTree = {
 
     def respondableToTree(respondable: Respondable): BabyTree = {
       val i = instructionToString(respondable.instruction)
@@ -53,10 +59,6 @@ object HandlerUtil {
         plan.messages.sortBy(_.toString).map(messageToTree))
   }
 
-  def printPlan(plan: Plan): String = {
-    val tree: BabyTree = planToTree(plan)
-    TreeNodePrinter.draw[BabyTree](_.children, _.print)(tree)
-  }
 
   private def awaitAndTreeLogEvents(name: String, events: Seq[PlanLogEvent]): BabyTree = {
     def logEventToTree(one: PlanLogEvent): BabyTree = {
@@ -83,6 +85,4 @@ object HandlerUtil {
     BabyTree(name, children.sortBy(_.print))
   }
 
-  def drawEventLogs(name: String, events: Seq[PlanLogEvent]) =
-    TreeNodePrinter.drawTree(awaitAndTreeLogEvents(name, events))
 }

--- a/src/main/scala/com/atomist/rug/tree/utils/TreeNodePrinter.scala
+++ b/src/main/scala/com/atomist/rug/tree/utils/TreeNodePrinter.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.tree.utils
 
 object TreeNodePrinter {
 
-  case class BabyTree(print: String, children: Seq[BabyTree])
+  case class BabyTree(print: String, children: Seq[BabyTree] = Seq())
 
   def drawTree(baby: BabyTree) = draw[BabyTree](_.children, _.print)(baby)
 

--- a/src/main/scala/com/atomist/rug/tree/utils/TreeNodePrinter.scala
+++ b/src/main/scala/com/atomist/rug/tree/utils/TreeNodePrinter.scala
@@ -1,0 +1,73 @@
+package com.atomist.rug.tree.utils
+
+object TreeNodePrinter {
+
+  /**
+   * TreeNodePrinter utility.
+   * It draws a cute tree like
+   *
+
+Grandma
+├─┬ Dad
+| ├── Sister
+| └─┬ Me
+|   ├── Daughter
+|   └── Son
+└── Aunt
+
+   *
+   * To use it, pass two functions:
+   * @param children how to access child nodes
+   * @param info how to print a node
+   *
+   * @param topOfTree and then the top-level node!
+   *
+   * @return String. Print it yourself
+   */
+  def draw[T](children: T => Seq[T], info: T => String)(topOfTree: T): String = {
+
+    def drawInternal(tn: T): Seq[String] = {
+      tn match {
+        case leaf if children(leaf).isEmpty => Seq(info(leaf))
+        case parent => info(parent) +: printChildren(children(parent))
+      }
+    }
+
+    def printChildren(ch: Seq[T]): Seq[String] = {
+      val last = ch.last
+      val notLast = ch.slice(0, ch.length - 1)
+
+      val lastLine = prefixChildLines(children(last).nonEmpty, last = true, drawInternal(last))
+      val earlierLines = notLast.flatMap(tn => prefixChildLines(children(tn).nonEmpty, last = false, drawInternal(tn)))
+
+      earlierLines ++ lastLine
+    }
+
+    drawInternal(topOfTree).mkString("\n")
+  }
+
+  private def prefixChildLines(hasChildren: Boolean, last: Boolean, childLines: Seq[String]): Seq[String] =
+    childLines.toList match {
+      case head :: rest =>
+        val connector = if (last) FILLER else TREE_CONNECTOR
+        val firstLine = firstLineOfChildPrefix(hasChildren, last) + head
+        val restLines = rest.map(connector + _)
+        firstLine +: restLines
+      case _ => throw new RuntimeException("empty list")
+    }
+
+  private def firstLineOfChildPrefix(hasChildren: Boolean, last: Boolean): String =
+    if (hasChildren && last) LAST_TREE_NODE_WITH_CHILDREN
+    else if (hasChildren && !last) TREE_NODE_WITH_CHILDREN
+    else if (!hasChildren && last) LAST_TREE_NODE
+    else if (!hasChildren && !last) TREE_NODE
+    else "the impossible has happened"
+
+  // this won't be pretty on Windows
+  val LAST_TREE_NODE: String = "└── "
+  val LAST_TREE_NODE_WITH_CHILDREN = "└─┬ "
+  val TREE_NODE: String = "├── "
+  val TREE_NODE_WITH_CHILDREN: String = "├─┬ "
+  val TREE_CONNECTOR: String = "| "
+  val FILLER: String = "  "
+}

--- a/src/main/scala/com/atomist/rug/tree/utils/TreeNodePrinter.scala
+++ b/src/main/scala/com/atomist/rug/tree/utils/TreeNodePrinter.scala
@@ -2,6 +2,10 @@ package com.atomist.rug.tree.utils
 
 object TreeNodePrinter {
 
+  case class BabyTree(print: String, children: Seq[BabyTree])
+
+  def drawTree(baby: BabyTree) = draw[BabyTree](_.children, _.print)(baby)
+
   /**
    * TreeNodePrinter utility.
    * It draws a cute tree like

--- a/src/test/scala/com/atomist/rug/runtime/plans/LocalPlanRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/LocalPlanRunnerTest.scala
@@ -1,5 +1,6 @@
 package com.atomist.rug.runtime.plans
 
+import com.atomist.rug.spi.HandlerUtil
 import com.atomist.rug.spi.Handlers.Instruction._
 import com.atomist.rug.spi.Handlers.Status._
 import com.atomist.rug.spi.Handlers._
@@ -16,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class LocalPlanRunnerTest extends FunSpec with Matchers with DiagrammedAssertions with OneInstancePerTest with MockitoSugar  {
+class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest with MockitoSugar  {
 
   val messageDeliverer = mock[MessageDeliverer]
   val instructionRunner = mock[InstructionRunner]
@@ -149,13 +150,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with DiagrammedAssertion
     verifyNoMoreInteractions(messageDeliverer, instructionRunner, nestedPlanRunner, logger)
   }
 
-  val makeEventsComparable = (log: Iterable[PlanLogEvent]) => log.map {
-    case InstructionResponse(i, r) => (i, r)
-    case NestedPlanRun(p, f) => (p, f.value.get)
-    case InstructionError(i, e) => (i, e.getMessage)
-    case MessageDeliveryError(m, e) => (m, e.getMessage)
-    case CallbackError(c, e) => (c, e.getMessage)
-  }
+  val makeEventsComparable = (log: Iterable[PlanLogEvent]) => HandlerUtil.drawEventLogs("events", log.toSeq)
 
   it ("should handle error during message delivery") {
     val plan = Plan(

--- a/src/test/scala/com/atomist/rug/tree/utils/TreeNodePrinterTest.scala
+++ b/src/test/scala/com/atomist/rug/tree/utils/TreeNodePrinterTest.scala
@@ -1,0 +1,34 @@
+package com.atomist.rug.tree.utils
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TreeNodePrinterTest extends FlatSpec with Matchers {
+
+  case class TreeNode(print: String, children: Seq[TreeNode] = Seq())
+
+  val drawTree: TreeNode => String = TreeNodePrinter.draw[TreeNode](_.children, _.print)
+
+  it should "conform to the example" in {
+    val expected = """Grandma
+├─┬ Dad
+| ├── Sister
+| └─┬ Me
+|   ├── Daughter
+|   └── Son
+└── Aunt"""
+
+    val input =
+      TreeNode("Grandma",Seq(
+        TreeNode("Dad",Seq(
+            TreeNode("Sister"),
+            TreeNode("Me",Seq(
+              TreeNode("Daughter"),
+              TreeNode("Son"))))),
+        TreeNode("Aunt")))
+
+    val output = drawTree(input)
+
+    output should be(expected)
+
+  }
+}


### PR DESCRIPTION
Add a utility for printing Plans and PlanEventLogs

```
Plan
├── Edit edit1 None List()
├─┬ Edit edit2 None List()
| ├─┬ onSuccess
| | └── Message: MessageText(pass), like List()
| └─┬ onFailure
|   └── Message: MessageText(fail), like List()
├─┬ Edit edit3 None List()
| └─┬ onSuccess
|   └── Respond respond1 None List()
├─┬ Edit edit4 None List()
| └─┬ onSuccess
|   └─┬ Plan
|     └── Message: MessageText(nested plan), like List()
└── Message: MessageText(message1), like List(Presentable(Generate(Detail(generate1,None,List())),Some(label1)))
```

Then use this for comparison in the test; string diffs become tree diffs when the assertion fails.