### PR TITLE
Allow empty results on NodesWithTag when dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [Unreleased]: https://github.com/atomist/rug/compare/0.17.2...HEAD
 
 ### Fixed
+ 
+-   NodesWithTag allows dynamic nodes on `Child` axis to not match without error
 
 -   Don't set default parameter values if they are null
     https://github.com/atomist/rug/issues/458

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
@@ -7,6 +7,7 @@ import com.atomist.rug.runtime.js.interop.{jsContextMatch, jsSafeCommittingProxy
 import com.atomist.rug.runtime.{AddressableRug, EventHandler, RugSupport, SystemEvent}
 import com.atomist.rug.spi.Handlers.Plan
 import com.atomist.rug.{InvalidHandlerResultException, RugRuntimeException}
+import com.atomist.tree.TreeNode
 import com.atomist.tree.pathexpression.{NamedNodeTest, NodesWithTag, PathExpression, PathExpressionParser}
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
@@ -54,7 +55,7 @@ class JavaScriptEventHandler(jsc: JavaScriptContext,
   override def handle(ctx: RugContext, e: SystemEvent): Option[Plan] = {
     val targetNode = ctx.treeMaterializer.rootNodeFor(e, pathExpression)
     // Put a new artificial root above to make expression work
-    val root = SimpleContainerGraphNode("root", targetNode)
+    val root = SimpleContainerGraphNode("root", targetNode, Set(TreeNode.Dynamic))
     ctx.pathExpressionEngine.ee.evaluate(root, pathExpression, ctx.typeRegistry, None) match {
       case Right(Nil) => None
       case Right(matches) if matches.nonEmpty =>

--- a/src/main/scala/com/atomist/rug/runtime/js/SimpleContainerGraphNode.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/SimpleContainerGraphNode.scala
@@ -4,11 +4,13 @@ import com.atomist.graph.GraphNode
 
 object SimpleContainerGraphNode {
 
-  def apply(nodeName: String, child: GraphNode): SimpleContainerGraphNode =
-    SimpleContainerGraphNode(nodeName, Seq(child))
+  def apply(nodeName: String, child: GraphNode, nodeTags: Set[String]): SimpleContainerGraphNode =
+    SimpleContainerGraphNode(nodeName, Seq(child), nodeTags)
 }
 
-case class SimpleContainerGraphNode(nodeName: String, relatedNodes: Seq[GraphNode] = Nil)
+case class SimpleContainerGraphNode(nodeName: String,
+                                    relatedNodes: Seq[GraphNode] = Nil,
+                                    override val nodeTags: Set[String] = Set.empty)
   extends GraphNode {
 
   override def relatedNodeNames: Set[String] = relatedNodes.map(_.nodeName).toSet

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/NashornBackedGraphNodeTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/NashornBackedGraphNodeTest.scala
@@ -156,7 +156,7 @@ class NashornBackedGraphNodeTest extends FlatSpec with Matchers {
     )
     import com.atomist.tree.pathexpression.PathExpressionParser._
     val caspar = toGraphNode(n).get
-    val root = SimpleContainerGraphNode("root", caspar)
+    val root = SimpleContainerGraphNode("root", caspar, Set.empty[String])
     val pexpr: PathExpression = expr
     //println(pexpr)
     pe.evaluate(root, pexpr) match {

--- a/src/test/scala/com/atomist/tree/QueryByExampleTest.scala
+++ b/src/test/scala/com/atomist/tree/QueryByExampleTest.scala
@@ -103,7 +103,7 @@ class QueryByExampleTest extends FlatSpec with Matchers {
         // Check that the path matches against the rootObject
         val gn: GraphNode = NashornMapBackedGraphNode.toGraphNode(createdObject)
           .getOrElse(throw new IllegalArgumentException(s"Not a valid graph node: $createdObject"))
-        val root = SimpleContainerGraphNode("root", gn)
+        val root = SimpleContainerGraphNode("root", gn, Set.empty[String])
         val matchTest: GraphNode => Boolean = matchTestO.getOrElse(_ == gn)
 
         //println(s"Evaluating [$expr] against [$gn]")


### PR DESCRIPTION
This stops path expressions such as `/Build()` from blowing up when they don't match.

@jessitron I added the dynamic tag to disambiguate between cases where it's OK to blow up on Nodes that don't exist and where it's impossible for us to know.

Hopefully this means we don't regress on this issue:

https://github.com/atomist/rug/issues/323

That I found (where this behaviour was introduced). The tests added for that case still pass so I think this solves both issues.