### PR TITLE
Add response coercion support

### DIFF
--- a/src/main/scala/com/atomist/rug/BadRugException.scala
+++ b/src/main/scala/com/atomist/rug/BadRugException.scala
@@ -89,3 +89,9 @@ class BadPlanException(msg: String)
 
 class MissingRugException(msg: String)
   extends BadRugException(msg)
+
+class BadRugFunctionResponseException(msg: String)
+  extends BadRugException(msg)
+
+class InvalidHandlerException(msg: String)
+  extends BadRugException(msg)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptUtils.scala
@@ -5,7 +5,6 @@ import javax.script.{ScriptContext, SimpleBindings}
 import com.atomist.param.{Parameter, ParameterValues, Tag}
 import com.atomist.rug.{InvalidRugParameterDefaultValue, InvalidRugParameterPatternException}
 import com.atomist.rug.parser.DefaultIdentifierResolver
-import com.atomist.rug.spi.Secret
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/com/atomist/rug/runtime/js/JsonSerializer.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JsonSerializer.scala
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 /**
-  * Serialize nashorn objects to Json
+  * Serialize objects to Json
   */
 object JsonSerializer {
 
@@ -35,6 +35,9 @@ object JsonSerializer {
     val writer = new StringWriter()
     objectWriter.writeValue(writer, ref)
     val str = writer.toString
-    str.substring(22).dropRight(1)
+    ref match {
+      case o: ScriptObjectMirror => str.substring(22).dropRight(1)//objects coming out of nashor seem to be wrapped
+      case _ => str
+    }
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/plans/JsonResponseCoercer.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/JsonResponseCoercer.scala
@@ -1,0 +1,36 @@
+package com.atomist.rug.runtime.plans
+
+import javax.script.{ScriptContext, SimpleBindings}
+
+import com.atomist.rug.runtime.js.{JavaScriptContext, JsonSerializer}
+import com.atomist.rug.spi.Handlers.Response
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+import scala.collection.JavaConverters._
+
+/**
+  * Convert a string or byte array to an JS Object
+  */
+class JsonResponseCoercer(jsc: JavaScriptContext, handler: ScriptObjectMirror) extends ResponseCoercer {
+
+  override def coerce(response: Response): Response = {
+    val body = response.body match {
+      case Some(bytes: Array[Byte]) => new String(bytes)
+      case Some(str: String) => str
+      case Some(o) => JsonSerializer.toJson(o)
+      case agg => throw new RuntimeException(s"Could not recognize body type for coercion: $agg")
+    }
+    Response(response.status, response.msg, response.code, Some(toJSObject(body)))
+  }
+
+  private def toJSObject(body: String): AnyRef = {
+
+    val bindings = new SimpleBindings()
+    bindings.put("__coercion",body)
+
+    //TODO - why do we need this?
+    jsc.engine.getContext.getBindings(ScriptContext.ENGINE_SCOPE).asScala.foreach{
+      case (k: String, v: AnyRef) => bindings.put(k,v)
+    }
+    jsc.engine.eval(s"""JSON.parse(__coercion);""", bindings)
+  }
+}

--- a/src/main/scala/com/atomist/rug/runtime/plans/ResponseCoercer.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/ResponseCoercer.scala
@@ -1,0 +1,18 @@
+package com.atomist.rug.runtime.plans
+
+import com.atomist.rug.spi.Handlers.Response
+
+/**
+  * Coerces a Response in some way
+  */
+trait ResponseCoercer {
+  def coerce(response: Response): Response
+}
+
+
+/**
+  * Does nothing to the response
+  */
+object NullResponseCoercer extends ResponseCoercer{
+  override def coerce(response: Response): Response = response
+}

--- a/src/main/scala/com/atomist/rug/spi/AnnotatedRugFunction.scala
+++ b/src/main/scala/com/atomist/rug/spi/AnnotatedRugFunction.scala
@@ -43,7 +43,7 @@ trait AnnotatedRugFunction extends RugFunction {
     }
   }).flatten.toSeq
 
-  override def run(parameters: ParameterValues): Response = {
+  override def run(parameters: ParameterValues): FunctionResponse = {
     val method = functionMethod()
     val args = method.getParameters.map(p => {
       val parameterAnnotation = p.getAnnotation(classOf[com.atomist.rug.spi.annotation.Parameter])
@@ -58,6 +58,6 @@ trait AnnotatedRugFunction extends RugFunction {
         throw new IllegalArgumentException(s"Parameter ${p.getName} not annotated with either @Secret or @Parameter")
       }
     })
-    method.invoke(this, args:_*).asInstanceOf[Response]
+    method.invoke(this, args:_*).asInstanceOf[FunctionResponse]
   }
 }

