### PR TITLE
Parameters are not optional, fix regression

### DIFF
--- a/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
@@ -23,12 +23,12 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
     /**
      * Edit the project with the given editor, validating parameters
      */
-    editWith(ed: ProjectEditor, params?: {})
+    editWith(ed: ProjectEditor, params: {})
 
     /**
      * Create a project using the given generator named projectName, validating parameters
      */
-    generateWith(gen: ProjectGenerator, projectName: string, params?: {})
+    generateWith(gen: ProjectGenerator, projectName: string, params: {})
 
     /**
      * How many modifications did editors in this scenario make?  Note

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/AlpEditors.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/AlpEditors.ts
@@ -17,14 +17,14 @@ export const alpEditor = new AlpEditor();
 
 export class AlpEditorWithParameters implements ProjectEditor {
     name: string = "AlpEditorWithParameters"
-    description: string = "ALP history"
+    description: string = "ALP history";
 
     @Parameter({description: "Bold PM", pattern: "^.*$"})
-    heir: string
+    heir: string;
 
     edit(project: Project) {
-     project.addFile(this.heir, "Can a souffle rise twice?")
+        project.addFile(this.heir, "Can a souffle rise twice?");
     }
 }
 
-export let alpEditorWithParameters = new AlpEditorWithParameters()
+export const alpEditorWithParameters = new AlpEditorWithParameters();

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithParametersSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithParametersSteps.ts
@@ -9,7 +9,7 @@ Given("a visionary leader", p => {
 })
 When("politics takes its course", (p, w) => {
     let world = w as ProjectScenarioWorld;
-    world.editWith(world.editor("AlpEditor"), {});
+    world.editWith(world.editor("AlpEditorWithParameters"), {heir: "Paul"});
 });
 Then("one edit was made", (p, world) => {
     return world.editorsRun() == 1;
@@ -18,5 +18,6 @@ Then("the rage is maintained", p => {
     return p.fileExists("Paul");
 });
 Then("the rage has a name", p => {
-    return p.name != null && p.name() != "" && p.name().length > 0;
+    let name = p.name();
+    return name != null && name != "" && name.length > 0;
 });

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithoutParametersSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithoutParametersSteps.ts
@@ -18,5 +18,6 @@ Then("the rage is maintained", p => {
     return p.fileExists("Paul");
 });
 Then("the rage has a name", p => {
-    return p.name != null && p.name() != "" && p.name().length > 0;
+    let name = p.name();
+    return name != null && name != "" && name.length > 0;
 });


### PR DESCRIPTION
Calling `editWith()` and `generateWith()` in TypeScript without a
second argument resulted in an exception since the underlying method
in Scala did not provide a default value.  Given @alankstwewart
finding issues with method overloading, to fix I just made the second
argument not optional in the TypeScript interface.

When EditorWithParametersSteps got moved to its own file, it lost its
parameter.