### PR TITLE
Cache serviceloader results keyed by ClassLoader

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/ServiceLoaderTypeRegistry.scala
+++ b/src/main/scala/com/atomist/rug/kind/ServiceLoaderTypeRegistry.scala
@@ -1,11 +1,11 @@
 package com.atomist.rug.kind
 
-import _root_.java.util.ServiceLoader
-
 import com.atomist.rug.RugRuntimeException
 import com.atomist.rug.spi._
 import com.typesafe.scalalogging.LazyLogging
+import _root_.java.util.ServiceLoader
 
+import _root_.scala.collection.mutable.WeakHashMap
 import _root_.scala.collection.JavaConverters._
 
 /**
@@ -19,17 +19,27 @@ class ServiceLoaderTypeRegistry
   extends TypeRegistry
     with LazyLogging {
 
-  private lazy val typesMap: Map[String, Typed] = {
-    ServiceLoader.load(classOf[Typed]).asScala.map {
-      case t: Typed =>
-        logger.info(s"Registered type extension '${t.name}, with class ${t.getClass},description=${t.description}")
-        val st = t
-        logger.debug(s"Found operations: ${st.allOperations.map(_.name).mkString(",")}")
-        t.name -> t
-      case wtf =>
-        throw new RugRuntimeException("ExtensionType", s"Type class ${wtf.getClass} must implement Typed interface", null)
+  // Sharing Rug in a hierarchy of CLassLoaders requires the ServiceLoader to be triggered
+  // for each ClassLoader; using WeakHashMap so ClassLoader references can be garbage collected
+  private val typesMapByClassLoader = WeakHashMap[ClassLoader, Map[String, Typed]]()
+
+  private def typesMap: Map[String, Typed] = {
+    typesMapByClassLoader.get(Thread.currentThread().getContextClassLoader) match {
+      case Some(tm) => tm
+      case _ =>
+        val typesMap: Map[String, Typed] = ServiceLoader.load(classOf[Typed]).asScala.map {
+          case t: Typed =>
+            logger.info(s"Registered type extension '${t.name}, with class ${t.getClass},description=${t.description}")
+            val st = t
+            logger.debug(s"Found operations: ${st.allOperations.map(_.name).mkString(",")}")
+            t.name -> t
+          case wtf =>
+            throw new RugRuntimeException("ExtensionType", s"Type class ${wtf.getClass} must implement Typed interface", null)
+        }.toMap
+        typesMapByClassLoader += Thread.currentThread().getContextClassLoader -> typesMap
+        typesMap
     }
-  }.toMap
+  }
 
   override def findByName(kind: String): Option[Typed] = typesMap.get(kind)
 

--- a/src/main/scala/com/atomist/rug/runtime/plans/ServiceLoaderRugFunctionRegistry.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/ServiceLoaderRugFunctionRegistry.scala
@@ -1,42 +1,16 @@
 package com.atomist.rug.runtime.plans
 
-import java.util.ServiceLoader
-
-import com.atomist.rug.RugRuntimeException
-import com.atomist.rug.spi.{RugFunction, RugFunctionRegistry, Typed}
-import com.typesafe.scalalogging.LazyLogging
-
-import _root_.scala.collection.mutable.WeakHashMap
-import scala.collection.JavaConverters._
+import com.atomist.rug.spi.{RugFunction, RugFunctionRegistry}
+import com.atomist.util.ServiceLoaderBackedExtensionProvider
 
 /**
   * Use ServiceLoader to load RugFunction in to a registry
   */
