### PR TITLE
First stage of command and event handler testing

### DIFF
--- a/src/main/scala/com/atomist/graph/GraphNode.scala
+++ b/src/main/scala/com/atomist/graph/GraphNode.scala
@@ -55,6 +55,7 @@ trait GraphNode extends Visitable {
     */
   def followEdge(name: String): Seq[GraphNode] = {
     NodeUtils.invokeMethodIfPresent[Seq[GraphNode]](this, name) match {
+      case null => Nil
       case Some(l) => l
       case None =>
         NodeUtils.invokeMethodIfPresent[GraphNode](this, name)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptProjectOperation.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptProjectOperation.scala
@@ -4,6 +4,7 @@ import javax.script.{ScriptContext, SimpleBindings}
 
 import com.atomist.param.{Parameter, ParameterValues, Tag}
 import com.atomist.project.ProjectOperation
+import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.parser.DefaultIdentifierResolver
 import com.atomist.rug.runtime.{AddressableRug, RugSupport}
@@ -224,6 +225,6 @@ abstract class JavaScriptProjectOperation(
     * @return proxy TypeScript callers can use
     */
   protected def wrapProject(pmv: ProjectMutableView): jsSafeCommittingProxy = {
-    new jsSafeCommittingProxy(pmv)
+    new jsSafeCommittingProxy(pmv, DefaultTypeRegistry)
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
@@ -28,7 +28,7 @@ class PlanBuilder {
       // we are allowed to return a Message directly from handlers
       Plan(Seq(constructMessage(jsPlan)),Nil)
     } else {
-      val jsMessages = jsPlan.getMember("messages") match {
+      val jsMessages = jsPlan.getMember("_messages") match {
         case o: ScriptObjectMirror => o.values().toArray.toList
         case _ => Nil
       }
@@ -36,7 +36,7 @@ class PlanBuilder {
         val m = message.asInstanceOf[ScriptObjectMirror]
         constructMessage(m)
       }
-      val instructions = jsPlan.getMember("instructions") match {
+      val instructions = jsPlan.getMember("_instructions") match {
         case u: Undefined => Nil
         case jsInstructions: ScriptObjectMirror =>
           jsInstructions.values().toArray.toList.map { respondable =>

--- a/src/main/scala/com/atomist/rug/runtime/js/RugContext.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/RugContext.scala
@@ -1,6 +1,7 @@
 package com.atomist.rug.runtime.js
 
 import com.atomist.rug.runtime.js.interop.jsPathExpressionEngine
+import com.atomist.rug.spi.TypeRegistry
 import com.atomist.tree.{IdentityTreeMaterializer, TreeMaterializer}
 
 
@@ -9,6 +10,8 @@ import com.atomist.tree.{IdentityTreeMaterializer, TreeMaterializer}
   * Editors or Executors or Handlers etc.
   */
 trait RugContext {
+
+  def typeRegistry: TypeRegistry = pathExpressionEngine.typeRegistry
 
   def pathExpressionEngine: jsPathExpressionEngine
 

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/NashornMapBackedGraphNode.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/NashornMapBackedGraphNode.scala
@@ -1,0 +1,127 @@
+package com.atomist.rug.runtime.js.interop
+
+import java.util.Objects
+
+import com.atomist.graph.GraphNode
+import com.atomist.tree.SimpleTerminalTreeNode
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+
+import scala.collection.JavaConverters._
+
+object NashornMapBackedGraphNode {
+
+  /**
+    * Convert this object returned from Nashorn to a GraphNode if possible. Only take
+    * account of properties
+    */
+  def toGraphNode(nashornReturn: Object): Option[GraphNode] = nashornReturn match {
+    case som: ScriptObjectMirror =>
+      Some(new NashornMapBackedGraphNode(som, new NodeRegistry()))
+    case _ =>
+      None
+  }
+
+  private val NodeIdField = "nodeId"
+  private val NodeNameField = "nodeName"
+  private val NodeTagsField = "nodeTag"
+  private val NodeRefField = "nodeRef"
+
+}
+
+/**
+  * Mutable registry of nodes we've seen
+  */
+private[interop] class NodeRegistry {
+
+  private var reg: Map[String, NashornMapBackedGraphNode] = Map()
+
+  def register(gn: NashornMapBackedGraphNode): Unit = {
+    gn.nodeId.foreach(id => {
+      reg = reg ++ Map(id -> gn)
+    })
+  }
+
+  def get(id: String): Option[NashornMapBackedGraphNode] = reg.get(id)
+
+  override def toString: String = s"NodeRegistry ${hashCode()}: Known ids=[${reg.keySet.mkString(",")}]"
+
+}
+
+/**
+  * Backed by a Map that can include simple properties or Nashorn ScriptObjectMirror in the event of nesting.
+  * Handles cycles if references are provided.
+  */
+private class NashornMapBackedGraphNode(som: ScriptObjectMirror,
+                                        nodeRegistry: NodeRegistry) extends GraphNode {
+
+  import NashornMapBackedGraphNode._
+
+  private val relevantPropertiesAndValues =
+    (NashornUtils.extractProperties(som) ++
+    NashornUtils.extractNoArgFunctions(som))
+      // Null properties don't match path expressions, so suppress them
+      .filter(_._2 != null)
+
+  val nodeId: Option[String] = relevantPropertiesAndValues.get(NodeIdField).map(id => "" + id)
+  nodeRegistry.register(this)
+
+  override def nodeName: String = relevantPropertiesAndValues.get(NodeNameField) match {
+    case None => ""
+    case Some(s: String) => s
+    case x => Objects.toString(x)
+  }
+
+  override def nodeTags: Set[String] = {
+    relevantPropertiesAndValues("nodeTags") match {
+      case som: ScriptObjectMirror if som.isArray =>
+        som.values().asScala.map(Objects.toString(_)).toSet
+      case _ => Set()
+    }
+  }
+
+  override lazy val relatedNodes: Seq[GraphNode] =
+    relevantPropertiesAndValues.keySet.filter(!Set(NodeNameField, NodeTagsField, NodeIdField).contains(_)).flatMap(toNode).toSeq
+
+  override lazy val relatedNodeNames: Set[String] = relatedNodes.map(_.nodeName).toSet
+
+  override def relatedNodeTypes: Set[String] = relatedNodes.flatMap(_.nodeTags).toSet
+
+  override def relatedNodesNamed(name: String): Seq[GraphNode] =
+    relatedNodes.filter(_.nodeName == name)
+
+  override def followEdge(name: String): Seq[GraphNode] =
+    toNode(name)
+
+  private def toNode(key: String): Seq[GraphNode] = {
+    def nodify(som: ScriptObjectMirror): GraphNode = {
+      if (NashornUtils.hasDefinedProperties(som, NodeRefField)) {
+        // It's a ref to an existing node. We must have seen that node before
+        val id = NashornUtils.stringProperty(som, NodeRefField)
+        nodeRegistry.get(id) match {
+          case None => throw new IllegalArgumentException(s"No node found with referenced id [$id] in $nodeRegistry")
+          case Some(n) => n
+        }
+      }
+      else {
+        new NashornMapBackedGraphNode(som, nodeRegistry)
+      }
+    }
+
+    relevantPropertiesAndValues.get(key) match {
+      case None => Nil
+      case Some(s: String) => Seq(SimpleTerminalTreeNode(key, s, Set()))
+      case Some(som: ScriptObjectMirror) if som.isArray =>
+        som.values().asScala.collect {
+          case s: ScriptObjectMirror => nodify(s)
+        }.toSeq
+      case Some(som: ScriptObjectMirror) =>
+        Seq(nodify(som))
+      case x =>
+        val v = Objects.toString(x)
+        Seq(SimpleTerminalTreeNode(key, v, Set()))
+    }
+  }
+
+  override def toString: String = s"${getClass.getSimpleName}: name=[$nodeName],id=$nodeId"
+
+}

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsContextMatch.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsContextMatch.scala
@@ -6,4 +6,9 @@ package com.atomist.rug.runtime.js.interop
 case class jsContextMatch(root: Object,
                           matches: _root_.java.util.List[jsSafeCommittingProxy],
                           teamId: String) {
+
+  import scala.collection.JavaConverters._
+
+  override def toString: String =
+    s"ContextMatch: TeamId=[$teamId]; root=$root, matches=[${matches.asScala.mkString(",")}]"
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -43,7 +43,7 @@ case class jsMatch(root: TreeNode, matches: _root_.java.util.List[jsSafeCommitti
 class jsPathExpressionEngine(
                               rugContext: RugContext,
                               val ee: ExpressionEngine = new PathExpressionEngine,
-                              typeRegistry: TypeRegistry = DefaultTypeRegistry) {
+                              val typeRegistry: TypeRegistry = DefaultTypeRegistry) {
 
   import jsSafeCommittingProxy._
 
@@ -98,7 +98,7 @@ class jsPathExpressionEngine(
     val hydrated = rugContext.treeMaterializer.hydrate(rugContext.teamId, toUnderlyingTreeNode(root), parsed)
     ee.evaluate(hydrated, parsed, typeRegistry) match {
       case Right(nodes) =>
-        val m = jsMatch(root, wrap(nodes))
+        val m = jsMatch(root, wrap(nodes, typeRegistry))
         m
       case Left(_) =>
         jsMatch(root, Collections.emptyList())
@@ -195,7 +195,7 @@ class jsPathExpressionEngine(
     (typ, rootTn) match {
       case (cr: ChildResolver, mv: MutableView[_]) =>
         val kids = cr.findAllIn(mv).getOrElse(Nil)
-        wrap(kids)
+        wrap(kids, typeRegistry)
       case _ => ???
     }
   }

--- a/src/main/scala/com/atomist/rug/runtime/lang/Invocable.scala
+++ b/src/main/scala/com/atomist/rug/runtime/lang/Invocable.scala
@@ -1,6 +1,0 @@
-package com.atomist.rug.runtime.lang
-
-trait Invocable {
-
-  def invokeFunction(context: Object, argsToUse: Map[String, Object]): Object
-}

--- a/src/main/scala/com/atomist/rug/spi/TypeOperations.scala
+++ b/src/main/scala/com/atomist/rug/spi/TypeOperations.scala
@@ -46,6 +46,11 @@ case class TypeOperation(
   def hasExample: Boolean = example.isDefined
 
   /**
+    * Does this type support reflective invocation on a node?
+    */
+  def invocable: Boolean = definedOn != null
+
+  /**
     * Convenient way of invoking the method using arguments
     * passed directly from Javascript.
     */
@@ -60,7 +65,8 @@ case class TypeOperation(
     if (methods.size != 1)
       throw new IllegalArgumentException(
         s"Operation [$name] cannot be invoked on [${target.getClass.getName}]: Found ${methods.size} definitions with ${parameters.size}, required exactly 1: " +
-          methods.mkString(","))
+          s"Known methods=[${methods.mkString(",")}]"
+      )
 
     try {
       methods.head.invoke(target, args: _*)

--- a/src/main/scala/com/atomist/rug/spi/UsageSpecificTypeRegistry.scala
+++ b/src/main/scala/com/atomist/rug/spi/UsageSpecificTypeRegistry.scala
@@ -9,7 +9,7 @@ class UsageSpecificTypeRegistry(delegate: TypeRegistry,
                                 newTypes: Seq[Typed]) extends TypeRegistry {
 
   override def findByName(kind: String): Option[Typed] =
-    newTypes.find(t => kind.equals(t.name)).orElse(delegate.findByName(kind))
+    newTypes.find(t => kind == t.name).orElse(delegate.findByName(kind))
 
   override def typeNames: Traversable[String] =
     newTypes.map(_.name) ++ delegate.typeNames

--- a/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
@@ -1,6 +1,8 @@
 package com.atomist.rug.test.gherkin
 
 import com.atomist.project.archive.{DefaultAtomistConfig, Rugs}
+import com.atomist.rug.test.gherkin.handler.command.CommandHandlerFeature
+import com.atomist.rug.test.gherkin.handler.event.EventHandlerFeature
 import com.atomist.rug.test.gherkin.project.ProjectManipulationFeature
 import com.atomist.source.ArtifactSource
 
@@ -17,9 +19,13 @@ object DefaultExecutableFeatureFactory extends ExecutableFeatureFactory {
                                     definitions: Definitions,
                                     rugAs: ArtifactSource,
                                     rugs: Option[Rugs],
-                                    listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_,_] = {
+                                    listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_] = {
     if (f.definition.path.contains("project"))
       new ProjectManipulationFeature(f, definitions, rugAs, rugs, listeners)
+    else if (f.definition.path.contains("handlers/command"))
+      new CommandHandlerFeature(f, definitions, rugAs, rugs, listeners)
+    else if (f.definition.path.contains("handlers/event"))
+      new EventHandlerFeature(f, definitions, rugAs, rugs, listeners)
     else {
       throw new IllegalArgumentException(s"Cannot handle path [${f.definition.path}]: Paths must be of form [${atomistConfig.testsDirectory}/project] or ${atomistConfig.testsDirectory}/handlers]")
     }

--- a/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
@@ -9,7 +9,9 @@ import com.atomist.source.ArtifactSource
 /**
   * Default implementation of ExecutableFeatureFactory, which
   * knows about project features and handler features (coming soon), which it identifies
-  * by their respective subdirectories under .atomist/test
+  * by their respective subdirectories under .atomist/test.
+  * Using location to determine type avoids the need to make the user
+  * provide additional metadata in their test definitions.
   */
 object DefaultExecutableFeatureFactory extends ExecutableFeatureFactory {
 
@@ -20,11 +22,12 @@ object DefaultExecutableFeatureFactory extends ExecutableFeatureFactory {
                                     rugAs: ArtifactSource,
                                     rugs: Option[Rugs],
                                     listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_] = {
-    if (f.definition.path.contains("project"))
+    // TODO clean up name of test directory
+    if (f.definition.path.contains(s"test/project"))
       new ProjectManipulationFeature(f, definitions, rugAs, rugs, listeners)
-    else if (f.definition.path.contains("handlers/command"))
+    else if (f.definition.path.contains(s"test/${atomistConfig.handlersDirectory}/command"))
       new CommandHandlerFeature(f, definitions, rugAs, rugs, listeners)
-    else if (f.definition.path.contains("handlers/event"))
+    else if (f.definition.path.contains(s"test/${atomistConfig.handlersDirectory}/event"))
       new EventHandlerFeature(f, definitions, rugAs, rugs, listeners)
     else {
       throw new IllegalArgumentException(s"Cannot handle path [${f.definition.path}]: Paths must be of form [${atomistConfig.testsDirectory}/project] or ${atomistConfig.testsDirectory}/handlers]")

--- a/src/main/scala/com/atomist/rug/test/gherkin/ExecutableFeatureFactory.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/ExecutableFeatureFactory.scala
@@ -12,7 +12,7 @@ trait ExecutableFeatureFactory {
                            definitions: Definitions,
                            rugAs: ArtifactSource,
                            rugs: Option[Rugs],
-                           listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_,_]
+                           listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_]
 }
 
 

--- a/src/main/scala/com/atomist/rug/test/gherkin/ScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/ScenarioWorld.scala
@@ -3,7 +3,9 @@ package com.atomist.rug.test.gherkin
 import com.atomist.param.{ParameterValues, SimpleParameterValues}
 import com.atomist.project.archive.Rugs
 import com.atomist.project.common.InvalidParametersException
-import com.atomist.rug.runtime.js.interop.NashornUtils
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.runtime.js.interop.{NashornUtils, jsPathExpressionEngine}
+import com.atomist.rug.spi.{TypeOperation, TypeRegistry, Typed, UsageSpecificTypeRegistry}
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 /**
@@ -17,6 +19,36 @@ abstract class ScenarioWorld(val definitions: Definitions, rugs: Option[Rugs]) {
   private var _aborted = false
 
   private var ipe: InvalidParametersException = _
+
+  private var tr: TypeRegistry = new UsageSpecificTypeRegistry(DefaultTypeRegistry, Seq(
+    new Typed() {
+      override val name = "Person"
+      override def description: String = name
+      override def allOperations: Seq[TypeOperation] = Seq(
+        //new TypeOperation("name", "", true, Nil, "String", null, None)
+      )
+      override def operations: Seq[TypeOperation] = allOperations
+    },
+    new Typed() {
+      override val name = "GitHubId"
+      override def description: String = name
+      override def allOperations: Seq[TypeOperation] = Seq(
+        //new TypeOperation("id", "", true, Nil, "String", null, None)
+      )
+      override def operations: Seq[TypeOperation] = allOperations
+    }
+  ))
+
+  def typeRegistry: TypeRegistry = tr
+
+  def registerType(t: Typed): Unit = {
+    this.tr = new UsageSpecificTypeRegistry(this.tr, Seq(t))
+  }
+
+  /**
+    * Target for each test. Defaults to the world. First parameter to step functions
+    */
+  def target: AnyRef = this
 
   /**
     * Was the scenario run aborted?

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/AbstractHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/AbstractHandlerScenarioWorld.scala
@@ -1,0 +1,75 @@
+package com.atomist.rug.test.gherkin.handler
+
+import com.atomist.project.archive.Rugs
+import com.atomist.rug.RugNotFoundException
+import com.atomist.rug.runtime.CommandHandler
+import com.atomist.rug.runtime.js.RugContext
+import com.atomist.rug.spi.Handlers.{Message, Plan}
+import com.atomist.rug.test.gherkin.{Definitions, ScenarioWorld}
+import com.atomist.tree.TreeMaterializer
+
+/**
+  * Superclass for Handler worlds. Handles plan capture and exposing to JavaScript
+  */
+abstract class AbstractHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs])
+  extends ScenarioWorld(definitions, rugs) {
+
+  private var planOption: Option[Plan] = None
+
+  protected def createRugContext(tm: TreeMaterializer): RugContext =
+    new FakeRugContext("team_id", typeRegistry, tm)
+
+  /**
+    * Return the editor with the given name or throw an exception
+    */
+  def commandHandler(name: String): CommandHandler = {
+    rugs match {
+      case Some(r) =>
+        r.commandHandlers.find(e => e.name == name) match {
+          case Some(e) => e
+          case _ => throw new RugNotFoundException(
+            s"CommandHandler with name '$name' can not be found in current context. Known CommandHandlers are [${r.commandHandlerNames.mkString(", ")}]")
+        }
+      case _ => throw new RugNotFoundException("No context provided")
+    }
+  }
+
+  protected def recordPlan(plan: Option[Plan]): Unit = {
+    //println(s"Recorded plan option $plan")
+    this.planOption = plan
+  }
+
+  /**
+    * Return the plan or throw an exception if none was recorded
+    */
+  def requiredPlan: jsPlan = {
+    //println(s"Contents of recorded plan: $planOption")
+    planOption.map(new jsPlan(_)).getOrElse(throw new IllegalArgumentException("No plan was recorded"))
+  }
+
+  /**
+    * Return the plan or null if none was recorded
+    */
+  def plan: jsPlan = {
+    planOption.map(new jsPlan(_)).orNull
+  }
+
+}
+
+import scala.collection.JavaConverters._
+
+/**
+  * JavaScript-friendly version of Plan structure, without Scala collections and using null instead of Option
+  */
+class jsPlan(plan: Plan) {
+
+  def messages: java.util.List[jsMessage] =
+    plan.messages.map(new jsMessage(_)).asJava
+
+}
+
+class jsMessage(message: Message) {
+
+  def body = message.body
+
+}

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/FakeRugContext.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/FakeRugContext.scala
@@ -1,0 +1,20 @@
+package com.atomist.rug.test.gherkin.handler
+
+import com.atomist.rug.runtime.js.RugContext
+import com.atomist.rug.runtime.js.interop.jsPathExpressionEngine
+import com.atomist.rug.spi.{TypeRegistry, Typed}
+import com.atomist.tree.TreeMaterializer
+
+class FakeRugContext(val teamId: String, tr: TypeRegistry, _treeMaterializer: TreeMaterializer) extends RugContext {
+
+  private var jsee = new jsPathExpressionEngine(this, typeRegistry = tr)
+
+  override val pathExpressionEngine: jsPathExpressionEngine = jsee
+
+  override def treeMaterializer: TreeMaterializer = _treeMaterializer
+
+  def registerType(t: Typed): Unit = {
+    jsee = jsee.addType(t)
+  }
+
+}

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerFeature.scala
@@ -1,0 +1,19 @@
+package com.atomist.rug.test.gherkin.handler.command
+
+import com.atomist.project.archive.Rugs
+import com.atomist.rug.test.gherkin.{AbstractExecutableFeature, Definitions, FeatureDefinition, GherkinExecutionListener}
+import com.atomist.source.ArtifactSource
+
+class CommandHandlerFeature(
+                      definition: FeatureDefinition,
+                      definitions: Definitions,
+                      rugArchive: ArtifactSource,
+                      rugs: Option[Rugs],
+                      listeners: Seq[GherkinExecutionListener])
+  extends AbstractExecutableFeature[CommandHandlerScenarioWorld](definition, definitions, rugs, listeners) {
+
+  override protected def createWorldForScenario: CommandHandlerScenarioWorld = {
+    new CommandHandlerScenarioWorld(definitions, rugs)
+  }
+}
+

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerScenarioWorld.scala
@@ -1,0 +1,18 @@
+package com.atomist.rug.test.gherkin.handler.command
+
+import com.atomist.project.archive.Rugs
+import com.atomist.rug.runtime.CommandHandler
+import com.atomist.rug.test.gherkin.Definitions
+import com.atomist.rug.test.gherkin.handler.AbstractHandlerScenarioWorld
+import com.atomist.tree.IdentityTreeMaterializer
+
+class CommandHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = None)
+  extends AbstractHandlerScenarioWorld(definitions, rugs) {
+
+  def invokeHandler(handler: CommandHandler, params: Any): Unit = {
+    recordPlan(handler.handle(createRugContext(IdentityTreeMaterializer),
+      parameters(params)))
+  }
+
+}
+

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerFeature.scala
@@ -1,0 +1,25 @@
+package com.atomist.rug.test.gherkin.handler.event
+
+import com.atomist.project.archive.Rugs
+import com.atomist.rug.runtime.js.RugContext
+import com.atomist.rug.test.gherkin.handler.FakeRugContext
+import com.atomist.rug.test.gherkin.{AbstractExecutableFeature, Definitions, FeatureDefinition, GherkinExecutionListener}
+import com.atomist.source.ArtifactSource
+import com.atomist.tree.IdentityTreeMaterializer
+
+class EventHandlerFeature(
+                      definition: FeatureDefinition,
+                      definitions: Definitions,
+                      rugArchive: ArtifactSource,
+                      rugs: Option[Rugs],
+                      listeners: Seq[GherkinExecutionListener])
+  extends AbstractExecutableFeature[EventHandlerScenarioWorld](definition, definitions, rugs, listeners) {
+
+  override protected def createWorldForScenario: EventHandlerScenarioWorld = {
+    new EventHandlerScenarioWorld(definitions, rugs)
+  }
+}
+
+
+
+

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerScenarioWorld.scala
@@ -1,0 +1,64 @@
+package com.atomist.rug.test.gherkin.handler.event
+
+import com.atomist.graph.GraphNode
+import com.atomist.project.archive.Rugs
+import com.atomist.rug.RugNotFoundException
+import com.atomist.rug.runtime.js.RugContext
+import com.atomist.rug.runtime.js.interop.NashornMapBackedGraphNode
+import com.atomist.rug.runtime.{EventHandler, SystemEvent}
+import com.atomist.rug.test.gherkin.Definitions
+import com.atomist.rug.test.gherkin.handler.{AbstractHandlerScenarioWorld, FakeRugContext}
+import com.atomist.tree.TreeMaterializer
+import com.atomist.tree.pathexpression.PathExpression
+
+class EventHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = None)
+  extends AbstractHandlerScenarioWorld(definitions, rugs) {
+
+  //private var registeredHandlers: Set[EventHandler] = Set()
+
+  private var handler: Option[EventHandler] = _
+
+  def eventHandler(name: String): EventHandler = {
+    rugs match {
+      case Some(r) =>
+        r.eventHandlers.find(e => e.name == name) match {
+          case Some(e) => e
+          case _ => throw new RugNotFoundException(
+            s"EventHandler with name '$name' can not be found in current context. Known EventHandlers are [${r.eventHandlerNames.mkString(", ")}]")
+        }
+      case _ => throw new RugNotFoundException("No context provided")
+    }
+  }
+
+  def registerHandler(name: String): EventHandler = {
+    val eh = eventHandler(name)
+    handler = Some(eh)
+    eh
+  }
+
+  /**
+    * It's hopefully a ScriptObjectMirror
+    */
+  def sendEvent(e: AnyRef): Unit = {
+    //println(s"Received event [$e]")
+    val gn = NashornMapBackedGraphNode.toGraphNode(e).getOrElse(
+      throw new IllegalArgumentException(s"Cannot make a GraphNode out of $e")
+    )
+    val h = handler.getOrElse(throw new IllegalStateException("No handler is registered"))
+    if (gn.nodeTags.contains(h.rootNodeName)) {
+      val tm = new TreeMaterializer {
+        override def rootNodeFor(e: SystemEvent, pe: PathExpression) = gn
+        override def hydrate(teamId: String, rawRootNode: GraphNode, pe: PathExpression) = rawRootNode
+      }
+      val rugContext: RugContext = new FakeRugContext("team_id", typeRegistry, tm)
+      //println("About to handle event")
+      recordPlan(h.handle(rugContext, SystemEvent(rugContext.teamId, h.rootNodeName, 1)))
+    }
+    else {
+      // TODO should publish an event
+      println(s"Handler $h handles [${h.rootNodeName}], not ${gn.nodeTags}")
+    }
+  }
+
+}
+

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectManipulationFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectManipulationFeature.scala
@@ -12,14 +12,11 @@ class ProjectManipulationFeature(
                                   definition: FeatureDefinition,
                                   definitions: Definitions,
                                   rugArchive: ArtifactSource,
-                                  rugs: Option[Rugs] = None,
+                                  rugs: Option[Rugs],
                                   listeners: Seq[GherkinExecutionListener] = Nil)
-  extends AbstractExecutableFeature[ProjectMutableView, ProjectScenarioWorld](definition, definitions, listeners) {
+  extends AbstractExecutableFeature[ProjectScenarioWorld](definition, definitions, rugs, listeners) {
 
-  override protected def createFixture =
-    new ProjectMutableView(rugAs = rugArchive, originalBackingObject = EmptyArtifactSource())
-
-  override protected def createWorldForScenario(fixture: ProjectMutableView): ScenarioWorld = {
-    new ProjectScenarioWorld(definitions, fixture, rugs)
+  override protected def createWorldForScenario: ScenarioWorld = {
+    new ProjectScenarioWorld(definitions, rugs)
   }
 }

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
@@ -10,16 +10,22 @@ import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.rug.runtime.js.JavaScriptProjectOperation
 import com.atomist.rug.runtime.js.interop.NashornUtils
 import com.atomist.rug.test.gherkin._
+import com.atomist.source.EmptyArtifactSource
 
 /**
   * Convenient methods for working with projects
   */
-class ProjectScenarioWorld( definitions: Definitions,
-                            project: ProjectMutableView,
+class ProjectScenarioWorld(
+                            definitions: Definitions,
                             rugs: Option[Rugs] = None)
   extends ScenarioWorld(definitions, rugs) {
 
   private var editorResults: Seq[Either[Throwable, ModificationAttempt]] = Nil
+
+
+  val project = new ProjectMutableView(rugAs = definitions.jsc.rugAs, originalBackingObject = EmptyArtifactSource())
+
+  override def target: AnyRef = project
 
   /**
     * Return the editor with the given name or throw an exception

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -1,4 +1,4 @@
-import {TreeNode, PathExpressionEngine, PathExpression, Match} from "../tree/PathExpression"
+import {GraphNode, TreeNode, PathExpressionEngine, PathExpression, Match} from "../tree/PathExpression"
 import {Parameter} from "./RugOperation"
 
 interface RugCoordinate {
@@ -51,7 +51,7 @@ interface Edit extends ProjectInstruction <"edit">{
 }
 
 //extends ProjectInstruction because we need to know the project name
-interface Generate extends ProjectInstruction <"generate">{
+interface Generate extends ProjectInstruction <"generate"> {
 
 }
 
@@ -70,22 +70,22 @@ interface PresentableReview extends Instruction<"review"> {
     project?: string | ProjectReference
 }
 
-interface Execute extends Instruction<"execute">{
+interface Execute extends Instruction<"execute"> {
 }
 
-interface Command extends Instruction<"command">{
-
-}
-
-interface Respond extends Instruction<"respond">{
+interface Command extends Instruction<"command"> {
 
 }
 
-interface HandleCommand{
+interface Respond extends Instruction<"respond"> {
+
+}
+
+interface HandleCommand {
   handle(ctx: HandlerContext): Plan | Message
 }
 
-interface HandleEvent<R extends TreeNode, M extends TreeNode> {
+interface HandleEvent<R extends GraphNode, M extends GraphNode> {
   handle(root: Match<R,M>): Plan | Message
 }
 
@@ -110,33 +110,41 @@ interface Response<T> {
 }
 
 /**
-A bunch of stuff to do asynchronously
-Messages got to the bot.
-Rugs are run straight away
-*/
-
+ * A bunch of stuff to do asynchronously
+ * Messages got to the bot.
+ * Rugs are run straight away
+ */
 class Plan {
-   private messages: Message[] = [];
-   private instructions: Plannable[] = [];
+
+   private _messages: Message[] = [];
+   private _instructions: Plannable[] = [];
+
+   messages(): Message[] { return this._messages }
+
+   instructions(): Plannable[] { return this._instructions }
+
    public add?(thing: Plannable | Message): this {
      if(thing instanceof Message){
-       this.messages.push(thing)
-     }else{
-        this.instructions.push(thing)
+       this._messages.push(thing)
+     }
+     else {
+        this._instructions.push(thing)
      }
      return this;
    }
 }
+
 /**
 Represents a Message to the bot.
 Any rugs can contain unbound parameters, and the bot will try to fill them out
 */
 class Message {
+
   body: string | Json;
   channelId?: string;
   instructions?: Presentable<any>[] = [];
 
-  treeNode?: TreeNode;
+  treeNode?: GraphNode;
   correlationId?: string
 
   public withCorrelationId?(id: string) : this {
@@ -144,7 +152,7 @@ class Message {
     return this;
   }
 
-  public withTreeNode?(node: TreeNode) : this {
+  public withTreeNode?(node: GraphNode) : this {
     this.treeNode = node;
     return this;
   }

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -1,11 +1,21 @@
 import {ScenarioWorld} from "../ScenarioWorld"
 import {Result} from "../Result"
+import {Plan} from "../../operations/Handlers"
+import {GraphNode} from "../../tree/PathExpression"
+
+export interface HandlerScenarioWorld extends ScenarioWorld {
+
+    /**
+     * Throws an exception if no plan was recorded
+     */
+    plan(): Plan
+}
 
 /**
  * Subinterface of ScenarioWorld specific to 
  * scenarios testing project operations
  */
-export interface HandlerScenarioWorld extends ScenarioWorld {
+export interface CommandHandlerScenarioWorld extends ScenarioWorld {
     
     /**
      * Return the CommandHandler with the given name, or null if none is found.
@@ -13,13 +23,27 @@ export interface HandlerScenarioWorld extends ScenarioWorld {
      */
     commandHandler(name: string): any
     
-    eventHandler(name: string): any
-
     /**
      * Execute the given handler, validating parameters
      */
     invokeHandler(commandHandler: any, params?: {})
+
 }
+
+export interface EventHandlerScenarioWorld extends ScenarioWorld {
+    
+    /**
+     * Register the named handler to respond to input
+     * Return the handler, or null if none is found.
+     */
+    registerHandler(name: string): any
+    
+    /**
+     * Publish the given event. Should be materialized
+     */
+    sendEvent(n: GraphNode): void
+}
+
  
 interface Definitions {
 

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -3,6 +3,10 @@ import {Result} from "../Result"
 import {Plan} from "../../operations/Handlers"
 import {GraphNode} from "../../tree/PathExpression"
 
+/**
+ * All handler scenario worlds expose the plan,
+ * if constructed by code under test.
+ */
 export interface HandlerScenarioWorld extends ScenarioWorld {
 
     /**
@@ -15,7 +19,7 @@ export interface HandlerScenarioWorld extends ScenarioWorld {
  * Subinterface of ScenarioWorld specific to 
  * scenarios testing project operations
  */
-export interface CommandHandlerScenarioWorld extends ScenarioWorld {
+export interface CommandHandlerScenarioWorld extends HandlerScenarioWorld {
     
     /**
      * Return the CommandHandler with the given name, or null if none is found.
@@ -30,7 +34,7 @@ export interface CommandHandlerScenarioWorld extends ScenarioWorld {
 
 }
 
-export interface EventHandlerScenarioWorld extends ScenarioWorld {
+export interface EventHandlerScenarioWorld extends HandlerScenarioWorld {
     
     /**
      * Register the named handler to respond to input

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
@@ -5,3 +5,6 @@ import {Given, When, Then} from "./Core"
 Then("parameters were invalid", 
     (p, world) => world.invalidParameters() != null)
 
+Then("plan has no messages", (p,world) => {
+    return world.plan().messages().length == 0
+})

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -1,7 +1,7 @@
 /**
  *  Returned when a PathExpression is evaluated
  */
-interface Match<R extends TreeNode,N extends TreeNode> {
+interface Match<R extends GraphNode,N extends GraphNode> {
 
     root(): R
 
@@ -11,7 +11,7 @@ interface Match<R extends TreeNode,N extends TreeNode> {
 /**
  * Object encapsulating a path expression. Facilitates reuse.
  */
-class PathExpression<R extends TreeNode, N extends TreeNode> {
+class PathExpression<R extends GraphNode, N extends GraphNode> {
     constructor(readonly expression: string) {}
 }
 
@@ -56,14 +56,18 @@ interface PointFormatInfo {
     indent(): String
 }
 
-/**
- * Operations common to all tree nodes.
- */
-interface TreeNode {
+export interface GraphNode {
 
     nodeName(): string
 
     nodeTags(): string[]
+
+}
+
+/**
+ * Operations common to all tree nodes.
+ */
+interface TreeNode extends GraphNode {
 
     children(): TreeNode[]
 }

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
@@ -1,0 +1,35 @@
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {CommandHandler, Secrets, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+
+@CommandHandler("ReturnsEmptyPlanCommandHandler","Search Youtube for kitty videos and post results to slack")
+@Tags("kitty", "youtube", "slack")
+@Intent("show me kitties","cats please")
+@Secrets("atomist/user_token", "atomist/showmethemoney")
+class ReturnsEmptyPlanCommandHandler implements HandleCommand {
+
+  handle(ctx: HandlerContext) : Plan {
+
+    let result = new Plan()
+    //result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "woot"}}})
+    return result;
+  }
+}
+
+export let command1 = new ReturnsEmptyPlanCommandHandler();
+
+
+@CommandHandler("ReturnsOneMessageCommandHandler","Search Youtube for kitty videos and post results to slack")
+@Tags("kitty", "youtube", "slack")
+@Intent("show me kitties","cats please")
+@Secrets("atomist/user_token", "atomist/showmethemoney")
+class ReturnsOneMessageCommandHandler implements HandleCommand {
+
+  handle(ctx: HandlerContext) : Plan {
+    let result = new Plan()
+    result.add(new Message("woot").withCorrelationId("dude"))
+    console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
+    return result;
+  }
+}
+
+export let command2 = new ReturnsOneMessageCommandHandler();

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
@@ -1,0 +1,57 @@
+import {HandleEvent, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {GraphNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
+import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
+
+import * as node from "./Nodes"
+
+@EventHandler("ReturnsEmptyPlanEventHandler", "Handles a new Commit event", 
+new PathExpression<GraphNode,GraphNode>("/Commit"))
+@Tags("github", "build")
+class ReturnsEmptyPlanEventHandler implements HandleEvent<GraphNode,GraphNode> {
+
+  handle(event: Match<GraphNode, GraphNode>) {
+    return new Plan();
+  }
+}
+export let handler = new ReturnsEmptyPlanEventHandler()
+
+@EventHandler("ReturnsEmptyPlanEventHandler2", "Handles a new Commit event", 
+  new PathExpression<GraphNode,GraphNode>("/Commit/madeBy[@name='Ebony']"))
+@Tags("github", "issue")
+class ReturnsEmptyPlanEventHandler2 implements HandleEvent<GraphNode,GraphNode> {
+
+  handle(event: Match<GraphNode, GraphNode>) {
+    return new Plan();
+  }
+}
+export let handler2 = new ReturnsEmptyPlanEventHandler2()
+
+
+@EventHandler("ReturnsEmptyPlanEventHandler2a", "Handles a new Commit event", 
+  new PathExpression<node.Commit,node.Person>("/Commit/Person()[@name='Ebony']"))
+@Tags("github", "issue")
+class ReturnsEmptyPlanEventHandler2a implements HandleEvent<GraphNode,GraphNode> {
+
+  handle(m: Match<node.Commit, node.Person>) {
+    let peep = m.matches()[0]
+    console.log(`Match ${m}: peep=${peep}`)
+    return new Plan();
+  }
+}
+export let handler2a = new ReturnsEmptyPlanEventHandler2a()
+
+
+@EventHandler("ReturnsEmptyPlanEventHandler3", "Handles a new Commit event", 
+  new PathExpression<node.Commit,node.Person>(
+    `/Commit/Person()[@name='Ebony']/gitHubId
+    `))
+@Tags("github", "issue")
+class ReturnsEmptyPlanEventHandler3 implements HandleEvent<node.Commit,node.GitHubId> {
+ 
+  handle(m: Match<node.Commit, node.GitHubId>) {
+    let ghid: node.GitHubId = m.matches()[0]
+    console.log(`Developer's github id=${ghid.id()}`)
+    return new Plan();
+  }
+}
+export let handler3 = new ReturnsEmptyPlanEventHandler3()

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/Nodes.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/Nodes.ts
@@ -1,0 +1,53 @@
+
+import {GraphNode} from "@atomist/rug/tree/PathExpression"
+
+export class Commit implements GraphNode {
+
+    private _madeBy: Person = null
+
+    nodeName(): string {  return "Commit" }
+
+    // Node we need -dynamic to allow dispatch in the proxy
+    nodeTags(): string[] { return [ "Commit", "-dynamic" ] }
+
+    withMadeBy(p: Person): Commit {
+        this._madeBy = p 
+        return this
+    }
+
+    madeBy(): Person { return this._madeBy }
+
+}
+
+export class Person implements GraphNode {
+
+    private _gitHubId: GitHubId = null
+
+    constructor(private _name: string) {}
+
+    nodeName(): string {  return this._name }
+
+    nodeTags(): string[] { return [ "Person", "-dynamic" ] }
+
+    name(): string {  return this._name }
+
+    gitHubId() { return this._gitHubId } 
+
+    withGitHubId(g: GitHubId): Person {
+        this._gitHubId = g
+        return this
+    }
+
+}
+
+export class GitHubId implements GraphNode {
+
+    constructor(private _id: string) {}
+
+    nodeName(): string {  return this._id }
+
+    nodeTags(): string[] { return [ "GitHubId", "-dynamic" ] }
+
+    id(): string {  return this._id }
+
+}

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps.ts
@@ -1,0 +1,12 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsEmptyPlanEventHandler")
+   world.sendEvent(new node.Commit)
+})
+Then("excitement ensues", (p,world) => {
+    return world.plan().messages().length == 0
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2.ts
@@ -1,0 +1,13 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsEmptyPlanEventHandler2")
+   let c = new node.Commit().withMadeBy(new node.Person("Ebony"))
+   world.sendEvent(c)
+})
+Then("excitement ensues", (p,world) => {
+    return world.plan().messages().length == 0
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2a.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2a.ts
@@ -1,0 +1,13 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsEmptyPlanEventHandler2a")
+   let c = new node.Commit().withMadeBy(new node.Person("Ebony"))
+   world.sendEvent(c)
+})
+Then("excitement ensues", (p,world) => {
+    return world.plan().messages().length == 0
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps3.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps3.ts
@@ -1,0 +1,12 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsEmptyPlanEventHandler2")
+   world.sendEvent(new node.Commit)
+})
+Then("excitement ensues", (p,world) => {
+    return !world.plan()
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps4.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps4.ts
@@ -1,0 +1,15 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsEmptyPlanEventHandler3")
+   let c = new node.Commit().withMadeBy(
+       new node.Person("Ebony").withGitHubId(new node.GitHubId("gogirl"))
+    )
+   world.sendEvent(c)
+})
+Then("excitement ensues", (p,world) => {
+    return world.plan() != null
+})

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/NashornBackedGraphNodeTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/NashornBackedGraphNodeTest.scala
@@ -1,0 +1,245 @@
+package com.atomist.rug.runtime.js.interop
+
+import com.atomist.tree.TreeNode
+import jdk.nashorn.api.scripting.{NashornScriptEngine, NashornScriptEngineFactory}
+import org.scalatest.{FlatSpec, Matchers}
+
+class NashornBackedGraphNodeTest extends FlatSpec with Matchers {
+
+  val engine: NashornScriptEngine =
+    new NashornScriptEngineFactory()
+      .getScriptEngine("--optimistic-types", "--language=es6", "--no-java")
+      .asInstanceOf[NashornScriptEngine]
+
+  import com.atomist.rug.runtime.js.interop.NashornMapBackedGraphNode._
+
+  "toGraphNode" should "fail to convert null without error" in {
+    toGraphNode(null, "test") shouldBe empty
+  }
+
+  it should "fail to convert non Nashorn return without error" in {
+    toGraphNode(new Object(), "test") shouldBe empty
+  }
+
+  it should "get name and properties from simple node" in {
+    val n = engine.eval(
+      """
+        |{
+        |   var x = { nodeName: 'Gangster', forename: 'Johnny', surname: 'Caspar', nodeTags: ["tag1", "tag2"]};
+        |   x
+        |}
+      """.stripMargin
+    )
+    val gn = toGraphNode(n).get
+    assert(gn.nodeName === "Gangster")
+    assert(gn.relatedNodeNames === Set("forename", "surname"))
+    assert(gn.relatedNodesNamed("surname").size === 1)
+    val forename = gn.relatedNodesNamed("surname").head
+    assert(forename.asInstanceOf[TreeNode].value === "Caspar")
+    assert(gn.relatedNodes.size === 2)
+  }
+
+  it should "get tags from simple node" in {
+    val n = engine.eval(
+      """
+        |{
+        |   var x = { nodeName: 'Gangster', forename: 'Johnny', surname: 'Caspar', nodeTags: ["tag1", "tag2"]};
+        |   x
+        |}
+      """.stripMargin
+    )
+    val gn = toGraphNode(n).get
+    assert(gn.nodeTags === Set("tag1", "tag2"))
+  }
+
+  it should "get name and properties from nested node" in {
+    val rootName = "Gangster"
+    val n = engine.eval(
+      s"""
+        |{
+        |   var x = { nodeName: '$rootName', forename: 'Johnny', surname: 'Caspar',
+        |     associate: { nodeName: 'Leo', forename: 'Leo', nodeTags: ["Irish"]},
+        |     nodeTags: ["tag1", "tag2"]};
+        |   x
+        |}
+      """.stripMargin
+    )
+    val caspar = toGraphNode(n).get
+    assert(caspar.nodeName === rootName)
+    assert(caspar.relatedNodeNames === Set("forename", "surname", "Leo"))
+    assert(caspar.relatedNodesNamed("surname").size === 1)
+    val forename = caspar.relatedNodesNamed("surname").head
+    assert(forename.asInstanceOf[TreeNode].value === "Caspar")
+    assert(caspar.relatedNodesNamed("associate").size === 0)
+    val assoc = caspar.followEdge("associate").head
+    assert(assoc.nodeName === "Leo")
+    assert(assoc.nodeTags.contains("Irish"))
+    assert(assoc.relatedNodesNamed("forename").head.asInstanceOf[TreeNode].value === "Leo")
+  }
+
+  it should "get name and properties, including array of object, from nested node" in {
+    val rootName = "Gangster"
+    val n = engine.eval(
+      s"""
+         |{
+         |   var x = { nodeName: '$rootName', forename: 'Johnny', surname: 'Caspar',
+         |     associates: [
+         |      { nodeName: 'Leo', forename: 'Leo', nodeTags: ["Irish"]},
+         |      { nodeName: 'Tom', forename: 'Tom', nodeTags: ["Irish"]}
+         |     ],
+         |     nodeTags: ["tag1", "tag2"]};
+         |   x
+         |}
+      """.stripMargin
+    )
+    val caspar = toGraphNode(n).get
+    assert(caspar.nodeName === rootName)
+    assert(caspar.relatedNodeNames === Set("forename", "surname", "Leo", "Tom"))
+    assert(caspar.relatedNodesNamed("surname").size === 1)
+    val forename = caspar.relatedNodesNamed("surname").head
+    assert(forename.asInstanceOf[TreeNode].value === "Caspar")
+    assert(caspar.relatedNodesNamed("associates").size === 0)
+    caspar.followEdge("associates").size should be (2)
+    val assoc = caspar.followEdge("associates").head
+    assert(assoc.nodeName === "Leo")
+    assert(assoc.nodeTags.contains("Irish"))
+    assert(assoc.relatedNodesNamed("forename").head.asInstanceOf[TreeNode].value === "Leo")
+  }
+
+  it should "handle cycle expressed via scalar" in {
+    val rootName = "Gangster"
+    val n = engine.eval(
+      s"""
+         |{
+         |   var x = { nodeId: 211, nodeName: '$rootName', forename: 'Johnny', surname: 'Caspar',
+         |     associates: [
+         |      { nodeName: 'Leo', forename: 'Leo', nodeTags: ["Irish"], protects: { nodeRef: 211 } },
+         |      { nodeName: 'Tom', forename: 'Tom', nodeTags: ["Irish"]}
+         |     ],
+         |     nodeTags: ["tag1", "tag2"]};
+         |   x
+         |}
+      """.stripMargin
+    )
+    val caspar = toGraphNode(n).get
+    assert(caspar.nodeName === rootName)
+    assert(caspar.relatedNodeNames === Set("forename", "surname", "Leo", "Tom"))
+    assert(caspar.relatedNodesNamed("surname").size === 1)
+    val forename = caspar.relatedNodesNamed("surname").head
+    assert(forename.asInstanceOf[TreeNode].value === "Caspar")
+    assert(caspar.relatedNodesNamed("associates").size === 0)
+    caspar.followEdge("associates").size should be (2)
+    val assoc = caspar.followEdge("associates").head
+    assert(assoc.nodeName === "Leo")
+    assert(assoc.nodeTags.contains("Irish"))
+    assert(assoc.relatedNodesNamed("forename").head.asInstanceOf[TreeNode].value === "Leo")
+    assert(assoc.followEdge("protects").head == caspar)
+  }
+
+  it should "handle cycle expressed via array" in {
+    val rootName = "Gangster"
+    val n = engine.eval(
+      s"""
+         |{
+         |   var x = { nodeId: 211, nodeName: '$rootName', forename: 'Johnny', surname: 'Caspar',
+         |     associates: [
+         |      { nodeName: 'Leo', forename: 'Leo', nodeTags: ["Irish"], protects: [{ nodeRef: 211 }] },
+         |      { nodeName: 'Tom', forename: 'Tom', nodeTags: ["Irish"]}
+         |     ],
+         |     nodeTags: ["tag1", "tag2"]};
+         |   x
+         |}
+      """.stripMargin
+    )
+    val caspar = toGraphNode(n).get
+    assert(caspar.nodeName === rootName)
+    assert(caspar.relatedNodeNames === Set("forename", "surname", "Leo", "Tom"))
+    assert(caspar.relatedNodesNamed("surname").size === 1)
+    val forename = caspar.relatedNodesNamed("surname").head
+    assert(forename.asInstanceOf[TreeNode].value === "Caspar")
+    assert(caspar.relatedNodesNamed("associates").size === 0)
+    caspar.followEdge("associates").size should be (2)
+    val assoc = caspar.followEdge("associates").head
+    assert(assoc.nodeName === "Leo")
+    assert(assoc.nodeTags.contains("Irish"))
+    assert(assoc.relatedNodesNamed("forename").head.asInstanceOf[TreeNode].value === "Leo")
+    assert(assoc.followEdge("protects").head == caspar)
+  }
+
+  it should "get name and properties from simple node using functions" in
+    getNameAndPropertiesFromSimpleNode(
+      """
+        |{
+        |var Commit = (function () {
+        |    function Commit() {
+        |    }
+        |    Commit.prototype.nodeName = function () { return "Commit"; };
+        |    Commit.prototype.nodeTags = function () { return ["Commit", "GithubThing"]; };
+        |    Commit.prototype.forename = function () { return "Johnny"; };
+        |    Commit.prototype.surname = function () { return "Caspar"; };
+        |    //Commit.prototype.messThisUp = function (a) { return "Caspar" + a; };
+        |    return Commit;
+        |}());
+        |new Commit()
+        |}
+      """.stripMargin)
+
+  it should "get name and properties from simple node using functions backed by properties" in
+    getNameAndPropertiesFromSimpleNode(
+      """
+        |{
+        |var Commit = (function () {
+        |    function Commit() {
+        |    }
+        |    Commit.prototype._surname = null
+        |    Commit.prototype.nodeName = function () { return "Commit"; };
+        |    Commit.prototype.nodeTags = function () { return ["Commit", "GithubThing"]; };
+        |    Commit.prototype.forename = function () { return "Johnny"; };
+        |    Commit.prototype.surname = function () { return this._surname; };
+        |    Commit.prototype.setSurname = function (s) { this._surname = s; print("Set surname to " + s) };
+        |    return Commit;
+        |}());
+        |var c = new Commit()
+        |c.setSurname("Caspar")
+        |c
+        |}
+      """.stripMargin)
+
+  private def getNameAndPropertiesFromSimpleNode(s: String) {
+    val n = engine.eval(s)
+    val gn = toGraphNode(n).get
+    assert(gn.nodeName === "Commit")
+    //assert(gn.relatedNodeNames === Set("forename", "surname"))
+    assert(gn.relatedNodesNamed("surname").size === 1)
+    val surname = gn.relatedNodesNamed("surname").head
+    assert(surname.asInstanceOf[TreeNode].value === "Caspar")
+    assert(gn.relatedNodes.size >= 2)
+    assert(gn.nodeTags === Set("Commit", "GithubThing"))
+  }
+
+  it should "get name and properties from simple node using function relationship" in {
+    val n = engine.eval(
+      """
+        |{
+        |var Commit = (function () {
+        |    function Commit() {
+        |    }
+        |    Commit.prototype.nodeName = function () { return "Commit"; };
+        |    Commit.prototype.nodeTags = function () { return ["Commit", "GithubThing"]; };
+        |    Commit.prototype.forename = function () { return "Johnny"; };
+        |    Commit.prototype.surname = function () { return "Caspar"; };
+        |    Commit.prototype.raisedBy = function () { return { nodeName: 'Tom', name: 'Ebony', nodeTags: ["Person"]} };
+        |    return Commit;
+        |}());
+        |new Commit()
+        |}
+      """.stripMargin
+    )
+    val gn = toGraphNode(n).get
+    assert(gn.nodeName === "Commit")
+    val s = gn.followEdge("raisedBy")
+    assert(s.size === 1)
+    assert(s.head.relatedNodeNames.contains("name"))
+  }
+
+}

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
@@ -1,6 +1,7 @@
 package com.atomist.rug.runtime.js.interop
 
 import com.atomist.rug.RugRuntimeException
+import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.core.FileMutableView
 import com.atomist.source.StringFileArtifact
 import org.scalatest.{FlatSpec, Matchers}
@@ -10,7 +11,7 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
   it should "not allow invocation of non export function" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    val sc = new jsSafeCommittingProxy(fmv)
+    val sc = new jsSafeCommittingProxy(fmv, DefaultTypeRegistry)
     intercept[RugRuntimeException] {
       sc.getMember("bla")
     }
@@ -19,7 +20,7 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
   it should "fail for unregistered command function" in {
     val f = StringFileArtifact("name", "The quick brown jumped over the lazy dog")
     val fmv = new FileMutableView(f, null)
-    val sc = new jsSafeCommittingProxy(fmv)
+    val sc = new jsSafeCommittingProxy(fmv, DefaultTypeRegistry)
     intercept[RugRuntimeException] {
       sc.getMember("delete")
     }

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerTestTargets.scala
@@ -1,0 +1,25 @@
+package com.atomist.rug.test.gherkin.handler.command
+
+import com.atomist.source.StringFileArtifact
+
+object CommandHandlerTestTargets {
+
+  val Feature1 =
+    """
+      |Feature: Australian political history
+      | This is a test
+      | to demonstrate that the Gherkin DSL
+      | is a good fit for Rug BDD testing
+      |
+      |Scenario: Australian politics, 1972-1991
+      | Given a sleepy country
+      | When a visionary leader enters
+      | Then excitement ensues
+    """.stripMargin
+
+  val Feature1File = StringFileArtifact(
+    ".atomist/test/handlers/command/Feature1.feature",
+    Feature1
+  )
+
+}

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
@@ -1,0 +1,87 @@
+package com.atomist.rug.test.gherkin.handler.command
+
+import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig, RugArchiveReader}
+import com.atomist.rug.TestUtils._
+import com.atomist.rug.runtime.js.JavaScriptContext
+import com.atomist.rug.test.gherkin.{GherkinRunner, Passed}
+import com.atomist.rug.ts.TypeScriptBuilder
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.scalatest.{FlatSpec, Matchers}
+
+class GherkinRunnerCommandHandlerTest extends FlatSpec with Matchers {
+
+  import CommandHandlerTestTargets._
+
+  val atomistConfig: AtomistConfig = DefaultAtomistConfig
+
+  "command handler testing" should "verify no plan steps" in {
+    val passingFeature1Steps =
+      """
+        |import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+        |
+        |Given("a sleepy country", f => {
+        | console.log("Given invoked for handler")
+        |})
+        |When("a visionary leader enters", (rugContext, world) => {
+        |   let handler = world.commandHandler("ReturnsEmptyPlanCommandHandler")
+        |   world.invokeHandler(handler, {})
+        |})
+        |Then("excitement ensues", (p,world) => {
+        |    return world.plan().messages().length == 0
+        |})
+      """.stripMargin
+    val passingFeature1StepsFile = StringFileArtifact(
+      ".atomist/test/handlers/command/PassingFeature1Step.ts",
+      passingFeature1Steps
+    )
+
+    val handlerName = "ReturnsEmptyPlanCommandHandler.ts"
+    val handlerFile = requiredFileInPackage(this, "CommandHandlers.ts").withPath(atomistConfig.handlersRoot + "/command/" + handlerName)
+    val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile)
+
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Some(RugArchiveReader.find(cas)))
+    val run = grt.execute()
+    //println(new TestReport(run))
+    run.result match {
+      case Passed =>
+      case wtf => fail(s"Unexpected: $wtf")
+    }
+  }
+
+  it should "verify single returned message" in {
+    val passingFeature1Steps =
+      """
+        |import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+        |
+        |Given("a sleepy country", f => {
+        | console.log("Given invoked for handler")
+        |})
+        |When("a visionary leader enters", (rugContext, world) => {
+        |   let handler = world.commandHandler("ReturnsOneMessageCommandHandler")
+        |   world.invokeHandler(handler, {})
+        |})
+        |Then("excitement ensues", (p,world) => {
+        |   console.log("The plan message were " + world.plan().messages())
+        |    return world.plan().messages().length == 1
+        |})
+      """.stripMargin
+    val passingFeature1StepsFile = StringFileArtifact(
+      ".atomist/test/handlers/PassingFeature1Step.ts",
+      passingFeature1Steps
+    )
+
+    val handlerName = "ReturnsOneMessageCommandHandler.ts"
+    val handlerFile = requiredFileInPackage(this, "CommandHandlers.ts").withPath(atomistConfig.handlersRoot + "/command/" + handlerName)
+    val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile)
+
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Some(RugArchiveReader.find(cas)))
+    val run = grt.execute()
+    //println(new TestReport(run))
+    run.result match {
+      case Passed =>
+      case wtf => fail(s"Unexpected: $wtf")
+    }
+  }
+}

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerTestTargets.scala
@@ -1,0 +1,25 @@
+package com.atomist.rug.test.gherkin.handler.event
+
+import com.atomist.source.StringFileArtifact
+
+object EventHandlerTestTargets {
+
+  val Feature1 =
+    """
+      |Feature: Australian political history
+      | This is a test
+      | to demonstrate that the Gherkin DSL
+      | is a good fit for Rug BDD testing
+      |
+      |Scenario: Australian politics, 1972-1991
+      | Given a sleepy country
+      | When a visionary leader enters
+      | Then excitement ensues
+    """.stripMargin
+
+  val Feature1File = StringFileArtifact(
+    ".atomist/test/handlers/event/Feature1.feature",
+    Feature1
+  )
+
+}

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
@@ -1,0 +1,89 @@
+package com.atomist.rug.test.gherkin.handler.event
+
+import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig, RugArchiveReader}
+import com.atomist.rug.TestUtils._
+import com.atomist.rug.runtime.js.JavaScriptContext
+import com.atomist.rug.test.gherkin.{GherkinRunner, Passed}
+import com.atomist.rug.ts.TypeScriptBuilder
+import com.atomist.source.{ArtifactSourceUtils, FileArtifact, SimpleFileBasedArtifactSource}
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Files ending with "a" are identical in effect
+  */
+class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
+
+  import EventHandlerTestTargets._
+
+  val atomistConfig: AtomistConfig = DefaultAtomistConfig
+
+  val nodesFile: FileArtifact = requiredFileInPackage(this, "Nodes.ts", ".atomist/handlers/event")
+
+
+  "event handler testing" should "verify no plan steps without any path match" in {
+    val passingFeature1StepsFile = requiredFileInPackage(
+      this,
+      "PassingFeature1Steps.ts",
+      ".atomist/test/handlers/event"
+    )
+
+    val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")
+    val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile, nodesFile)
+
+    //println(ArtifactSourceUtils.prettyListFiles(as))
+    val cas = TypeScriptBuilder.compileWithModel(as)
+
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Some(RugArchiveReader.find(cas)))
+    val run = grt.execute()
+    run.result match {
+      case Passed =>
+      case wtf => fail(s"Unexpected: $wtf")
+    }
+  }
+
+  it should "verify no plan steps with matching simple path match" in
+    verifyNoPlanStepsWithMatchingSimplePathMatch("PassingFeature1Steps2.ts")
+
+  it should "verify no plan steps with matching simple path match using named type" in
+    verifyNoPlanStepsWithMatchingSimplePathMatch("PassingFeature1Steps2a.ts")
+
+  it should "verify no plan steps with matching deeper path match" in
+    verifyNoPlanStepsWithMatchingSimplePathMatch("PassingFeature1Steps4.ts")
+
+
+  def verifyNoPlanStepsWithMatchingSimplePathMatch(stepsFile: String) {
+    val passingFeature1StepsFile = requiredFileInPackage(
+      this,
+      stepsFile,
+      ".atomist/test/handler/event"
+    )
+    val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")
+    val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile, nodesFile)
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Some(RugArchiveReader.find(cas)))
+    val run = grt.execute()
+    run.result match {
+      case Passed =>
+      case wtf => fail(s"Unexpected: $wtf")
+    }
+  }
+
+  it should "verify no plan steps with non-matching simple path match" in {
+    val passingFeature1StepsFile = requiredFileInPackage(
+      this,
+      "PassingFeature1Steps3.ts",
+      ".atomist/test/handler/event"
+    )
+
+    val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")
+    val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile, nodesFile)
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Some(RugArchiveReader.find(cas)))
+    val run = grt.execute()
+    run.result match {
+      case Passed =>
+      case wtf => fail(s"Unexpected: $wtf")
+    }
+  }
+
+}


### PR DESCRIPTION
This work isn't finished, but this branch has touched enough files that it seems prudent to avoid conflicts. Changes to existing code are stable.

Per #414, this extends the BDD test framework to test command and event handlers. The idea is that objects can be constructed in JS/TS and used to test path expressions. This model should be very productive, especially when we provide generated test stubs.

Beyond the new functionality, the following changes were necessary:

- Ensure that the current `TypeRegistry` is passed to even new `jsSafeCommittingProxy` instance, add it to the `RugContext`
- Clean up signatures of BDD test `ScenarioWorld`

Please squash.