### PR TITLE
Fix editor testing with bad parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.15.0...HEAD
 
+### Fixed
+
+-   Testing editors no longer crashes when provided invalid
+    parameters [#444][444]
+
+[444]: https://github.com/atomist/rug/issues/444
+
 ## [0.15.0] - 2017-03-17
 
 [0.15.0]: https://github.com/atomist/rug/compare/0.14.0...0.15.0

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
@@ -82,7 +82,7 @@ class ProjectScenarioWorld(
       case Right(_) =>
       // We've already logged it. Do nothing
       case Left(ipe: InvalidParametersException) =>
-        ???
+        throw ipe
       case Left(unknown) =>
         throw unknown
     }

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/AlpEditors.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/AlpEditors.ts
@@ -19,7 +19,7 @@ export class AlpEditorWithParameters implements ProjectEditor {
     name: string = "AlpEditorWithParameters"
     description: string = "ALP history";
 
-    @Parameter({description: "Bold PM", pattern: "^.*$"})
+    @Parameter({description: "Bold PM", pattern: "^[A-Za-z]*$"})
     heir: string;
 
     edit(project: Project) {

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithBadParametersSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithBadParametersSteps.ts
@@ -1,0 +1,17 @@
+import { Project } from "@atomist/rug/model/Core"
+import { ProjectEditor } from "@atomist/rug/operations/ProjectEditor"
+import { Given, When, Then, ProjectScenarioWorld } from "@atomist/rug/test/project/Core"
+
+import { AlpEditor } from "../../editors/AlpEditors"
+
+Given("a visionary leader", p => {
+    p.addFile("Gough", "Maintain the rage");
+})
+When("politics takes its course", (p, w) => {
+    let world = w as ProjectScenarioWorld;
+    world.editWith(world.editor("AlpEditorWithParameters"), {heir: "Malcolm0Fraser"});
+});
+Then("the rage has a name", p => {
+    let name = p.name();
+    return name != null && name != "" && name.length > 0;
+});

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
@@ -99,6 +99,20 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
     assert(el.scCount == 0)
   }
 
+  it should "handle an editor test checking for an invalid parameter" in {
+    val el = new TestExecutionListener
+    val as = SimpleFileBasedArtifactSource(
+      alpEditorsFile,
+      EditorBadParameterFeatureFile,
+      EditorWithBadParametersStepsFile
+    )
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Option(RugArchiveReader.find(cas)), Seq(el))
+    val run = grt.execute()
+    assert(run.testCount > 0)
+    assert(run.result === Passed)
+  }
+
   it should "test a reviewer" in {
     val as =
       SimpleFileBasedArtifactSource(
@@ -164,19 +178,8 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
     val atomistStuff: ArtifactSource =
       TestUtils.resourcesInPackage(this).filter(_ => true, f => f.name == "SimpleGeneratorWithParams.ts")
         .withPathAbove(".atomist/editors") +
-        SimpleFileBasedArtifactSource(StringFileArtifact(
-          ".atomist/tests/project/Simple.feature",
-          """
-            |Feature: Generate a new project
-            |  This is a test
-            |  to see whether
-            |  we can test project generators
-            |
-            |  Scenario: New project should have content from template
-            |    Given an empty project
-            |    When run simple generator
-            |    Then parameters were invalid
-            |""".stripMargin),
+        SimpleFileBasedArtifactSource(
+          GenerationBadParameterFeatureFile,
           StringFileArtifact(".atomist/tests/project/GenerationSteps.ts",
             generateWithInvalidParameters("SimpleGeneratorWithParams", projectName, Map("text" -> "`Anders Hjelsberg is 1God`")))
         )

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
@@ -17,6 +17,9 @@ object ProjectTestTargets {
   val EditorWithParametersStepsFile = StringFileArtifact(".atomist/test/project/Simple_definitions.ts",
     TestUtils.requiredFileInPackage(this, "EditorWithParametersSteps.ts").content)
 
+  val EditorWithBadParametersStepsFile = StringFileArtifact(".atomist/test/project/Simple_definitions.ts",
+    TestUtils.requiredFileInPackage(this, "EditorWithBadParametersSteps.ts").content)
+
   val CorruptionFeature =
     """
       |Feature: Look for corrupt politicians
@@ -81,6 +84,24 @@ object ProjectTestTargets {
        |});
        |""".stripMargin
 
+  val GenerationBadParameterFeature =
+    """
+      |Feature: Generate a new project
+      |  This is a test
+      |  to see whether
+      |  we can test project generators
+      |
+      |  Scenario: New project should have content from template
+      |    Given an empty project
+      |    When run simple generator
+      |    Then parameters were invalid
+      |""".stripMargin
+
+  val GenerationBadParameterFeatureFile = StringFileArtifact(
+    ".atomist/tests/project/GenerationBadParam.feature",
+    GenerationBadParameterFeature
+  )
+
   def generateWithInvalidParameters(gen: String, projectName: String, params: Map[String,String]): String =
     s"""
        |import { Project } from "@atomist/rug/model/Core"
@@ -93,5 +114,23 @@ object ProjectTestTargets {
        |    world.generateWith(g, "${projectName}", {${params.map(p => s"${p._1}: ${p._2}").mkString(", ")}});
        |});
        |""".stripMargin
+
+  val EditorBadParameterFeature =
+    """
+      |Feature: Australian political history
+      |  This is a test
+      |  to demonstrate that the Gherkin DSL
+      |  is a good fit for Rug BDD testing
+      |
+      |  Scenario: Australian politics, 1972-1991
+      |    Given an empty project
+      |    Given a visionary leader
+      |    When politics takes its course
+      |    Then parameters were invalid
+      |    Then the rage has a name
+    """.stripMargin
+
+  val EditorBadParameterFeatureFile =
+    StringFileArtifact(".atomist/tests/project/BadParameter.feature", EditorBadParameterFeature)
 
 }


### PR DESCRIPTION
Pass the InvalidParameterException up through editor calls so they get
recorded and you do not hit `???` and blow up when checking if the
editor checks parameters.

Fixes #444