### PR TITLE
Add ArchiveRoot step, TypeDoc test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     handlers to run path expressions as needed.  This change impacts
     runtime as well as testing, but is necessary to support our
     programming model.
+-   Gherkin testing "the archive root" Given
+-   TypeScript test documentation to generated TypeDoc
 
 ### Changed
 

--- a/src/main/typescript/node_modules/@atomist/rug/gulpfile.js
+++ b/src/main/typescript/node_modules/@atomist/rug/gulpfile.js
@@ -5,7 +5,7 @@ gulp.task("default", ["typedoc"]);
 
 gulp.task("typedoc", function () {
     return gulp
-        .src(["./model", "./ast"])
+        .src(["./model", "./ast", "./test"])
         .pipe(typedoc({
             module: "commonjs",
             target: "ES5",

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -1,7 +1,7 @@
-import {ScenarioWorld} from "../ScenarioWorld"
-import {Result} from "../Result"
-import {Plan} from "../../operations/Handlers"
-import {GraphNode} from "../../tree/PathExpression"
+import { ScenarioWorld } from "../ScenarioWorld"
+import { Result } from "../Result"
+import { Plan } from "../../operations/Handlers"
+import { GraphNode } from "../../tree/PathExpression"
 
 /**
  * All handler scenario worlds expose the plan,
@@ -23,17 +23,17 @@ export interface HandlerScenarioWorld extends ScenarioWorld {
 }
 
 /**
- * Subinterface of ScenarioWorld specific to 
+ * Subinterface of ScenarioWorld specific to
  * scenarios testing project operations
  */
 export interface CommandHandlerScenarioWorld extends HandlerScenarioWorld {
-    
+
     /**
      * Return the CommandHandler with the given name, or null if none is found.
      * Pass to invokeHandler
      */
     commandHandler(name: string): any
-    
+
     /**
      * Execute the given handler, validating parameters
      */
@@ -42,20 +42,20 @@ export interface CommandHandlerScenarioWorld extends HandlerScenarioWorld {
 }
 
 export interface EventHandlerScenarioWorld extends HandlerScenarioWorld {
-    
+
     /**
      * Register the named handler to respond to input
      * Return the handler, or null if none is found.
      */
     registerHandler(name: string): any
-    
+
     /**
      * Publish the given event. Should be materialized
      */
     sendEvent(n: GraphNode): void
 }
 
- 
+
 interface Definitions {
 
     Given(s: string, f: (Project, HandlerScenarioWorld?) => void): void
@@ -63,22 +63,22 @@ interface Definitions {
     When(s: string, f: (Project, HandlerScenarioWorld?) => void): void
 
     Then(s: string, f: (Project, HandlerScenarioWorld?) => Result | boolean): void
-    
+
 }
 
  // Registered with Nashorn by the test runner
 declare var com_atomist_rug_test_gherkin_GherkinRunner$_definitions: Definitions
 
-export function Given(s: string, f: (Project, HandlerScenarioWorld?) => void) { 
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f) 
+export function Given(s: string, f: (Project, HandlerScenarioWorld?) => void) {
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f)
 }
 
-export function When(s: string, f: (Project, HandlerScenarioWorld?) => void) { 
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f) 
+export function When(s: string, f: (Project, HandlerScenarioWorld?) => void) {
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f)
 }
 
-export function Then(s: string, f: (Project, HandlerScenarioWorld?) => Result | boolean) { 
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f) 
+export function Then(s: string, f: (Project, HandlerScenarioWorld?) => Result | boolean) {
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f)
 }
 
 // Import well-known step definitions. It's nicer

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
@@ -1,11 +1,11 @@
-import {Project} from "../../model/Core"
-import {ProjectEditor} from "../../operations/ProjectEditor"
-import {ProjectGenerator} from "../../operations/ProjectGenerator"
-import {ScenarioWorld} from "../ScenarioWorld"
-import {Result} from "../Result"
+import { Project } from "../../model/Core"
+import { ProjectEditor } from "../../operations/ProjectEditor"
+import { ProjectGenerator } from "../../operations/ProjectGenerator"
+import { ScenarioWorld } from "../ScenarioWorld"
+import { Result } from "../Result"
 
 /**
- * Subinterface of ScenarioWorld specific to 
+ * Subinterface of ScenarioWorld specific to
  * scenarios testing project operations
  */
 export interface ProjectScenarioWorld extends ScenarioWorld {
@@ -31,7 +31,10 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
     generateWith(gen: ProjectGenerator, params?: {})
 
     /**
-     * How many modifications did editors in this scenario make?
+     * How many modifications did editors in this scenario make?  Note
+     * the initial population of a project prior to entering the
+     * generator 'populate' method does not contribute to the number
+     * of modifications returned by this method.
      */
     modificationsMade(): number
 
@@ -45,7 +48,7 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
      */
     editorsRun(): number
 }
- 
+
 interface Definitions {
 
     Given(s: string, f: (Project, ProjectScenarioWorld?) => void): void
@@ -53,22 +56,22 @@ interface Definitions {
     When(s: string, f: (Project, ProjectScenarioWorld?) => void): void
 
     Then(s: string, f: (Project, ProjectScenarioWorld?) => Result | boolean): void
-    
+
 }
 
  // Registered with Nashorn by the test runner
 declare var com_atomist_rug_test_gherkin_GherkinRunner$_definitions: Definitions
 
-export function Given(s: string, f: (Project, ProjectScenarioWorld?) => void) { 
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f) 
+export function Given(s: string, f: (Project, ProjectScenarioWorld?) => void) {
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f)
 }
 
-export function When(s: string, f: (Project, ProjectScenarioWorld?) => void) { 
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f) 
+export function When(s: string, f: (Project, ProjectScenarioWorld?) => void) {
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f)
 }
 
-export function Then(s: string, f: (Project, ProjectScenarioWorld?) => Result | boolean) { 
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f) 
+export function Then(s: string, f: (Project, ProjectScenarioWorld?) => Result | boolean) {
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f)
 }
 
 // Import well-known step definitions. It's nicer

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
@@ -2,19 +2,42 @@ import {Given, When, Then} from "./Core"
 
 // Register well-known steps
 
+/**
+ * Empty project
+ */
 Given("an empty project", p => {
-    // Nothing to do
-})
+    /* Nothing to do */
+});
 
+/**
+ * ArchiveRoot project
+ */
+Given("the archive root", p => {
+    p.copyEditorBackingFilesPreservingPath("");
+});
+
+/**
+ * Editor made changes
+ */
 Then("changes were made", (p, world) => {
     return world.modificationsMade()
-})
+});
 
+/**
+ * Editor made NoChange
+ */
 Then("no changes were made", (p, world) => {
     return !world.modificationsMade()
-})
+});
 
-Then("parameters were invalid", 
-    (p, world) => world.invalidParameters() != null)
+/**
+ * Invalid parameters
+ */
+Then("parameters were invalid", (p, world) => {
+    return world.invalidParameters() != null;
+});
 
+/**
+ * When step should fail
+ */
 Then("it should fail", (p, world) => world.failed())


### PR DESCRIPTION
Add a well-known step for the DSL ArchiveRoot.

Include the test directory in the generated TypeDoc (is there a reason
operations and tree are not?).

Clean up TypeScript formatting.

Make TypeDoc on ScenarioWorld.modificationsMade clear that the initial
population of the project by a generator does not count as a
modification.

Possible closes #426