--- a/src/main/scala/com/atomist/rug/spi/RugFunction.scala
+++ b/src/main/scala/com/atomist/rug/spi/RugFunction.scala
@@ -1,7 +1,8 @@
 package com.atomist.rug.spi
 
 import com.atomist.param.ParameterValues
-import com.atomist.rug.spi.Handlers.Response
+import com.atomist.rug.runtime.js.JsonSerializer
+import com.atomist.rug.spi.Handlers.{Response, Status}
 
 /**
   * Arbitrary functions to be executed as a result add 'execute' instructions to a Plan
@@ -15,5 +16,27 @@ trait RugFunction extends SecretAwareRug {
     * @param parameters
     * @return
     */
-  def run(parameters: ParameterValues): Response
+  def run(parameters: ParameterValues): FunctionResponse
+}
+
+case class FunctionResponse(status: Status, msg: Option[String] = None, code: Option[Int] = None, body: Option[Body] = None)
+
+case class Body(str: Option[String] = None, bytes: Option[Array[Byte]] = None)
+
+object StringBodyOption {
+  def apply(body: String) : Option[Body] = {
+    Some(Body(str = Some(body)))
+  }
+}
+
+object JsonBodyOption {
+  def apply(body: AnyRef) : Option[Body] = {
+    StringBodyOption(JsonSerializer.toJson(body))
+  }
+}
+
+object ByteBodyOption {
+  def apply(body: Array[Byte]) : Option[Body] = {
+    Some(Body(bytes =  Some(body)))
+  }
 }

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Decorators.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Decorators.ts
@@ -114,6 +114,12 @@ function Secrets(...secrets: string[]) {
   }
 }
 
+//for parameters to ResponseHandlers to do response body coercion
+function ParseJson(target: Object, propertyKey: string | symbol, parameterIndex: number) {
+  set_metadata(target, "__coercion", "JSON");
+}
+
 export {Parameter, Secrets, Tags, Intent, MappedParameter}
 export {Editor, Generator, Reviewer}
