### PR TITLE
A first microgrammar constructor

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -226,3 +226,18 @@ editor:
   parameters:
     - "class_under_test": "com.atomist.rug.runtime.js.JavaScriptContext"
 
+---
+kind: "operation"
+client: "rug-cli 0.25.0"
+editor:
+  name: "AddTypeScriptTest"
+  group: "atomist"
+  artifact: "rug"
+  version: "0.2.0"
+  origin:
+    repo: "git@github.com:atomist/rug"
+    branch: "master"
+    sha: "c0d5777*"
+  parameters:
+    - "class_under_test": "com.atomist.tree.content.text.microgrammar.MatcherMicrogrammarConstruction"
+

--- a/.atomist/manifest.yml
+++ b/.atomist/manifest.yml
@@ -1,6 +1,6 @@
 group: atomist
 artifact: rug
-version: "0.1.0"
-requires: "[0.8.0,1.0.0)"
+version: "0.2.0"
+requires: "[0.13.0,1.0.0)"
 dependencies:
 extensions:

--- a/.atomist/package.json
+++ b/.atomist/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@atomist/rug": "0.12.0"
+    "@atomist/rug": "0.13.0"
   }
 }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstruction.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstruction.scala
@@ -11,10 +11,28 @@ object MatcherMicrogrammarConstruction {
     val parsedMatcher = matcherParser.parseMatcher(name, grammar)
 
     val knownMatchers: Map[String, Matcher] = submatchers.map {
-      case (name, grammar : String) => (name, matcherParser.parseMatcher(name, grammar))
-    }
+      case (name, matcher) => (name, interpretMatcher(matcher, name))
+      }
 
     new MatcherMicrogrammar(parsedMatcher, name, knownMatchers)
+  }
+
+  def constructOr(properties: Map[String, Any]): Matcher = {
+    val componentProperty = properties.getOrElse("components", throw new RuntimeException("an Or should have a component"))
+    // I have no idea why the array comes in as a map of indices to values but it does
+    val components = componentProperty match {
+      case m: Map[_, _] => m.values.map(interpretMatcher(_))
+      case _ => throw new RuntimeException("I expected an array of 'or' components to get to me as a map")
+    }
+    components.reduce(_.alternate(_))
+  }
+
+  def interpretMatcher(m: Any, name: String = "anonymous") = m match {
+    case grammar: String => matcherParser.parseMatcher(name, grammar)
+    case micromatcher: Map[String, Any] @unchecked if micromatcher("kind") == "or" =>
+      constructOr(micromatcher.asInstanceOf[Map[String, Any]])
+    case _ => throw new RuntimeException(s"Unrecognized object provided for submatcher $name")
+
   }
 
 }

--- a/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstruction.scala
+++ b/src/main/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstruction.scala
@@ -22,7 +22,7 @@ object MatcherMicrogrammarConstruction {
     // I have no idea why the array comes in as a map of indices to values but it does
     val components = componentProperty match {
       case m: Map[_, _] => m.values.map(interpretMatcher(_))
-      case _ => throw new RuntimeException("I expected an array of 'or' components to get to me as a map")
+      case _ => throw new RuntimeException("expected an array of 'or' components, as a Map[Number, Any]")
     }
     components.reduce(_.alternate(_))
   }

--- a/src/main/typescript/node_modules/@atomist/rug/tree/Microgrammars.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/Microgrammars.ts
@@ -1,0 +1,12 @@
+
+type MicroMatcher = { kind: string } | String
+
+let Or = function(alternatives: MicroMatcher []): MicroMatcher {
+    let or = {
+        kind : "or",
+        components: alternatives
+    };
+    return or;
+};
+
+export { MicroMatcher, Or }

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -158,12 +158,15 @@ interface DynamicType {
 
 }
 
+import { MicroMatcher } from "./Microgrammars"
 /**
  * Dynamic type for a microgrammar. Pass to PathExpression.addType method
  */
 class Microgrammar implements DynamicType {
 
-    constructor(public name: string, public grammar: string, public submatchers: any = {}) {}
+    constructor(public name: string,
+                public grammar: string,
+                public submatchers: {[matcherName: string]: MicroMatcher} = {}) {}
 }
 
 export {Match}

--- a/src/test/resources/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.ts
@@ -1,14 +1,23 @@
 import { Project } from '@atomist/rug/model/Core'
 import { Editor } from '@atomist/rug/operations/Decorators'
+import { Microgrammar, TextTreeNode } from '@atomist/rug/tree/PathExpression'
+import { Or } from '@atomist/rug/tree/Microgrammars'
+
 
 @Editor("MatcherMicrogrammarConstructionTypeScriptTest", "Uses MatcherMicrogrammarConstruction from TypeScript")
 class MatcherMicrogrammarConstructionTypeScriptTest {
 
     edit(project: Project) {
 
-        let pom = project.findFile('pom.xml');
+        let mg = new Microgrammar("testMe", `I like $vegetable`,
+            { vegetable: Or(["broccoli", "carrots"]) });
 
-        pom.replace('dependency', 'dependenciesAreForBirds');
+        let eng = project.context().pathExpressionEngine().addType(mg);
+
+        eng.with<TextTreeNode>(project, "/targetFile/testMe()", e => {
+            //console.log("Found " + e.value())
+            e.update(e.value() + " (which is a vegetable)")
+        })
 
     }
 }