-class ServiceLoaderRugFunctionRegistry
-  extends RugFunctionRegistry
-    with LazyLogging {
-
-  // Sharing Rug in a hierarchy of CLassLoaders requires the ServiceLoader to be triggered
-  // for each ClassLoader; using WeakHashMap so ClassLoader references can be garbage collected
-  private val functionsByClassLoader = WeakHashMap[ClassLoader, Map[String, RugFunction]]()
-
-  private def functionsMap: Map[String, RugFunction] = {
-    functionsByClassLoader.get(Thread.currentThread().getContextClassLoader) match {
-      case Some(tm) => tm
-      case _ =>
-        val functionssMap: Map[String, RugFunction] = ServiceLoader.load(classOf[RugFunction]).asScala.map {
-          case t: RugFunction =>
-            logger.info(s"Registered rug function '${t.name}, with class ${t.getClass},description=${t.description}")
-            t.name -> t
-          case wtf =>
-            throw new RugRuntimeException("RugFunction", s"RugFunction class ${wtf.getClass} must implement RugFunction interface", null)
-        }.toMap
-        functionsByClassLoader += Thread.currentThread().getContextClassLoader -> functionssMap
-        functionssMap
-    }
-  }
+class ServiceLoaderRugFunctionRegistry(keyProvider: (RugFunction) => String = (r) => r.name)
+  extends ServiceLoaderBackedExtensionProvider[RugFunction] (keyProvider)
+    with RugFunctionRegistry {
 
   override def find(name: String): Option[RugFunction] = {
-    functionsMap.get(name)
+    providerMap.get(name)
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/plans/ServiceLoaderRugFunctionRegistry.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/ServiceLoaderRugFunctionRegistry.scala
@@ -2,28 +2,41 @@ package com.atomist.rug.runtime.plans
 
 import java.util.ServiceLoader
 
-import com.atomist.rug.spi.{RugFunction, RugFunctionRegistry}
+import com.atomist.rug.RugRuntimeException
+import com.atomist.rug.spi.{RugFunction, RugFunctionRegistry, Typed}
 import com.typesafe.scalalogging.LazyLogging
 
+import _root_.scala.collection.mutable.WeakHashMap
 import scala.collection.JavaConverters._
 
 /**
   * Use ServiceLoader to load RugFunction in to a registry
   */
 class ServiceLoaderRugFunctionRegistry
-  extends RugFunctionRegistry with LazyLogging {
+  extends RugFunctionRegistry
+    with LazyLogging {
 
-  private lazy val functions: Map[String, RugFunction] = {
-    try{
-      ServiceLoader.load(classOf[RugFunction]).asScala.map(r => (r.name, r)).toMap
-    }catch {
-      case x: Throwable =>
-        x.printStackTrace()
-        Map()
+  // Sharing Rug in a hierarchy of CLassLoaders requires the ServiceLoader to be triggered
+  // for each ClassLoader; using WeakHashMap so ClassLoader references can be garbage collected
+  private val functionsByClassLoader = WeakHashMap[ClassLoader, Map[String, RugFunction]]()
+
+  private def functionsMap: Map[String, RugFunction] = {
+    functionsByClassLoader.get(Thread.currentThread().getContextClassLoader) match {
+      case Some(tm) => tm
+      case _ =>
+        val functionssMap: Map[String, RugFunction] = ServiceLoader.load(classOf[RugFunction]).asScala.map {
+          case t: Typed =>
+            logger.info(s"Registered rug function '${t.name}, with class ${t.getClass},description=${t.description}")
+            t.name -> t
+          case wtf =>
+            throw new RugRuntimeException("RugFunction", s"RugFunction class ${wtf.getClass} must implement RugFunction interface", null)
+        }.toMap
+        functionsByClassLoader += Thread.currentThread().getContextClassLoader -> functionssMap
+        functionssMap
     }
   }
 
   override def find(name: String): Option[RugFunction] = {
-    functions.get(name)
+    functionsMap.get(name)
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/plans/ServiceLoaderRugFunctionRegistry.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/ServiceLoaderRugFunctionRegistry.scala
@@ -25,7 +25,7 @@ class ServiceLoaderRugFunctionRegistry
       case Some(tm) => tm
       case _ =>
         val functionssMap: Map[String, RugFunction] = ServiceLoader.load(classOf[RugFunction]).asScala.map {
-          case t: Typed =>
+          case t: RugFunction =>
             logger.info(s"Registered rug function '${t.name}, with class ${t.getClass},description=${t.description}")
             t.name -> t
           case wtf =>

--- a/src/main/scala/com/atomist/util/ServiceLoaderBackedExtensionProvider.scala
+++ b/src/main/scala/com/atomist/util/ServiceLoaderBackedExtensionProvider.scala
@@ -1,0 +1,41 @@
+package com.atomist.util
+
+import java.util.ServiceLoader
+
+import com.atomist.rug.RugRuntimeException
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+import scala.reflect._
+
+/**
+  * Provider of instances of type [[T]]. Instances are loaded via JDK [[ServiceLoader]] and cached; keyed by their
+  * respective [[ClassLoader]]s.
+  */
+class ServiceLoaderBackedExtensionProvider[T: ClassTag](val keyProvider: (T) => String)
+  extends LazyLogging {
+
+  // Sharing Rug in a hierarchy of CLassLoaders requires the ServiceLoader to be triggered
+  // for each ClassLoader; using WeakHashMap so ClassLoader references can be garbage collected
+  private val providers = mutable.WeakHashMap[ClassLoader, Map[String, T]]()
+
+  def providerMap: Map[String, T] = {
+    providers.get(Thread.currentThread().getContextClassLoader) match {
+      case Some(tm) => tm
+      case _ =>
+        val providersMap: Map[String, T] = ServiceLoader.load(classTag[T].runtimeClass).asScala.map {
+          case t: T =>
+            val key = keyProvider.apply(t)
+            logger.info(s"Registered provider '${key}' with class '${t.getClass}'")
+            key -> t
+          case wtf =>
+            throw new RugRuntimeException("Extension", s"Provider class ${wtf.getClass} must implement ${classTag[T].runtimeClass.getName} interface", null)
+        }.toMap
+        providers += Thread.currentThread().getContextClassLoader -> providersMap
+        providersMap
+    }
+  }
+
+}


### PR DESCRIPTION
In a shared classloader environment the previous approach using lazy, only loaded Types and RugFunctions for the first archvie/classpath. Now the cache is keyed by ClassLoader with weak reference so the ClassLoader can get collected if possible.