### PR TITLE
Move typedoc outside of the node module

### DIFF
--- a/src/main/scripts/gh-publish.bash
+++ b/src/main/scripts/gh-publish.bash
@@ -56,7 +56,7 @@ function main() {
     fi
 
     for module in rug cortex; do
-        if ! mv "target/.atomist/node_modules/@atomist/$module/typedoc" "target/site/typedoc/$module"; then
+        if ! mv "target/typedoc/$module" "target/site/typedoc/$module"; then
             err "failed to move $module TypeDoc to site directory"
             return 1
         fi

--- a/src/main/typescript/node_modules/@atomist/cortex/gulpfile.js
+++ b/src/main/typescript/node_modules/@atomist/cortex/gulpfile.js
@@ -10,7 +10,7 @@ gulp.task("typedoc", function () {
             module: "commonjs",
             target: "ES5",
             includeDeclarations: true,
-            out: "./typedoc",
+            out: "../../../../typedoc/cortex",
             mode: "file",
             // json: "typedoc/rug.json",
             name: "Atomist",

--- a/src/main/typescript/node_modules/@atomist/rug/gulpfile.js
+++ b/src/main/typescript/node_modules/@atomist/rug/gulpfile.js
@@ -10,7 +10,7 @@ gulp.task("typedoc", function () {
             module: "commonjs",
             target: "ES5",
             includeDeclarations: true,
-            out: "./typedoc",
+            out: "../../../../typedoc/rug",
             mode: "file",
             // json: "typedoc/rug.json",
             name: "Atomist",


### PR DESCRIPTION
Remove `typedoc` from node modules `rug` and `cortex`. 