### PR TITLE
Allow void returns for Then steps

### DIFF
--- a/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
@@ -75,6 +75,10 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
           case Right(rsom: ScriptObjectMirror) =>
             val result = NashornUtils.stringProperty(rsom, "result", "false") == "true"
             AssertionResult(step.getText, Result(result, NashornUtils.stringProperty(rsom, "message", "Detailed information unavailable")))
+          case Right(r) if ScriptObjectMirror.isUndefined(r) =>
+            // Returning void (which will be undefined) is truthy
+            // This enables use of frameworks such as as chai
+            AssertionResult(step.getText, Result(f = true, stepMatch.jsVar.toString))
           case Right(wtf) =>
             throw new IllegalArgumentException(s"Unexpected result from Then '${step.getText}': $wtf")
           case Left(t) =>
@@ -136,9 +140,7 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
       case t => t
     }
     val args = Seq(target, world) ++ sm.args
-    allCatch.either(sm.jsVar.call("apply",
-      args:_*
-    ))
+    allCatch.either(sm.jsVar.call("apply", args:_*))
   }
 
 }

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -73,7 +73,7 @@ interface Definitions {
 
     When(s: string, f: (Project, HandlerScenarioWorld?, ...args) => void): void
 
-    Then(s: string, f: (Project, HandlerScenarioWorld?, ...args) => Result | boolean): void
+    Then(s: string, f: (Project, HandlerScenarioWorld?, ...args) => Result | boolean | void): void
 
 }
 
@@ -88,7 +88,15 @@ export function When(s: string, f: (Project, HandlerScenarioWorld?, ...args) => 
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f)
 }
 
-export function Then(s: string, f: (Project, HandlerScenarioWorld?, ...args) => Result | boolean) {
+
+/**
+ * A Then step can return a Result object, containing a result and details,
+ * a boolean indicating pass or fail, or void.
+ * A successful void return is equivalent to true, while throwing an Error
+ * means failure. The void return style allows idiomatic use of assertion frameworks
+ * such as chai.
+ */
+export function Then(s: string, f: (Project, HandlerScenarioWorld?, ...args) => Result | boolean | void) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f)
 }
 

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/FailsDueToError.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/FailsDueToError.ts
@@ -1,0 +1,12 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", world => {
+    world.registerHandler("ReturnsEmptyPlanEventHandler")
+})
+When("a visionary leader enters", world => {
+   world.sendEvent(new node.Commit)
+})
+Then("excitement ensues", world => {
+    throw new Error("What in God's holy name are you blathering about")
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2d.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2d.ts
@@ -1,0 +1,14 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+import * as node from "../../../handlers/event/Nodes"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsAMessage")
+   let c = new node.Commit().withMadeBy(new node.Person("Ebony"))
+   world.sendEvent(c)
+})
+Then("excitement ensues", world => {
+    // Void return is the same as returning true.
+    // This enables us to use assertion frameworks such as Chai
+})

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
@@ -59,8 +59,29 @@ class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
     val run = grt.execute()
     run.result match {
       case Failed(msg) =>
-        println(s"Message is[$msg]")
         assert(!msg.contains("null"))
+      case wtf => fail(s"Unexpected: $wtf")
+    }
+  }
+
+  it should "produce good message when a test fails with a void return and exception" in {
+    val passingFeature1StepsFile = requiredFileInPackage(
+      this,
+      "FailsDueToError.ts",
+      ".atomist/tests/handlers/event"
+    )
+
+    val handlerFile = requiredFileInPackage(this, "EventHandlers.ts", atomistConfig.handlersRoot + "/event")
+    val as = SimpleFileBasedArtifactSource(Feature1File, passingFeature1StepsFile, handlerFile, nodesFile)
+
+    //println(ArtifactSourceUtils.prettyListFiles(as))
+    val cas = TypeScriptBuilder.compileWithModel(as)
+
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Some(RugArchiveReader.find(cas)))
+    val run = grt.execute()
+    run.result match {
+      case Failed(msg) =>
+        assert(msg.contains("What in God's holy name are you blathering about"))
       case wtf => fail(s"Unexpected: $wtf")
     }
   }
@@ -94,6 +115,9 @@ class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
 
   it should "verify no plan steps with matching simple path match using named type" in
     verifyNoPlanStepsWithMatchingSimplePathMatch("PassingFeature1Steps2a.ts")
+
+  it should "verify no plan steps with matching simple path match with void return" in
+    verifyNoPlanStepsWithMatchingSimplePathMatch("PassingFeature1Steps2d.ts")
 
   it should "verify no plan steps with matching deeper path match" in
     verifyNoPlanStepsWithMatchingSimplePathMatch("PassingFeature1Steps4.ts")


### PR DESCRIPTION
Allowing a void returning allow users to use assertion frameworks such as chai.