### PR TITLE
TypeScript cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   **BREAKING** Removed `TreeHelper` class. This module now contains only
+    functions, as a class was not necessary.
 -   **BREAKING** Python Requirements old type has been removed as it
     was not matching the current programming model.  It will be moved
     to its own project.  [#434][434]

--- a/src/main/typescript/node_modules/@atomist/rug/ast/AstHelper.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/AstHelper.ts
@@ -1,5 +1,5 @@
 import {TreeNode,TextTreeNode,ParentAwareTreeNode,PathExpressionEngine} from "../tree/PathExpression"
-import {TreeHelper} from "../tree/TreeHelper"
+import * as treeHelper from "../tree/TreeHelper"
 
 import {File} from "../model/Core"
 
@@ -10,13 +10,11 @@ export class AstHelper {
 
     public constructor(public pexe: PathExpressionEngine) {}
 
-    protected treeHelper = new TreeHelper()
-
     /**
      * Reparse this file, given the type and return the top level node.
      */
     protected reparseNodeUnderFile(languageNode: TextTreeNode, type: String): TextTreeNode {
-        let f = this.treeHelper.findAncestorWithTag<File>(languageNode, "File")
+        let f = treeHelper.findAncestorWithTag<File>(languageNode, "File")
         if (f) {
             let pathExpression = `/${type}()`
             let r = this.pexe.scalarStr<File,TextTreeNode>(f, pathExpression)

--- a/src/main/typescript/node_modules/@atomist/rug/ast/TextTreeNodeOps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/TextTreeNodeOps.ts
@@ -1,11 +1,9 @@
 import {PathExpressionEngine,TextTreeNode} from "../tree/PathExpression"
 import {AstHelper} from "./AstHelper"
-import {TreeHelper} from "../tree/TreeHelper"
+import * as treeHelper from "../tree/TreeHelper"
 import {ReviewComment,Severity} from "../operations/RugOperation"
 
 import {File} from "../model/Core"
-
-let treeHelper = new TreeHelper()
 
 /** 
  * Base class for decorators on node.

--- a/src/main/typescript/node_modules/@atomist/rug/ast/java/Types.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/java/Types.ts
@@ -11,4 +11,4 @@ export class Catch extends PathExpression<Project,TextTreeNode> {
     }
 }
 
-export let CatchException = new Catch("Exception")
+export const CatchException = new Catch("Exception")

--- a/src/main/typescript/node_modules/@atomist/rug/tree/TreeHelper.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/TreeHelper.ts
@@ -1,72 +1,75 @@
+/**
+ * Helper functions for working with TreeNodes in simple
+ * cases where we don't need a path expression.
+ */
+
 import {Addressed,TreeNode,TextTreeNode,ParentAwareTreeNode} from "./PathExpression"
 
 export function hasTag(n: TreeNode, t: string): boolean {
     return n.nodeTags().indexOf(t) > -1
 }
 
-/**
- * Helper functions for working with TreeNodes in simple
- * cases where we don't need a path expression.
- */
-export class TreeHelper {
-
-    findPathFromAncestor(n: ParentAwareTreeNode, nodeTest: (TextTreeNode) => boolean): string {
-        let parent = n.parent() as any // Makes checking for parent function later easy
-        if (parent == null) {
-            // We couldn't resolve the path
-            return null
-        }
-        else if (nodeTest(parent)) {
-            //console.log(`Gotcha: Parent is ${parent}`)
-            // TODO what if it's not unique - need position, but then parent.children may reinitialize.
-            // Not if a mutable container, admittedly
-            return `/${n.nodeName()}`
-        }
-        else if (parent.parent()) { // Essentially an instanceof, which we can't do on an interface
-            return this.findPathFromAncestor(parent as ParentAwareTreeNode, nodeTest) + `/${n.nodeName()}`
-        }
-        else
-            return null
+export function findPathFromAncestor(n: ParentAwareTreeNode, nodeTest: (TextTreeNode) => boolean): string {
+    let parent = n.parent() as any // Makes checking for parent function later easy
+    if (parent == null) {
+        // We couldn't resolve the path
+        return null
     }
-
-    findPathFromAncestorWithTag(n: ParentAwareTreeNode, tag: String): string {
-        let r = this.findPathFromAncestor(
-            n,
-            n => n.nodeTags().contains(tag))
-        return r
+    else if (nodeTest(parent)) {
+        //console.log(`Gotcha: Parent is ${parent}`)
+        // TODO what if it's not unique - need position, but then parent.children may reinitialize.
+        // Not if a mutable container, admittedly
+        return `/${n.nodeName()}`
     }
-
-    /**
-     * Return an ancestor meeting the given criteria
-     * or null if it cannot be found
-     */
-    findAncestor<N extends TreeNode>(n: ParentAwareTreeNode, nodeTest: (N) => boolean): N {
-        let parent = n.parent() as any // Makes checking for parent function later easy
-        if (parent == null) {
-            return null
-        }
-        else if (nodeTest(parent)) {
-            //console.log(`Gotcha: Parent is ${parent}`)
-            return parent as N
-        }
-        else if (parent.parent()) { // Essentially an instanceof, which we can't do on an interface
-            return this.findAncestor(parent as ParentAwareTreeNode, nodeTest) as N
-        }
-        else
-            return null
+    else if (parent.parent()) { // Essentially an instanceof, which we can't do on an interface
+        return findPathFromAncestor(parent as ParentAwareTreeNode, nodeTest) + `/${n.nodeName()}`
     }
-
-    /**
-     * Find an ancestor with a given tag
-     */
-    findAncestorWithTag<N extends TreeNode>(n: ParentAwareTreeNode, tag: string): N {
-        let r = this.findAncestor<N>(
-            n,
-            n => n.nodeTags().contains(tag))
-        return r
-    }
+    else
+        return null
 }
 
+export function findPathFromAncestorWithTag(n: ParentAwareTreeNode, tag: String): string {
+    let r = findPathFromAncestor(
+        n,
+        n => n.nodeTags().contains(tag))
+    return r
+}
+
+/**
+ * Return an ancestor meeting the given criteria
+ * or null if it cannot be found
+ */
+export function findAncestor<N extends TreeNode>(n: ParentAwareTreeNode, nodeTest: (N) => boolean): N {
+    let parent = n.parent() as any // Makes checking for parent function later easy
+    if (parent == null) {
+        return null
+    }
+    else if (nodeTest(parent)) {
+        //console.log(`Gotcha: Parent is ${parent}`)
+        return parent as N
+    }
+    else if (parent.parent()) { // Essentially an instanceof, which we can't do on an interface
+        return findAncestor(parent as ParentAwareTreeNode, nodeTest) as N
+    }
+    else
+        return null
+}
+
+/**
+ * Find an ancestor with a given tag
+ */
+export function findAncestorWithTag<N extends TreeNode>(n: ParentAwareTreeNode, tag: string): N {
+    let r = findAncestor<N>(
+        n,
+        n => n.nodeTags().contains(tag))
+    return r
+}
+
+
+/**
+ * Convenient mutable superclass for node implementations that
+ * should be address aware
+ */
 export abstract class AddressedNodeSupport implements Addressed {
 
     private _navigatedFrom: Addressed = null

--- a/src/test/resources/com/atomist/rug/K8Redeploy.ts
+++ b/src/test/resources/com/atomist/rug/K8Redeploy.ts
@@ -1,19 +1,18 @@
 import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
 import {Project} from '@atomist/rug/model/Core'
 import {Parameter} from '@atomist/rug/operations/RugOperation'
-import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
 
-    
-/**
-       Update Kube spec to redeploy a service
-*/
+
 interface Parameters {
 
     service: string
     new_sha: string
 
 }
-     
+
+/**
+       Update Kube spec to redeploy a service
+*/
 class Redeploy implements ProjectEditor {
 
     name: string = "Redeploy"
@@ -23,20 +22,11 @@ class Redeploy implements ProjectEditor {
     parameters: Parameter[] = [{name: "service", pattern: "^[\\w.\\-_]+$", maxLength: -1, minLength: -1, validInput: "String value"}, {name: "new_sha", pattern: "^[a-f0-9]{7}$", maxLength: -1, minLength: -1, validInput: "String value"}];
     
     edit(project: Project, parameters: Parameters) {
-    
-        let eng: PathExpressionEngine = project.context().pathExpressionEngine();
-        
-        let service = parameters.service
-            let new_sha = parameters.new_sha
-        
-            let p = project
-                if (true) {
-                    p.regexpReplace((() => { 
-                     return service + ":[a-f0-9]{7}"  })(),  service + ":" + new_sha )
-                }
-    
+
+         project.regexpReplace(parameters.service + ":[a-f0-9]{7}", parameters.service + ":" + parameters.new_sha)
+
     }
 
 }
 
-export let ked = new Redeploy()
+export const ked = new Redeploy()

--- a/src/test/resources/com/atomist/rug/kind/csharp/NavigateTree.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/NavigateTree.ts
@@ -3,7 +3,7 @@ import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
 import {PathExpression,TextTreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
 import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
 import {Match} from '@atomist/rug/tree/PathExpression'
-import {TreeHelper} from '@atomist/rug/tree/TreeHelper'
+import * as treeHelper from '@atomist/rug/tree/TreeHelper'
 import {Parameter} from '@atomist/rug/operations/Decorators'
 
 class NavigateTree implements ProjectEditor {
@@ -31,16 +31,14 @@ class NavigateTree implements ProjectEditor {
         if (classType.parent().value() != cc.value())
           throw new Error(`Unexpected value for parent of ${classType.nodeName()}: ${classType.parent()}`)
 
-        let th = new TreeHelper()
-
-        let inFile: File = th.findAncestorWithTag<File>(classType, "File")
+        let inFile: File = treeHelper.findAncestorWithTag<File>(classType, "File")
         if (inFile != null) {
             if (inFile.name() != "exception.cs")
                 throw new Error(`File has wrong name: ${inFile.name()}`)
             count++
         }
-         let inFile1: File = th.findAncestorWithTag<File>(c2, "File")
-         let inFile2: File = th.findAncestorWithTag<File>(cc, "File")
+         let inFile1: File = treeHelper.findAncestorWithTag<File>(c2, "File")
+         let inFile2: File = treeHelper.findAncestorWithTag<File>(cc, "File")
       })
 
       if (count == 0)

--- a/src/test/resources/com/atomist/rug/kind/docker/DockerUpgrade.ts
+++ b/src/test/resources/com/atomist/rug/kind/docker/DockerUpgrade.ts
@@ -17,10 +17,8 @@ class DockerUpgrade implements ProjectEditor {
         let eng: PathExpressionEngine = project.context().pathExpressionEngine();
 
             eng.with<DockerFile>(project, '//DockerFile()', d => {
-                if (true) {
-                    d.addExpose("8081")
-                    d.addOrUpdateFrom("java:8-jre")
-                }
+                d.addExpose("8081")
+                d.addOrUpdateFrom("java:8-jre")
             })
 
     }

--- a/src/test/resources/com/atomist/rug/kind/docker/DockerUpgrade2.ts
+++ b/src/test/resources/com/atomist/rug/kind/docker/DockerUpgrade2.ts
@@ -17,12 +17,10 @@ class DockerUpgrade2 implements ProjectEditor {
         let eng: PathExpressionEngine = project.context().pathExpressionEngine();
         
         eng.with<DockerFile>(project, '//DockerFile()', d => {
-                if (true) {
-                    d.addOrUpdateExpose("8081")
-                    d.addOrUpdateFrom("java:8-jre")
-                    d.addOrUpdateHealthcheck("--interval=5s --timeout=3s CMD curl --fail http://localhost:8080/ || exit 1")
-                }
-            })
+            d.addOrUpdateExpose("8081")
+            d.addOrUpdateFrom("java:8-jre")
+            d.addOrUpdateHealthcheck("--interval=5s --timeout=3s CMD curl --fail http://localhost:8080/ || exit 1")
+        })
     
     }
 

--- a/src/test/resources/com/atomist/rug/kind/docker/DockerUpgrade3.ts
+++ b/src/test/resources/com/atomist/rug/kind/docker/DockerUpgrade3.ts
@@ -21,10 +21,8 @@ class DockerUpgrade3 implements ProjectEditor {
         let exposePort = "8181"
     
             eng.with<DockerFile>(project, '//DockerFile()', d => {
-                if (true) {
-                    d.addOrUpdateExpose(exposePort)
-                    d.addOrUpdateFrom("java:8-jre")
-                }
+                d.addOrUpdateExpose(exposePort)
+                d.addOrUpdateFrom("java:8-jre")
             })
     
     }

--- a/src/test/resources/com/atomist/rug/kind/java/ClassAnnotated.ts
+++ b/src/test/resources/com/atomist/rug/kind/java/ClassAnnotated.ts
@@ -16,12 +16,10 @@ class ClassAnnotated implements ProjectEditor {
     
         let eng: PathExpressionEngine = project.context().pathExpressionEngine();
         
-            eng.with<SpringBootProject>(project, '//SpringBootProject()', p => {
-                if (true) {
-                    p.annotateBootApplication("com.someone", "Foobar")
-                }
-            })
+        eng.with<SpringBootProject>(project, '//SpringBootProject()', p => {
+            p.annotateBootApplication("com.someone", "Foobar")
+        })
     
     }
 }
-export let editor_classAnnotated = new ClassAnnotated();
+export const editor_classAnnotated = new ClassAnnotated();

--- a/src/test/resources/com/atomist/rug/kind/pom/EveryPomEdit.ts
+++ b/src/test/resources/com/atomist/rug/kind/pom/EveryPomEdit.ts
@@ -17,15 +17,11 @@ class EveryPomEdit implements ProjectEditor {
         let eng: PathExpressionEngine = project.context().pathExpressionEngine();
         
             let p = project
-                if (true) {
-                        eng.with<EveryPom>(p, '//EveryPom()', o => {
-                            if (true) {
-                                o.setGroupId("mygroup")
-                            }
-                        })
-                }
-    
+            eng.with<EveryPom>(p, '//EveryPom()', o => {
+                o.setGroupId("mygroup")
+            })
+
     }
 
 }
-export let editor_everyPomEdit = new EveryPomEdit();
+export const editor_everyPomEdit = new EveryPomEdit();

--- a/src/test/resources/com/atomist/rug/kind/scala/EqualsToSymbol.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/EqualsToSymbol.ts
@@ -1,9 +1,6 @@
 import {Project,File} from '@atomist/rug/model/Core'
 import {ProjectEditor} from '@atomist/rug/operations/ProjectEditor'
-import {PathExpression,TextTreeNode,TypeProvider} from '@atomist/rug/tree/PathExpression'
-import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-import {Match} from '@atomist/rug/tree/PathExpression'
-import {TreeHelper} from '@atomist/rug/tree/TreeHelper'
+import {PathExpression,PathExpressionEngine,TextTreeNode} from '@atomist/rug/tree/PathExpression'
 
 /**
  * Upgrade Scala use of Java-style "a.equals(b)" to
@@ -56,4 +53,4 @@ class EqualsToSymbol implements ProjectEditor {
 
 }
 
-export let editor = new EqualsToSymbol()
+export const editor = new EqualsToSymbol()

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
@@ -17,7 +17,6 @@ class FruitererType implements TypeProvider {
  find(context: TreeNode): TreeNode[] {
    if (this.isFile(context)) {
      let f = context as File
-     //console.log(f.name())
      if (f.isJava())
       return [ new Fruiterer(f) ]
       else return []


### PR DESCRIPTION
This removes the `TreeHelper` class in TypeScript, which was not needed as function export is simpler. It also cleans up some TypeScript in the test suite that was created by the old Rug transpired, and reduces console logging in tests.