### PR TITLE
Move test directory back to tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/atomist/rug/compare/0.13.0...HEAD
+[Unreleased]: https://github.com/atomist/rug/compare/0.14.0...HEAD
+
+## [0.14.0] - 2017-03-15
+
+[0.14.0]: https://github.com/atomist/rug/compare/0.13.0...0.14.0
+
+Ides of March release
+
+### Changes
+
+-   TypeDoc, ScalaDoc, and scoverage reports are now published
+    automatically
+-   Xml extension can now derive itself from a file
+
+### Added
+
+-   Command and event handler testing
+-   TypeScript "it should fail" test step via @justinedelson #429
+-   Xml `addNodeIfNotPresent` via @justinedelson #423
+
+### Fixed
+
+-   TypeScript interface and class generation #427
 
 ## [0.13.0] - 2017-03-10
 

--- a/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
@@ -23,11 +23,11 @@ object DefaultExecutableFeatureFactory extends ExecutableFeatureFactory {
                                     rugs: Option[Rugs],
                                     listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_] = {
     // TODO clean up name of test directory
-    if (f.definition.path.contains(s"test/project"))
+    if (f.definition.path.contains(s"${atomistConfig.testsDirectory}/project"))
       new ProjectManipulationFeature(f, definitions, rugAs, rugs, listeners)
-    else if (f.definition.path.contains(s"test/${atomistConfig.handlersDirectory}/command"))
+    else if (f.definition.path.contains(s"${atomistConfig.testsDirectory}/${atomistConfig.handlersDirectory}/command"))
       new CommandHandlerFeature(f, definitions, rugAs, rugs, listeners)
-    else if (f.definition.path.contains(s"test/${atomistConfig.handlersDirectory}/event"))
+    else if (f.definition.path.contains(s"${atomistConfig.testsDirectory}/${atomistConfig.handlersDirectory}/event"))
       new EventHandlerFeature(f, definitions, rugAs, rugs, listeners)
     else {
       throw new IllegalArgumentException(s"Cannot handle path [${f.definition.path}]: Paths must be of form [${atomistConfig.testsDirectory}/project] or [${atomistConfig.testsDirectory}/handlers]")

--- a/src/test/scala/com/atomist/rug/test/gherkin/GherkinReaderTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/GherkinReaderTest.scala
@@ -70,8 +70,8 @@ object GherkinReaderTest {
       | Then everything's done
     """.stripMargin
 
-  val SimpleFeatureFile = StringFileArtifact(".atomist/test/project/Simple.feature", Simple)
+  val SimpleFeatureFile = StringFileArtifact(".atomist/tests/project/Simple.feature", Simple)
 
-  val TwoScenarioFeatureFile = StringFileArtifact(".atomist/test/project/Two.feature", TwoScenarios)
+  val TwoScenarioFeatureFile = StringFileArtifact(".atomist/tests/project/Two.feature", TwoScenarios)
 
 }

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerTestTargets.scala
@@ -18,7 +18,7 @@ object CommandHandlerTestTargets {
     """.stripMargin
 
   val Feature1File = StringFileArtifact(
-    ".atomist/test/handlers/command/Feature1.feature",
+    ".atomist/tests/handlers/command/Feature1.feature",
     Feature1
   )
 

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
@@ -31,7 +31,7 @@ class GherkinRunnerCommandHandlerTest extends FlatSpec with Matchers {
         |})
       """.stripMargin
     val passingFeature1StepsFile = StringFileArtifact(
-      ".atomist/test/handlers/command/PassingFeature1Step.ts",
+      ".atomist/tests/handlers/command/PassingFeature1Step.ts",
       passingFeature1Steps
     )
 
@@ -67,7 +67,7 @@ class GherkinRunnerCommandHandlerTest extends FlatSpec with Matchers {
         |})
       """.stripMargin
     val passingFeature1StepsFile = StringFileArtifact(
-      ".atomist/test/handlers/PassingFeature1Step.ts",
+      ".atomist/tests/handlers/PassingFeature1Step.ts",
       passingFeature1Steps
     )
 

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerTestTargets.scala
@@ -18,7 +18,7 @@ object EventHandlerTestTargets {
     """.stripMargin
 
   val Feature1File = StringFileArtifact(
-    ".atomist/test/handlers/event/Feature1.feature",
+    ".atomist/tests/handlers/event/Feature1.feature",
     Feature1
   )
 

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
@@ -24,7 +24,7 @@ class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
     val passingFeature1StepsFile = requiredFileInPackage(
       this,
       "PassingFeature1Steps.ts",
-      ".atomist/test/handlers/event"
+      ".atomist/tests/handlers/event"
     )
 
     val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")
@@ -55,7 +55,7 @@ class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
     val passingFeature1StepsFile = requiredFileInPackage(
       this,
       stepsFile,
-      ".atomist/test/handler/event"
+      ".atomist/tests/handler/event"
     )
     val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")
     val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile, nodesFile)
@@ -72,7 +72,7 @@ class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
     val passingFeature1StepsFile = requiredFileInPackage(
       this,
       "PassingFeature1Steps3.ts",
-      ".atomist/test/handler/event"
+      ".atomist/tests/handler/event"
     )
 
     val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
@@ -118,7 +118,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
     val as = TestUtils.resourcesInPackage(this).withPathAbove(".atomist/editors") +
       SimpleFileBasedArtifactSource(
         CorruptionFeatureFile,
-        StringFileArtifact(".atomist/test/project/CorruptionSteps.ts", CorruptionTest)
+        StringFileArtifact(".atomist/tests/project/CorruptionSteps.ts", CorruptionTest)
       )
     val cas = TypeScriptBuilder.compileWithModel(as)
     val grt = new GherkinRunner(new JavaScriptContext(cas))
@@ -136,7 +136,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
         .withPathAbove(".atomist/editors") +
         SimpleFileBasedArtifactSource(
           GenerationFeatureFile,
-          StringFileArtifact(".atomist/test/project/GenerationSteps.ts", generationTest("SimpleGenerator", Map()))
+          StringFileArtifact(".atomist/tests/project/GenerationSteps.ts", generationTest("SimpleGenerator", Map()))
         )
 
     val projTemplate = ParsingTargets.NewStartSpringIoProject
@@ -159,7 +159,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
         .withPathAbove(".atomist/editors") +
         SimpleFileBasedArtifactSource(
           GenerationFeatureFile,
-          StringFileArtifact(".atomist/test/project/GenerationSteps.ts",
+          StringFileArtifact(".atomist/tests/project/GenerationSteps.ts",
             generationTest("SimpleGeneratorWithParams", Map("text" -> "`Anders Hjelsberg is God`")))
         )
 
@@ -176,7 +176,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
       TestUtils.resourcesInPackage(this).filter(_ => true, f => f.name == "SimpleGeneratorWithParams.ts")
         .withPathAbove(".atomist/editors") +
         SimpleFileBasedArtifactSource(StringFileArtifact(
-          ".atomist/test/project/Simple.feature",
+          ".atomist/tests/project/Simple.feature",
           """
             |Feature: Generate a new project
             | This is a test
@@ -188,7 +188,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
             | When run simple generator
             | Then parameters were invalid
           """.stripMargin),
-          StringFileArtifact(".atomist/test/project/GenerationSteps.ts",
+          StringFileArtifact(".atomist/tests/project/GenerationSteps.ts",
             generateWithInvalidParameters("SimpleGeneratorWithParams", Map("text" -> "`Anders Hjelsberg is 1God`")))
         )
 
@@ -209,7 +209,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
         .withPathAbove(".atomist/generators") +
         SimpleFileBasedArtifactSource(
           GenerationFeatureFile,
-          StringFileArtifact(".atomist/test/project/GenerationSteps.ts", generationTest("FailingGenerator", Map()))
+          StringFileArtifact(".atomist/tests/project/GenerationSteps.ts", generationTest("FailingGenerator", Map()))
         )
 
     val projTemplate = ParsingTargets.NewStartSpringIoProject
@@ -224,7 +224,7 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
     val as = TestUtils.resourcesInPackage(this).withPathAbove(".atomist/editors") +
       SimpleFileBasedArtifactSource(
         CorruptionFeatureFile,
-        StringFileArtifact(".atomist/test/project/CorruptionSteps.ts", CorruptionTest)
+        StringFileArtifact(".atomist/tests/project/CorruptionSteps.ts", CorruptionTest)
       )
     val cas = TypeScriptBuilder.compileWithModel(as)
     val grt1 = new GherkinRunner(new JavaScriptContext(cas))

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
@@ -111,7 +111,7 @@ object ProjectTestTargets {
     """.stripMargin
 
   val CorruptionFeatureFile = StringFileArtifact(
-    ".atomist/test/project/Corruption.feature",
+    ".atomist/tests/project/Corruption.feature",
     CorruptionFeature)
 
   val CorruptionTest =
@@ -157,7 +157,7 @@ object ProjectTestTargets {
     """.stripMargin
 
   val GenerationFeatureFile = StringFileArtifact(
-    ".atomist/test/project/Generation.feature",
+    ".atomist/tests/project/Generation.feature",
     GenerationFeature)
 
   /**


### PR DESCRIPTION
While the singular is more common, it would be best to do this
consistently, i.e., change all .atomist subdirectories to be singular,
and allowing for backward compatibility for a release or two.