### PR TITLE
Allow construction of Message without a body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.17.1...HEAD
 
+### Changed
+
+-   Allow construction of Message without body
+
 ## [0.17.1] - 2017-03-20
 
 [0.17.1]: https://github.com/atomist/rug/compare/0.17.0...0.17.1

--- a/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
@@ -7,7 +7,7 @@ import com.atomist.rug.spi.Handlers._
 import com.atomist.tree.TreeNode
 import com.atomist.util.JsonUtils
 import jdk.nashorn.api.scripting.ScriptObjectMirror
-import jdk.nashorn.internal.runtime.Undefined
+import jdk.nashorn.internal.runtime.{ScriptRuntime, Undefined}
 
 /**
   * Constructs plans from Nashorn response to a Handler/handle operation
@@ -60,6 +60,7 @@ class PlanBuilder {
         JsonBody(json.entrySet().toString)
       case text: String =>
         MessageText(text)
+      case ScriptRuntime.UNDEFINED => MessageText(null)
       case _ =>
         throw new InvalidHandlerResultException(s"Cannot determine message content from body: ${jsMessage.getMember("body")}")
     }

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -169,7 +169,7 @@ class Message {
     return this;
   }
 
-  constructor(about: string | Json){
+  constructor(about?: string | Json){
     this.body = about;
   }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningEmptyMessage.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningEmptyMessage.ts
@@ -1,0 +1,12 @@
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+
+@CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
+class KittieFetcher implements HandleCommand{
+
+  handle(ctx: HandlerContext) : Message {
+    return new Message();
+  }
+}
+
+export let command = new KittieFetcher();


### PR DESCRIPTION
We often see the following in handlers:

```typescript
 let message = new Message("");
```
This PR just allows the following which is a totally valid use case:

```typescript
 let message = new Message();
```