### PR TITLE
bug fix: Multiple uses of submatcher returned only the first one

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -241,3 +241,18 @@ editor:
   parameters:
     - "class_under_test": "com.atomist.tree.content.text.microgrammar.MatcherMicrogrammarConstruction"
 
+---
+kind: "operation"
+client: "rug-cli 0.25.0"
+editor:
+  name: "AddTypeScriptTest"
+  group: "atomist"
+  artifact: "rug"
+  version: "0.2.0"
+  origin:
+    repo: "git@github.com:atomist/rug"
+    branch: "multiple-use-of-submatcher"
+    sha: "e4e5a1e"
+  parameters:
+    - "class_under_test": "com.atomist.tree.content.text.microgrammar.MultipleUseOfSubmatcher"
+

--- a/src/main/typescript/node_modules/@atomist/rug/ast/scala/Types.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/scala/Types.ts
@@ -9,8 +9,8 @@
  * Classes with "Ops" suffix are additional operations.
  */
 
-import {TreeNode,PathExpression,PathExpressionEngine,Match,TextTreeNode} from "../../tree/PathExpression"
-import {TextTreeNodeOps} from "../TextTreeNodeOps"
+import { TextTreeNode } from "../../tree/PathExpression"
+import { TextTreeNodeOps } from "../TextTreeNodeOps"
 
 export interface SourceNav extends TextTreeNode {
      
@@ -102,11 +102,11 @@ export class TermApplyInfixOps extends TextTreeNodeOps<TermApplyInfix> {
 
     reverseShould() {
         //console.log(`Containing file=${this.containingFile()}`)
-        let termSelect = this.node.termSelect()
-        let termApply = this.node.termApply()
+        let termSelect = this.node.termSelect();
+        let termApply = this.node.termApply();
 
         if (termApply != null && ["be", "equal"].indexOf(termApply.termName().value()) > -1) {
-          let newValue = `assert(${termSelect.value()} === ${termApply.children()[1].value()})`
+          let newValue = `assert(${termSelect.value()} === ${termApply.children()[1].value()})`;
           //console.log(`Replacing [${shouldTerm.value()}] with [${newValue}]`)
           this.node.update(newValue)
         }

--- a/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
@@ -1,8 +1,6 @@
 import {Project,File} from '@atomist/rug/model/Core'
 import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-import {PathExpression,TextTreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
 import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-import {Match} from '@atomist/rug/tree/PathExpression'
 import {ScalaPathExpressionEngine} from '@atomist/rug/ast/scala/ScalaPathExpressionEngine'
 import * as scala from '@atomist/rug/ast/scala/Types'
 
@@ -30,18 +28,18 @@ class UpgradeScalaTestAssertions implements ProjectEditor {
                 TermName:[be]
                 Lit:[2]
       */
-      let oldAssertion = `/src/test/scala//ScalaFile()//termApplyInfix[/termName[@value='should']][termSelect]`
+      let oldAssertion = `/src/test/scala//ScalaFile()//termApplyInfix[/termName[@value='should']][termSelect]`;
 
       eng.with<scala.TermApplyInfix>(project, oldAssertion, shouldTerm => {
         //console.log(`ShouldTerm=${shouldTerm}`)
 
-        let termSelect = shouldTerm.termSelect()
-        let termApply = shouldTerm.termApply()
+        let termSelect = shouldTerm.termSelect();
+        let termApply = shouldTerm.termApply();
 
         if (termSelect == null)
           throw new Error(`termSelect should be navigable and non-null`)
 
-        shouldTerm.reverseShould()
+        shouldTerm.reverseShould();
 
         // console.log ("About to new absquatulate")
         // shouldTerm.absquatulate()

--- a/src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/rug/ts/SampleTypeScriptTest.ts
@@ -1,14 +1,19 @@
-import { Project } from '@atomist/rug/model/Core'
+import { Project, File } from '@atomist/rug/model/Core'
 import { Editor } from '@atomist/rug/operations/Decorators'
+import { PathExpressionEngine, Microgrammar } from '@atomist/rug/tree/PathExpression'
 
 @Editor("SampleTypeScriptTest", "Uses Sample from TypeScript")
 class SampleTypeScriptTest {
 
     edit(project: Project) {
 
-        let pom = project.findFile('pom.xml');
+        // or you can do this: let pom = project.findFile('pom.xml');
 
-        pom.replace('dependency', 'dependenciesAreForBirds');
+        let eng : PathExpressionEngine = project.context().pathExpressionEngine();
+
+        eng.with<File>(project, `/File()[@name="pom.xml"]`, pom => {
+            pom.replace('dependency', 'dependenciesAreForBirds');
+        })
 
     }
 }

--- a/src/test/resources/com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.ts
@@ -1,0 +1,30 @@
+import { Project, File } from '@atomist/rug/model/Core'
+import { Editor } from '@atomist/rug/operations/Decorators'
+import { PathExpressionEngine, Microgrammar } from '@atomist/rug/tree/PathExpression'
+
+@Editor("MultipleUseOfSubmatcherTypeScriptTest", "Uses MultipleUseOfSubmatcher from TypeScript")
+class MultipleUseOfSubmatcherTypeScriptTest {
+
+    edit(project: Project) {
+
+        let mg = new Microgrammar('things', 'I like $something, $something, $something, and $something.',
+            { something: '§[a-z]+§'});
+
+        let eng : PathExpressionEngine = project.context().pathExpressionEngine().addType(mg);
+
+        eng.with<any>(project, `/File()[@name="targetFile"]/things()`, things => {
+
+            console.log("here we go");
+            let somethings = things.something();
+
+          //  console.log(`the whole thing is ${things} and the somethings are ${somethings}`);
+
+            somethings[0].update("(1) " + somethings[0].value());
+            somethings[1].update("(2) " + somethings[1].value());
+            somethings[2].update("(3) " + somethings[2].value());
+            somethings[3].update("(4) " + somethings[3].value());
+        })
+
+    }
+}
+export let editor = new MultipleUseOfSubmatcherTypeScriptTest();

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.scala
@@ -1,0 +1,48 @@
+package com.atomist.tree.content.text.microgrammar
+
+import com.atomist.param.SimpleParameterValues
+import com.atomist.project.archive.RugArchiveReader
+import com.atomist.project.edit.SuccessfulModification
+import com.atomist.rug.ts.TypeScriptBuilder
+import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
+import com.atomist.source.file.ClassPathArtifactSource
+import org.scalatest.{FlatSpec, Matchers}
+
+class MultipleUseOfSubmatcherTypeScriptTest extends FlatSpec with Matchers {
+
+  val inputFile = "I like broccoli, carrots, bananas, and ponies."
+  val modifiedFile = "I like (1) broccoli, (2) carrots, (3) bananas, and (4) ponies."
+
+  def singleFileArtifactSource(name: String, content:String):ArtifactSource =
+    new SimpleFileBasedArtifactSource("whatever", Seq(StringFileArtifact(name, content)))
+
+  it should "use multiple submatchers" in {
+
+    val tsEditorResource = "com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.ts"
+    val parameters = SimpleParameterValues.Empty
+    val fileThatWillBeModified = "targetFile"
+    val target = singleFileArtifactSource(fileThatWillBeModified, inputFile)
+
+    // construct the Rug archive
+    val artifactSourceWithEditor = ClassPathArtifactSource.toArtifactSource(tsEditorResource).withPathAbove(".atomist/editors")
+    val artifactSourceWithRugNpmModule = TypeScriptBuilder.compileWithModel(artifactSourceWithEditor)
+    //println(s"rug archive: $artifactSourceWithEditor")
+
+    // get the operation out of the artifact source
+    val projectEditor = RugArchiveReader.find(artifactSourceWithRugNpmModule).editors.head
+
+    // apply the operation
+    projectEditor.modify(target, parameters) match {
+      case sm: SuccessfulModification =>
+        val contents = sm.result.findFile(fileThatWillBeModified).get.content
+        withClue(s"contents of $fileThatWillBeModified are:<$contents>") {
+          // check the results
+          contents should be(modifiedFile)
+        }
+
+      case boo => fail(s"Modification was not successful: $boo")
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is a change in how we wrap the results of childNodes.
We were throwing them away if we got more than one. Now we return our JavaScriptArray wrapper.