### PR TITLE
Added ReviewResult.combine method to fix #147

### DIFF
--- a/src/main/typescript/node_modules/@atomist/rug/operations/ProjectReviewer.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/ProjectReviewer.ts
@@ -2,10 +2,10 @@ import {RugOperation, ReviewResult} from "./RugOperation"
 import {Project} from "../model/Core"
 import {ProjectContext} from "./ProjectEditor"
 
-
 export interface ReviewProject {
   review(project: Project, params?: {}): ReviewResult
 }
+
 /**
  * Review the given project with given parameters
  */

--- a/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/RugOperation.ts
@@ -102,8 +102,27 @@ class ReviewResult {
     this.comments.push(rc)
   }
 
-  static empty(note: string) {
+  static empty(note: string): ReviewResult {
     return new ReviewResult(note, [])
+  }
+
+  /**
+   * Combine the results of the given reviewers
+   * @param results review results to combine
+   */
+  static combine(results: ReviewResult[]): ReviewResult {
+    if (results.length == 0)
+      throw new Error("Invalid argument: Need at least one review result")
+    let combinedComments: ReviewComment[] = []
+    results.forEach(r => 
+      r.comments.forEach(
+        c => combinedComments.push(c)
+      )
+    )
+    return new ReviewResult(
+      results.map(r => r.note).join(","),
+      combinedComments
+    )
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/TwoReviewers.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/TwoReviewers.ts
@@ -1,0 +1,46 @@
+import {Project} from '@atomist/rug/model/Core'
+import {ProjectReviewer} from '@atomist/rug/operations/ProjectReviewer'
+import {File} from '@atomist/rug/model/Core'
+import {ReviewResult, ReviewComment, Parameter, Severity} from '@atomist/rug/operations/RugOperation'
+
+class ReviewerA implements ProjectReviewer {
+
+    name: string = "ReviewerA"
+    description: string = "A nice little reviewer"
+
+    review(project: Project) {
+      return new ReviewResult("ReviewerA",
+          [new ReviewComment("A", Severity.Broken)]
+        );
+    }
+  }
+export let reviewerA = new ReviewerA()
+
+
+class ReviewerB implements ProjectReviewer {
+
+    name: string = "ReviewerB"
+    description: string = "A nice little reviewer"
+
+    review(project: Project) {
+      return new ReviewResult("ReviewerB",
+          [new ReviewComment("B", Severity.Broken)]
+        );
+    }
+  }
+export let reviewerB = new ReviewerB()
+
+class ReviewerC implements ProjectReviewer {
+
+    name: string = "ReviewerC"
+    description: string = "A nice little reviewer"
+
+    review(project: Project) {
+      return ReviewResult.combine ([
+          reviewerA.review(project), 
+          reviewerB.review(project)
+      ])
+    }
+  }
+
+export let reviewerC = new ReviewerC()

--- a/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugReviewerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/TypeScriptRugReviewerTest.scala
@@ -259,6 +259,16 @@ class TypeScriptRugReviewerTest extends FlatSpec with Matchers {
     assert(second.line === Some(3))
   }
 
+  it should "combine review results" in {
+    val rf = StringFileArtifact(".atomist/reviewers/TwoReviewers.ts", TestUtils.contentOf(this, "TwoReviewers.ts"))
+    val cas = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(rf))
+    val reviewer = RugArchiveReader.find(cas).reviewers.find(_.name == "ReviewerC").get
+    val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
+    val rr = reviewer.review(target, SimpleParameterValues( Map("content" -> ParameterContent)))
+    assert(rr.note === "ReviewerA,ReviewerB")
+    assert(rr.comments.size === 2)
+  }
+
   private  def reviewSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): ReviewResult = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 


### PR DESCRIPTION
Fixes #147 by adding convenient static `combine` method to `ReviewResult`.