### PR TITLE
Improved test message on failure if scenario aborted

### DIFF
--- a/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
@@ -50,7 +50,8 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
           case "Then " if !world.aborted =>
             Some(runThen(world, step))
           case "Then " if world.aborted =>
-            Some(AssertionResult(step.getText, Failed("Scenario aborted: Could not evaluate")))
+            Some(AssertionResult(step.getText,
+              Failed(s"Scenario aborted: Could not evaluate: [${world.abortMessage}]")))
           case _ =>
             None
         }
@@ -100,7 +101,7 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
           case Left(t) =>
             listeners.foreach(_.stepFailed(step, t))
             logger.error(t.getMessage, t)
-            world.abort()
+            world.abort(t.getMessage)
           case _ =>
           // Do nothing
         }
@@ -118,7 +119,7 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
           case Left(t) =>
             listeners.foreach(_.stepFailed(step, t))
             logger.error(t.getMessage, t)
-            world.abort()
+            world.abort(t.getMessage)
           case _ =>
           // OK
         }

--- a/src/main/scala/com/atomist/rug/test/gherkin/ScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/ScenarioWorld.scala
@@ -23,7 +23,7 @@ abstract class ScenarioWorld(val definitions: Definitions, rugs: Option[Rugs]) {
 
   private var bindings: Map[String,Object] = Map()
 
-  private var _aborted = false
+  private var abortedBy: Option[String] = None
 
   private var ipe: InvalidParametersException = _
 
@@ -43,13 +43,15 @@ abstract class ScenarioWorld(val definitions: Definitions, rugs: Option[Rugs]) {
   /**
     * Was the scenario run aborted?
     */
-  def aborted: Boolean = _aborted
+  def aborted: Boolean = abortedBy.isDefined
+
+  def abortMessage: String = abortedBy.getOrElse("NOT aborted")
 
   /**
     * Abort the scenario run, for example, because a given threw an exception.
     */
-  def abort(): Unit = {
-    _aborted = true
+  def abort(msg: String): Unit = {
+    abortedBy = Some(msg)
   }
 
   def put(key: String, value: Object): Unit = {

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerScenarioWorld.scala
@@ -16,7 +16,7 @@ class EventHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = N
 
   //private var registeredHandlers: Set[EventHandler] = Set()
 
-  private var handler: Option[EventHandler] = _
+  private var handler: Option[EventHandler] = None
 
   def eventHandler(name: String): EventHandler = {
     rugs match {

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/FailingFeature1Steps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/FailingFeature1Steps.ts
@@ -1,0 +1,13 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+    // Will fail as we don't register a handler
+   //world.registerHandler("ReturnsEmptyPlanEventHandler")
+   world.sendEvent(new node.Commit)
+})
+Then("excitement ensues", world => {
+    return world.plan().messages.length == 0
+})


### PR DESCRIPTION
The test support used the default value for `Option` - `null` rather than `None` and therefore failed with an NPE when trying to retrieve a handler if none was registered. Fixed this bug and also captured the message from a `Throwable` that caused the scenario to abort to display to the user in test results.