--- a/src/test/resources/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.ts
@@ -1,0 +1,15 @@
+import { Project } from '@atomist/rug/model/Core'
+import { Editor } from '@atomist/rug/operations/Decorators'
+
+@Editor("MatcherMicrogrammarConstructionTypeScriptTest", "Uses MatcherMicrogrammarConstruction from TypeScript")
+class MatcherMicrogrammarConstructionTypeScriptTest {
+
+    edit(project: Project) {
+
+        let pom = project.findFile('pom.xml');
+
+        pom.replace('dependency', 'dependenciesAreForBirds');
+
+    }
+}
+export let editor = new MatcherMicrogrammarConstructionTypeScriptTest();

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.scala
@@ -1,0 +1,41 @@
+package com.atomist.tree.content.text.microgrammar
+
+import com.atomist.param.SimpleParameterValues
+import com.atomist.project.archive.RugArchiveReader
+import com.atomist.parse.java.ParsingTargets
+import com.atomist.project.edit.SuccessfulModification
+import com.atomist.source.file.ClassPathArtifactSource
+import org.scalatest.{FlatSpec, Matchers}
+
+class MatcherMicrogrammarConstructionTypeScriptTest extends FlatSpec with Matchers {
+
+  it should "use MatcherMicrogrammarConstruction from TypeScript" in {
+
+    val tsEditorResource = "com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.ts"
+    val parameters = SimpleParameterValues.Empty
+    val target = ParsingTargets.NewStartSpringIoProject
+    val fileThatWillBeModified = "pom.xml"
+
+    // construct the Rug archive
+    val artifactSourceWithEditor = ClassPathArtifactSource.toArtifactSource(tsEditorResource).withPathAbove(".atomist/editors")
+    val artifactSourceWithRugNpmModule = TypeScriptBuilder.compileWithModel(artifactSourceWithEditor)
+    //println(s"rug archive: $artifactSourceWithEditor")
+
+    // get the operation out of the artifact source
+    val projectEditor = RugArchiveReader.find(artifactSourceWithRugNpmModule).editors.head
+
+    // apply the operation
+    projectEditor.modify(target, parameters) match {
+      case sm: SuccessfulModification =>
+        val contents = sm.result.findFile(fileThatWillBeModified).get.content
+        withClue(s"contents of $fileThatWillBeModified are:<$contents>") {
+          // check the results
+          contents.contains("dependenciesAreForBirds") should be(true)
+        }
+
+      case boo => fail(s"Modification was not successful: $boo")
+    }
+
+  }
+
+}

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.scala
@@ -2,19 +2,26 @@ package com.atomist.tree.content.text.microgrammar
 
 import com.atomist.param.SimpleParameterValues
 import com.atomist.project.archive.RugArchiveReader
-import com.atomist.parse.java.ParsingTargets
 import com.atomist.project.edit.SuccessfulModification
+import com.atomist.rug.ts.TypeScriptBuilder
+import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.source.file.ClassPathArtifactSource
 import org.scalatest.{FlatSpec, Matchers}
 
 class MatcherMicrogrammarConstructionTypeScriptTest extends FlatSpec with Matchers {
 
+  val inputFile = "I like broccoli. I like carrots. I like bananas."
+  val modifiedFile = "I like broccoli (which is a vegetable). I like carrots (which is a vegetable). I like bananas."
+
+  def singleFileArtifactSource(name: String, content:String):ArtifactSource =
+    new SimpleFileBasedArtifactSource("whatever", Seq(StringFileArtifact(name, content)))
+
   it should "use MatcherMicrogrammarConstruction from TypeScript" in {
 
     val tsEditorResource = "com/atomist/tree/content/text/microgrammar/MatcherMicrogrammarConstructionTypeScriptTest.ts"
     val parameters = SimpleParameterValues.Empty
-    val target = ParsingTargets.NewStartSpringIoProject
-    val fileThatWillBeModified = "pom.xml"
+    val fileThatWillBeModified = "targetFile"
+    val target = singleFileArtifactSource(fileThatWillBeModified, inputFile)
 
     // construct the Rug archive
     val artifactSourceWithEditor = ClassPathArtifactSource.toArtifactSource(tsEditorResource).withPathAbove(".atomist/editors")
@@ -30,7 +37,7 @@ class MatcherMicrogrammarConstructionTypeScriptTest extends FlatSpec with Matche
         val contents = sm.result.findFile(fileThatWillBeModified).get.content
         withClue(s"contents of $fileThatWillBeModified are:<$contents>") {
           // check the results
-          contents.contains("dependenciesAreForBirds") should be(true)
+          contents should be(modifiedFile)
         }
 
       case boo => fail(s"Modification was not successful: $boo")


### PR DESCRIPTION
The next step in Microgrammars is being able to specify all the different matchers, from TypeScript.

Currently, the only way to make a microgrammar is to specify the matcher as a string, which is then parsed. The parser is only implemented for a few matchers.
I don't intend to expand the parser - the target instead is to provide constructors in TypeScript for the other types.

I implemented one, for Or. Please comment on this implementation before I add a bunch of others.

Check the test first, in MatcherMicrogrammarConstructorTypeScriptTest.ts
This calls on a new file in @atomist/rug, Microgrammars.ts -- but the type inside is a MicroMatcher (naming advice welcome). A Microgrammar is a type that can be added to a pxe; a Matcher is not (but I thought "Matcher" was too general). A Microgrammar includes one or more MicroMatcher definitions, each specified by either a string to be parsed or a structure to be painstakingly interpreted in MatcherMicrogrammarConstructor.scala .

There are no breaking changes in here, only additions.