### PR TITLE
TypeScript library polishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   Allow type safe creation of plan instructions using instantiated operations
 -   Allow construction of Message without body
 
 ## [0.17.1] - 2017-03-20

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -169,13 +169,6 @@ class jsPathExpressionEngine(
   }
 
   /**
-    * Convenience method to avoid overloading in TypeScript,
-    * which can cause problems with inheritance.
-    */
-  def scalarStr(root: GraphNode, pe: String): jsSafeCommittingProxy =
-    scalar(root, pe)
-
-  /**
     * Try to cast the given node to the required type.
     */
   def as(root: GraphNode, name: String): jsSafeCommittingProxy = scalar(root, s"->$name")

--- a/src/main/typescript/node_modules/@atomist/rug/ast/AstHelper.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/AstHelper.ts
@@ -17,7 +17,7 @@ export class AstHelper {
         let f = treeHelper.findAncestorWithTag<File>(languageNode, "File")
         if (f) {
             let pathExpression = `/${type}()`
-            let r = this.pexe.scalarStr<File,TextTreeNode>(f, pathExpression)
+            let r = this.pexe.scalar<File,TextTreeNode>(f, pathExpression)
             //console.log(`Reparsed=${r}`)
             return r
         }

--- a/src/main/typescript/node_modules/@atomist/rug/ast/scala/Types.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/scala/Types.ts
@@ -23,7 +23,7 @@ export class SourceOps extends TextTreeNodeOps<SourceNav> {
      */
     packageName(): TextTreeNode {
         try {
-            return this.pexe.scalarStr<TextTreeNode,TextTreeNode>(this.node, "/pkg/termSelect")
+            return this.pexe.scalar<TextTreeNode,TextTreeNode>(this.node, "/pkg/termSelect")
         }
         catch (e) {
             return null

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -197,3 +197,4 @@ abstract class MappedParameters {
 export {MappedParameters}
 export {Respond, Presentable, NonRespondable, Respondable, Instruction, Response, HandlerContext, Plan, Message, Execute}
 export {HandleResponse, HandleCommand, HandleEvent}
+export {Edit, ProjectInstruction}

--- a/src/main/typescript/node_modules/@atomist/rug/operations/PlanUtils.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/PlanUtils.ts
@@ -1,4 +1,4 @@
-import {EditProject} from "./ProjectEditor"
+import {ProjectEditor, EditProject} from "./ProjectEditor"
 import {Project} from "../model/Project"
 import {Edit,Instruction,HandleCommand} from "./Handlers"
 
@@ -9,7 +9,7 @@ import {Edit,Instruction,HandleCommand} from "./Handlers"
  * @param p project or name of project to edit
  * @param ed editor to use
  */
-export function editWith(p: Project | string, ed: EditProject): Edit {
+export function editWith(p: Project | string, ed: EditProject | ProjectEditor): Edit {
     let obj = instruction(ed, "edit")
     let proj = p as any
     obj["project"] = proj.name ? proj.name() : p

--- a/src/main/typescript/node_modules/@atomist/rug/operations/PlanUtils.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/PlanUtils.ts
@@ -1,14 +1,19 @@
 import {EditProject} from "./ProjectEditor"
-import {Instruction,HandleCommand} from "./Handlers"
+import {Project} from "../model/Project"
+import {Edit,Instruction,HandleCommand} from "./Handlers"
 
 /**
  * Build a plan instruction for the given decorated
  * editor, extracting its present property values, which
  * follow a convention, with names like __name
- * @param ed editor
+ * @param p project or name of project to edit
+ * @param ed editor to use
  */
-export function editWith(ed: EditProject): Instruction<"edit"> {
-    return instruction(ed, "edit")
+export function editWith(p: Project | string, ed: EditProject): Edit {
+    let obj = instruction(ed, "edit")
+    let proj = p as any
+    obj["project"] = proj.name ? proj.name() : p
+    return obj as Edit
 }
 
 export function handleCommand(ed: HandleCommand): Instruction<"command"> {
@@ -16,7 +21,7 @@ export function handleCommand(ed: HandleCommand): Instruction<"command"> {
 }
 
 /**
- * Emit an instruction for the given operation type
+ * Emit an instruction for the given decorated operation type
  * @param op operation to emit instruction for
  * @param kind kind of the instruction, such as "edit"
  */

--- a/src/main/typescript/node_modules/@atomist/rug/operations/PlanUtils.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/PlanUtils.ts
@@ -1,0 +1,33 @@
+import {EditProject} from "./ProjectEditor"
+import {Instruction,HandleCommand} from "./Handlers"
+
+/**
+ * Build a plan instruction for the given decorated
+ * editor, extracting its present property values, which
+ * follow a convention, with names like __name
+ * @param ed editor
+ */
+export function editWith(ed: EditProject): Instruction<"edit"> {
+    return instruction(ed, "edit")
+}
+
+export function handleCommand(ed: HandleCommand): Instruction<"command"> {
+    return instruction(ed, "command")
+}
+
+/**
+ * Emit an instruction for the given operation type
+ * @param op operation to emit instruction for
+ * @param kind kind of the instruction, such as "edit"
+ */
+function instruction(op, kind) {
+    let params = {}
+    for (let param of op.__parameters) {
+        params[param.name] = op[param.name]
+    }
+    return {
+        kind: kind,
+        name: op.__name,
+        parameters: params,
+    }
+}

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -138,22 +138,17 @@ interface PathExpressionEngine {
      * Evaluate the given path expression
      */
 
-    evaluate<R extends GraphNode,N extends GraphNode>(root: R, expr: PathExpression<R,N>): Match<R,N>
+    evaluate<R extends GraphNode,N extends GraphNode>(root: R, expr: PathExpression<R,N> | string): Match<R,N>
 
     /**
      * Execute the given function on the nodes returned by the given path expression
      */
-    with<N extends GraphNode>(root: GraphNode, expr: string, f: (n: N) => void): void
+    with<N extends GraphNode>(root: GraphNode, expr: PathExpression<GraphNode,N> | string, f: (n: N) => void): void
 
     /**
      * Return a single match. Throw an exception otherwise.
      */
-    scalar<R extends GraphNode,N extends GraphNode>(root: R, expr: PathExpression<R,N>): N
-
-    /**
-     * Convenience method to eval scalar from string
-     */
-    scalarStr<R extends GraphNode,N extends GraphNode>(root: R, expr: string): N
+    scalar<R extends GraphNode,N extends GraphNode>(root: R, expr: PathExpression<R,N> | string): N
 
     /**
      * Cast the present node to the given type

--- a/src/main/typescript/node_modules/@atomist/rug/tree/TransformingPathExpressionEngine.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/TransformingPathExpressionEngine.ts
@@ -1,4 +1,4 @@
-import {PathExpressionEngine,PathExpression,Match,DynamicType,TreeNode} from "./PathExpression"
+import {PathExpressionEngine,PathExpression,Match,DynamicType,GraphNode,TreeNode} from "./PathExpression"
 
 /**
  * Convenient superclass that wraps an existing PathExpressionEngine
@@ -16,7 +16,7 @@ export class TransformingPathExpressionEngine implements PathExpressionEngine {
 
   // Unfortunately other calls don't go through this,
   // because they're in Scala
-  evaluate<R extends TreeNode,N extends TreeNode>(root: R, expr: PathExpression<R,N>): Match<R,N> {
+  evaluate<R extends TreeNode,N extends TreeNode>(root: R, expr: PathExpression<R,N> | string): Match<R,N> {
     let m1 = this.delegate.evaluate(root, expr)
     let m2 = {
       root() { return this.nodeTransform(m1.root()) },
@@ -27,7 +27,7 @@ export class TransformingPathExpressionEngine implements PathExpressionEngine {
     return m2
   }
 
-  with<N extends TreeNode>(root: TreeNode, expr: string,
+  with<N extends TreeNode>(root: TreeNode, expr: PathExpression<GraphNode,N> | string,
             f: (n: N) => void): void {
     this.delegate.with(root, expr, n => {
         //console.log("Intercepted with")
@@ -37,13 +37,8 @@ export class TransformingPathExpressionEngine implements PathExpressionEngine {
     })
   }
 
-  scalar<R extends TreeNode,N extends TreeNode>(root: R, expr: PathExpression<R,N>): N {
+  scalar<R extends TreeNode,N extends TreeNode>(root: R, expr: PathExpression<R,N> | string): N {
     return this.nodeTransform(this.delegate.scalar<R,N>(root, expr)) as N
-  }
-
-  scalarStr<R extends TreeNode,N extends TreeNode>(root: R, expr: string): N {
-    let n = this.delegate.scalarStr<R,N>(root, expr)
-    return this.nodeTransform(n) as N
   }
 
   as<N extends TreeNode>(root, name: string): N {

--- a/src/test/resources/com/atomist/rug/kind/xml/UpgradeVersion.ts
+++ b/src/test/resources/com/atomist/rug/kind/xml/UpgradeVersion.ts
@@ -25,7 +25,6 @@ export function versionOfDependency(group: string, artifact: string) {
     )
 }
 
-
 @Editor("UpgradeVersion", "Find and upgrade POM version")
 export class UpgradeVersion implements EditProject {
 
@@ -39,11 +38,15 @@ export class UpgradeVersion implements EditProject {
     desiredVersion: string
     
     edit(project: Project) {
+
+        // console.log(JSON.stringify(editWith(project, this)))
+        // console.log(JSON.stringify(editWith("foobar", this)))
+
         let eng: PathExpressionEngine = project.context().pathExpressionEngine();
         let search = versionOfDependency(this.group, this.artifact)
         eng.with<TextTreeNode>(project, search, version => {
             if (version.value() != this.desiredVersion) {
-                console.log(`Updated to desired version ${this.desiredVersion}`)
+                //console.log(`Updated to desired version ${this.desiredVersion}`)
                 version.update(this.desiredVersion)
             }
         })
@@ -51,19 +54,3 @@ export class UpgradeVersion implements EditProject {
 }
 
 export const uv = new UpgradeVersion();
-uv.group = "foobar"
-uv.artifact = "thingie"
-uv.desiredVersion = "1.0.0-M1"
-
-console.log(JSON.stringify(editWith(uv)))
-
-
-export class ArtifactRange {
-
-    constructor(public from: string, public to: string) {}
-
-    satisfies(s: string): boolean {
-        // TODO parse this properly using sem ver
-        return s == this.from || s == this.to
-    }
-}

--- a/src/test/resources/com/atomist/rug/kind/xml/UpgradeVersion.ts
+++ b/src/test/resources/com/atomist/rug/kind/xml/UpgradeVersion.ts
@@ -1,0 +1,65 @@
+import {ProjectEditor,EditProject} from '@atomist/rug/operations/ProjectEditor'
+import {Project, Xml} from '@atomist/rug/model/Core'
+import {PathExpression,PathExpressionEngine,TextTreeNode} from '@atomist/rug/tree/PathExpression'
+import { Editor, Tags, Parameter } from '@atomist/rug/operations/Decorators'
+
+/*
+    Return a path expression to match the version of a particular dependency, if found
+
+    <dependencies> ...
+		<dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>gherkin</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+*/
+export function versionOfDependency(group: string, artifact: string) {
+    return new PathExpression<TextTreeNode,TextTreeNode>(
+        `/*[@name='pom.xml']/XmlFile()/project/dependencies/dependency
+            [/groupId//TEXT[@value='${group}']]
+            [/artifactId//TEXT[@value='${artifact}']]
+            /version//TEXT
+        `
+    )
+}
+
+
+@Editor("UpgradeVersion", "Find and upgrade POM version")
+export class UpgradeVersion implements EditProject {
+
+    //TODO correct to use well-known pattern
+    @Parameter({pattern: "^.*$$", description: "Group to match"})
+    group: string
+
+    @Parameter({pattern: "^.*$$", description: "Artifact to match"})
+    artifact: string
+
+    @Parameter({pattern: "^.*$$", description: "Version to upgrade to"})
+    desiredVersion: string
+    
+    edit(project: Project) {
+        let eng: PathExpressionEngine = project.context().pathExpressionEngine();
+        let search = versionOfDependency(this.group, this.artifact)
+        // TODO can we use OR to get rid of this expression
+        eng.with<TextTreeNode>(project, search.expression, version => {
+            console.log(`Found version ${version.value()}`)
+            if (version.value() != this.desiredVersion) {
+                console.log(`Updated to desired version ${this.desiredVersion}`)
+                version.update(this.desiredVersion)
+            }
+        })
+    }
+}
+
+export const uv = new UpgradeVersion();
+
+
+export class ArtifactRange {
+
+    constructor(public from: string, public to: string) {}
+
+    satisfies(s: string): boolean {
+        // TODO parse this properly using sem ver
+        return s == this.from || s == this.to
+    }
+}

--- a/src/test/resources/com/atomist/rug/kind/xml/UpgradeVersion.ts
+++ b/src/test/resources/com/atomist/rug/kind/xml/UpgradeVersion.ts
@@ -39,8 +39,12 @@ export class UpgradeVersion implements EditProject {
     
     edit(project: Project) {
 
-        // console.log(JSON.stringify(editWith(project, this)))
-        // console.log(JSON.stringify(editWith("foobar", this)))
+        // TODO we should really test this with a pure JavaScript testing framework
+        let instruction = editWith(project, this) as any
+        if (instruction.name != "UpgradeVersion") throw new Error("Name is wrong")
+        if (instruction.kind != "edit") throw new Error("Kind is wrong")
+        if (!(instruction.parameters.group && instruction.parameters.artifact && instruction.parameters.desiredVersion))
+            throw new Error("Parameters wrong")
 
         let eng: PathExpressionEngine = project.context().pathExpressionEngine();
         let search = versionOfDependency(this.group, this.artifact)

--- a/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeUsageTest.scala
@@ -31,7 +31,7 @@ class XmlFileTypeUsageTest extends FlatSpec with Matchers {
     match {
       case sm: SuccessfulModification =>
         val outputxml = sm.result.findFile("pom.xml").get
-        println(outputxml.content)
+        //println(outputxml.content)
         outputxml.content.contains(s"<version>$desiredVersion</version>") should be(true)
       case wtf => fail(s"Expected SuccessfulModification, not $wtf")
     }

--- a/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeUsageTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class XmlFileTypeUsageTest extends FlatSpec with Matchers {
 
-  it should "update group id with native Rug function" in {
+  "XmlFileType" should "update group id with native Rug function" in {
     val ed = TestUtils.editorInSideFile(this, "Xit.ts")
     ed.modify(JavaTypeUsageTest.NewSpringBootProject, SimpleParameterValues.Empty) match {
       case sm: SuccessfulModification =>

--- a/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeUsageTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/xml/XmlFileTypeUsageTest.scala
@@ -18,4 +18,23 @@ class XmlFileTypeUsageTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "update version when needs upgrade" in {
+    val ed = TestUtils.editorInSideFile(this, "UpgradeVersion.ts")
+    val desiredVersion = "2.4.3"
+    ed.modify(JavaTypeUsageTest.NewSpringBootProject,
+      SimpleParameterValues(Map(
+        "group" -> "testgroup",
+        "artifact" -> "testartifact",
+        "desiredVersion" -> desiredVersion
+      ))
+    )
+    match {
+      case sm: SuccessfulModification =>
+        val outputxml = sm.result.findFile("pom.xml").get
+        println(outputxml.content)
+        outputxml.content.contains(s"<version>$desiredVersion</version>") should be(true)
+      case wtf => fail(s"Expected SuccessfulModification, not $wtf")
+    }
+  }
+
 }


### PR DESCRIPTION
- Cleanup of `PathExpressionEngine` signatures to use `|` to allow `string` or `PathExpression` to be passed in
- Added `PlanUtils` to allow instructions to be created from instantiated operations for type safety
- Export unexported but public types in `Handlers.ts`
- Added realistic `UpgradeVersion` editor to test suite to strengthen XML tests and flush out required functionality