### PR TITLE
JSON serialize complex params in Plans

### DIFF
--- a/src/main/java/com/atomist/rug/runtime/plans/InstructionRunner.java
+++ b/src/main/java/com/atomist/rug/runtime/plans/InstructionRunner.java
@@ -2,6 +2,7 @@ package com.atomist.rug.runtime.plans;
 
 import com.atomist.rug.spi.Handlers.Instruction;
 import com.atomist.rug.spi.Handlers.Response;
+import scala.Option;
 
 public interface InstructionRunner {
 
@@ -12,5 +13,5 @@ public interface InstructionRunner {
      * @param callbackInput if this was a callback, the result of running the instruction, null otherwise
      * @return response from running this instruction
      */
-    Response run(Instruction instruction, Object callbackInput);
+    Response run(Instruction instruction, Option<Response> callbackInput);
 }

--- a/src/main/java/com/atomist/rug/runtime/plans/MessageDeliverer.java
+++ b/src/main/java/com/atomist/rug/runtime/plans/MessageDeliverer.java
@@ -1,6 +1,7 @@
 package com.atomist.rug.runtime.plans;
 
 import com.atomist.rug.spi.Handlers;
+import scala.Option;
 
 public interface MessageDeliverer {
 
@@ -10,5 +11,5 @@ public interface MessageDeliverer {
      * @param message a message to deliver
      * @param callbackInput if this was a callback, the result of executing the instruction, null otherwise
      */
-    void deliver(Handlers.Message message, Object callbackInput);
+    void deliver(Handlers.Message message, Option<Handlers.Response> callbackInput);
 }

--- a/src/main/scala/com/atomist/rug/runtime/InstructionResponse.scala
+++ b/src/main/scala/com/atomist/rug/runtime/InstructionResponse.scala
@@ -1,8 +1,0 @@
-package com.atomist.rug.runtime
-
-import java.io.Serializable
-
-/**
-  * The response from Rug Functions
-  */
-case class InstructionResponse (status: String, code: Int, body: Serializable)

--- a/src/main/scala/com/atomist/rug/runtime/ResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/ResponseHandler.scala
@@ -1,11 +1,11 @@
 package com.atomist.rug.runtime
 
 import com.atomist.param.ParameterValues
-import com.atomist.rug.spi.Handlers.Plan
+import com.atomist.rug.spi.Handlers.{Plan, Response}
 
 /**
   * Handles responses from other Rugs & Executions
   */
 trait ResponseHandler extends ParameterizedRug{
-  def handle(response: InstructionResponse, params: ParameterValues) : Option[Plan]
+  def handle(response: Response, params: ParameterValues) : Option[Plan]
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/JsonSerializer.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JsonSerializer.scala
@@ -1,0 +1,40 @@
+package com.atomist.rug.runtime.js
+
+import java.io.StringWriter
+
+import com.fasterxml.jackson.databind.{ObjectMapper, ObjectWriter, SerializationFeature}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+
+/**
+  * Serialize nashorn objects to Json
+  */
+object JsonSerializer {
+
+  // Configure this to handle Scala
+  private val mapper = new ObjectMapper() with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true)
+
+  private val objectWriter: ObjectWriter = mapper.writer()
+
+  def toJson(ref: Option[AnyRef]): Option[String] = {
+    if(ref.nonEmpty){
+      Some(toJsonInternal(ref.get))
+    }else{
+      None
+    }
+  }
+
+  def toJson(ref: AnyRef): String = {
+   toJsonInternal(ref)
+  }
+
+  private def toJsonInternal(ref: AnyRef): String = {
+    val writer = new StringWriter()
+    objectWriter.writeValue(writer, ref)
+    val str = writer.toString
+    str.substring(22).dropRight(1)
+  }
+}

--- a/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
@@ -116,7 +116,11 @@ class PlanBuilder {
           o.keySet().toArray.toList.map { key =>
             val name = key.asInstanceOf[String]
             val value = o.getMember(name)
-            SimpleParameterValue(name, value)
+            SimpleParameterValue(name,
+              value match {
+                case s: String => s
+                case o => JsonSerializer.toJson(o)
+              })
           }
       }
 
@@ -142,11 +146,11 @@ class PlanBuilder {
     callback match {
       case u: Undefined => None
       case jsOnSuccess: ScriptObjectMirror =>
-        val callback = if (jsOnSuccess.hasMember("text") || jsOnSuccess.hasMember("body")) {
+        val callback = if (jsOnSuccess.hasMember("body")) {
           constructMessage(jsOnSuccess)
         } else if (jsOnSuccess.hasMember("kind")) {
           Respond(constructInstructionDetail(jsOnSuccess))
-        } else if (jsOnSuccess.hasMember("messages")) {
+        } else if (jsOnSuccess.hasMember("messages") || jsOnSuccess.hasMember("instructions")) {
           constructPlan(jsOnSuccess)
         } else {
           throw new InvalidHandlerResultException(s"Cannot create CallBack from: $jsOnSuccess")
@@ -155,3 +159,6 @@ class PlanBuilder {
     }
   }
 }
+
+
+

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanResultInterpreter.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanResultInterpreter.scala
@@ -7,7 +7,10 @@ import scala.annotation.tailrec
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
-class PlanResultInterpreter {
+/**
+  * Utils to example PlanResults
+  */
+object PlanResultInterpreter {
 
   def interpret(planResult: PlanResult): Response = {
     if (hasLogFailure(planResult.log)) {

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanRunner.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanRunner.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.runtime.plans
 
 import com.atomist.rug.spi.Handlers
-import com.atomist.rug.spi.Handlers.PlanResult
+import com.atomist.rug.spi.Handlers.{PlanResult, Response}
 
 import scala.concurrent.Future
 
@@ -9,5 +9,5 @@ import scala.concurrent.Future
   * Run a plan's instructions and send its messages
   */
 trait PlanRunner {
-  def run(plan: Handlers.Plan, callbackInput: AnyRef): Future[PlanResult]
+  def run(plan: Handlers.Plan, callbackInput: Option[Response]): Future[PlanResult]
 }

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
@@ -6,7 +6,7 @@ import com.atomist.project.common.MissingParametersException
 import com.atomist.rug.MissingSecretException
 import com.atomist.rug.runtime.{AddressableRug, CommandHandler, ResponseHandler}
 import com.atomist.rug.runtime.plans._
-import com.atomist.rug.spi.Handlers.{InstructionError, InstructionResult, Plan, Status}
+import com.atomist.rug.spi.Handlers._
 import com.atomist.rug.spi.{Handlers, Secret}
 import com.atomist.rug.ts.TypeScriptBuilder
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
@@ -213,7 +213,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
     val runner = new LocalPlanRunner(null, new LocalInstructionRunner(Seq(new TestResponseHandler(responseHandler)), null, null, new TestSecretResolver(null) {
       override def resolveSecrets(secrets: Seq[Secret]): Seq[ParameterValue] = Nil}))
 
-    val results = Await.result(runner.run(plan, ""), 10.seconds)
+    val results = Await.result(runner.run(plan, None), 10.seconds)
     PlanUtils.drawEventLogs("testplan",results.log)
     results.log.foreach {
       case i: InstructionResult =>
@@ -296,7 +296,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
         Seq(SimpleParameterValue("very", "cool"))
       }
     }))
-    Await.result(runner.run(handlers.head.handle(null, SimpleParameterValues.Empty).get, ""), 10.seconds).log.foreach {
+    Await.result(runner.run(handlers.head.handle(null, SimpleParameterValues.Empty).get, None), 10.seconds).log.foreach {
       case i:
         InstructionResult =>
         assert(i.response.status === Status.Success)
@@ -313,7 +313,7 @@ class TestResponseHandler(r: ResponseHandler) extends AddressableRug with Respon
 
   override def version: String = ???
 
-  override def handle(response: com.atomist.rug.runtime.InstructionResponse, params: ParameterValues): Option[Plan] = {
+  override def handle(response: Response, params: ParameterValues): Option[Plan] = {
     None
   }
 

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -152,7 +152,7 @@ class JavaScriptEventHandlerTest extends FlatSpec with Matchers with DiagrammedA
     val handler = ops.commandHandlers.find(p => p.name == "LicenseAdder").get
     val plan = handler.handle(LocalRugContext(TestTreeMaterializer), SimpleParameterValues(SimpleParameterValue("license","agpl")))
     val runner = new LocalPlanRunner(null, new LocalInstructionRunner(Nil,null,null,null))
-    val response = Await.result(runner.run(plan.get, "blah"),120.seconds)
+    val response = Await.result(runner.run(plan.get, None),120.seconds)
     assert(response.log.size === 1)
     response.log.foreach {
       case error: InstructionError => assert(error.error.getMessage === "Cannot find Rug Function HTTP")

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.runtime.js
 
 import com.atomist.param.{SimpleParameterValue, SimpleParameterValues}
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
-import com.atomist.rug.runtime.InstructionResponse
+import com.atomist.rug.spi.Handlers.{Response, Status}
 import com.atomist.rug.ts.TypeScriptBuilder
 import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.TreeMaterializer
@@ -50,7 +50,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
     handler.name should be(kitties)
     handler.description should be (kittyDesc)
     handler.tags.size should be (2)
-    val response = InstructionResponse("It worked! :p", 204, "woot")
+    val response = Response(Status.Success, Some("It worked! :p"), Some(204), Some("woot"))
     val plan = handler.handle(response, SimpleParameterValues(SimpleParameterValue("name","his dudeness")))
     //TODO validate the plan
   }

--- a/src/test/scala/com/atomist/rug/runtime/plans/ExampleRugFunction.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/ExampleRugFunction.scala
@@ -1,7 +1,6 @@
 package com.atomist.rug.runtime.plans
 
 import com.atomist.param._
-import com.atomist.rug.runtime.InstructionResponse
 import com.atomist.rug.spi.Handlers.{Response, Status}
 import com.atomist.rug.spi.{RugFunction, Secret}
 
@@ -33,7 +32,7 @@ class ExampleRugFunction
     */
   override def run(parameters: ParameterValues): Response = {
     validateParameters(parameters)
-    Response(Status.Success,None, None, Some(InstructionResponse("It worked! :p", 204, parameters.parameterValues.head.getValue.toString)))
+    Response(Status.Success,Some("It worked! :p"), Some(204), Some(parameters.parameterValues.head.getValue.toString))
   }
 
   /**

--- a/src/test/scala/com/atomist/rug/runtime/plans/PlanResultInterpreterTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/PlanResultInterpreterTest.scala
@@ -11,8 +11,6 @@ import scala.concurrent.Future
 
 class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAssertions with OneInstancePerTest  {
 
-  val planResultInterpreter = new PlanResultInterpreter()
-
   val successfulInstructionResult = InstructionResult(Edit(Detail("edit1", None, Nil, None)), Response(Success))
   val failureInstructionResult = InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Failure))
   val errorInstructionResult = InstructionError(Edit(Detail("edit3", None, Nil, None)), new IllegalStateException("doh!"))
@@ -22,7 +20,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
 
   it ("should interpret empty plan result as success") {
     val planResult = PlanResult(Nil)
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Success)
     assert (actualResponse == expectedResponse)
   }
@@ -31,7 +29,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
     val planResult = PlanResult(Seq(
       successfulInstructionResult
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Success)
     assert (actualResponse == expectedResponse)
   }
@@ -40,7 +38,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
     val planResult = PlanResult(Seq(
       failureInstructionResult
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Failure)
     assert (actualResponse == expectedResponse)
   }
@@ -49,7 +47,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
     val planResult = PlanResult(Seq(
       errorInstructionResult
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Failure)
     assert (actualResponse == expectedResponse)
   }
@@ -59,7 +57,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
       successfulInstructionResult,
       failureInstructionResult
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Failure)
     assert (actualResponse == expectedResponse)
   }
@@ -69,7 +67,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
       successfulInstructionResult,
       errorInstructionResult
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Failure)
     assert (actualResponse == expectedResponse)
   }
@@ -79,7 +77,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
       successfulInstructionResult,
       successfulNestedPlan
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Success)
     assert (actualResponse == expectedResponse)
   }
@@ -89,7 +87,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
       successfulInstructionResult,
       failureNestedPlan
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Failure)
     assert (actualResponse == expectedResponse)
   }
@@ -99,7 +97,7 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
       successfulInstructionResult,
       errorNestedPlan
     ))
-    val actualResponse = planResultInterpreter.interpret(planResult)
+    val actualResponse = PlanResultInterpreter.interpret(planResult)
     val expectedResponse = Response(Failure)
     assert (actualResponse == expectedResponse)
   }

--- a/src/test/scala/com/atomist/rug/runtime/plans/RugFunctionRegistryTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/RugFunctionRegistryTest.scala
@@ -2,9 +2,7 @@ package com.atomist.rug.runtime.plans
 
 import com.atomist.param.{SimpleParameterValue, SimpleParameterValues}
 import com.atomist.rug.MissingSecretException
-import com.atomist.rug.runtime.InstructionResponse
-import com.atomist.rug.spi.Handlers.Response
-import com.atomist.rug.spi.Handlers.Status
+import com.atomist.rug.spi.Handlers.{Response, Status}
 import com.atomist.rug.spi.Secret
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -13,9 +11,7 @@ class RugFunctionRegistryTest extends FlatSpec with Matchers{
     val fn = DefaultRugFunctionRegistry.find("ExampleFunction").get.asInstanceOf[ExampleRugFunction]
     fn.clearSecrets
     fn.run(SimpleParameterValues(SimpleParameterValue("thingy", "woot"))) match {
-      case Response(Status.Success, _, _, Some(body)) => body match {
-        case r: InstructionResponse => assert(r.body === "woot")
-      }
+      case Response(Status.Success, _, _, Some(body)) => assert(body === "woot")
       case _ => ???
     }
   }


### PR DESCRIPTION
- Also serialize response from Rug Functions to JSON if not already
  strings (we can loosen this later if we like, but this restriction keeps them serializable for now).
- Remove InstructionResponse - now Response turtles all the way down

No CHANGELOG as just changing/fixing up an unreleased feature.