+export {ParseJson}
 export {ResponseHandler, CommandHandler, EventHandler}

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
@@ -41,6 +41,29 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
       |
     """.stripMargin)
 
+  val simpleResponseHandlerWithJsonCoercion =  StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
+    s"""
+       |import {Respond, Instruction, Response, Plan, Message} from '@atomist/rug/operations/Handlers'
+       |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
+       |import {EventHandler, ParseJson, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+       |import {Project} from '@atomist/rug/model/Core'
+       |import {HandleResponse, HandleEvent, HandleCommand} from '@atomist/rug/operations/Handlers'
+       |
+       |@ResponseHandler("$kitties", "$kittyDesc")
+       |class KittiesResponder implements HandleResponse<any>{
+       | handle(@ParseJson response: Response<any>) : Plan {
+       |    let results = response.body() as any;
+       |
+       |    if(results.yaml != "is more annoying than json") { throw new Error("Rats: " + results.yaml)}
+       |    results.reasons.map(reason => reason.main.length)
+       |    return new Plan();
+       |  }
+       |}
+       |
+       |export let kit = new KittiesResponder();
+       |
+    """.stripMargin)
+
   it should "extract and run a response handler" in {
     val rugArchive = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(simpleResponseHandler))
     val finder = new JavaScriptResponseHandlerFinder()
@@ -53,5 +76,21 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
     val response = Response(Status.Success, Some("It worked! :p"), Some(204), Some("woot"))
     val plan = handler.handle(response, SimpleParameterValues(SimpleParameterValue("name","his dudeness")))
     //TODO validate the plan
+  }
+
+  it should "coerce responses to json if they are strings or bytes and the annotation is present" in {
+    val rugArchive = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(simpleResponseHandlerWithJsonCoercion))
+    val finder = new JavaScriptResponseHandlerFinder()
+    val handlers = finder.find(new JavaScriptContext(rugArchive))
+    handlers.size should be(1)
+    val handler = handlers.head
+    val response = Response(Status.Success, Some("It worked! :p"), Some(204), Some(
+      """
+        |{
+        |  "yaml" : "is more annoying than json",
+        |  "reasons": [{"main" : "because it's hard to parse, and annoying to write"}]
+        |}
+      """.stripMargin))
+    val plan = handler.handle(response, SimpleParameterValues.Empty)
   }
 }

--- a/src/test/scala/com/atomist/rug/runtime/plans/ExampleAnnotatedRugFunction.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/ExampleAnnotatedRugFunction.scala
@@ -1,9 +1,9 @@
 package com.atomist.rug.runtime.plans
 
 import com.atomist.rug.runtime.RugSupport
-import com.atomist.rug.spi.AnnotatedRugFunction
-import com.atomist.rug.spi.Handlers.{Response, Status}
+import com.atomist.rug.spi.Handlers.Status
 import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse}
 
 /**
   * For testing the annotation driven RugFunction api
@@ -14,11 +14,11 @@ class ExampleAnnotatedRugFunction
 
   @RugFunction(name = "example-function", description = "Description of function", tags = Array(new Tag(name = "tag content")))
   def invoke(@Parameter (name="number") number: Int,
-             @Secret(name = "user_token", path = "github/user_token=repo") user_token: String): Response = {
+             @Secret(name = "user_token", path = "github/user_token=repo") user_token: String): FunctionResponse = {
     if(number == 100 && user_token == "woot"){
-      Response(Status.Success)
+      FunctionResponse(Status.Success)
     }else{
-      Response(Status.Failure)
+      FunctionResponse(Status.Failure)
     }
   }
 }

--- a/src/test/scala/com/atomist/rug/runtime/plans/ExampleRugFunction.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/ExampleRugFunction.scala
@@ -2,8 +2,8 @@ package com.atomist.rug.runtime.plans
 
 import com.atomist.param._
 import com.atomist.rug.runtime.RugSupport
-import com.atomist.rug.spi.Handlers.{Response, Status}
-import com.atomist.rug.spi.{RugFunction, Secret}
+import com.atomist.rug.spi.Handlers.Status
+import com.atomist.rug.spi._
 
 import scala.collection.mutable.ListBuffer
 
@@ -32,9 +32,9 @@ class ExampleRugFunction
     * @param parameters
     * @return
     */
-  override def run(parameters: ParameterValues): Response = {
+  override def run(parameters: ParameterValues): FunctionResponse = {
     validateParameters(parameters)
-    Response(Status.Success,Some("It worked! :p"), Some(204), Some(parameters.parameterValues.head.getValue.toString))
+    FunctionResponse(Status.Success,Some("It worked! :p"), Some(204), StringBodyOption(parameters.parameterValues.head.getValue.toString))
   }
 
   /**

--- a/src/test/scala/com/atomist/rug/runtime/plans/RugFunctionRegistryTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/RugFunctionRegistryTest.scala
@@ -2,8 +2,8 @@ package com.atomist.rug.runtime.plans
 
 import com.atomist.param.{SimpleParameterValue, SimpleParameterValues}
 import com.atomist.rug.MissingSecretException
-import com.atomist.rug.spi.Handlers.{Response, Status}
-import com.atomist.rug.spi.Secret
+import com.atomist.rug.spi.Handlers.Status
+import com.atomist.rug.spi._
 import org.scalatest.{FlatSpec, Matchers}
 
 class RugFunctionRegistryTest extends FlatSpec with Matchers{
@@ -11,7 +11,7 @@ class RugFunctionRegistryTest extends FlatSpec with Matchers{
     val fn = DefaultRugFunctionRegistry.find("ExampleFunction").get.asInstanceOf[ExampleRugFunction]
     fn.clearSecrets
     fn.run(SimpleParameterValues(SimpleParameterValue("thingy", "woot"))) match {
-      case Response(Status.Success, _, _, Some(body)) => assert(body === "woot")
+      case FunctionResponse(Status.Success, _, _, Some(Body(Some(str), None))) => assert(str === "woot")
       case _ => ???
     }
   }
@@ -28,5 +28,10 @@ class RugFunctionRegistryTest extends FlatSpec with Matchers{
     assertThrows[MissingSecretException]{
       fn.run(SimpleParameterValues(SimpleParameterValue("thingy", "woot")))
     }
+  }
+
+  it should "serialize things to json easily" in {
+    val bodyStr = JsonBodyOption(FunctionResponse(Status.Success, Some("woot"), Some(200), StringBodyOption("woot"))).get.str.get
+    assert(bodyStr === """{"FunctionResponse":{"status":{},"msg":"woot","code":200,"body":{"str":"woot","bytes":null}}}""")
   }
 }


### PR DESCRIPTION
- Restrict RugFunction response to contain Strings or Array[Byte]
    - This is so that we can reserve the option to run this workload elsewhere
- Add support (via decorators) for ResponseHandler to coerce response
    - Currently on @ParseJson supported

Example taken from a test:

```typescript
class JsonResponder implements HandleResponse<any>{
 handle(@ParseJson response: Response<any>) : Plan {
    let results = response.body() as any;
    if(results.yaml != "is more annoying than json") { throw new Error("Rats: " + results.json)}
    results.reasons.map(r => r.main.length)
    return new Plan();
  }
}

```