### PR TITLE
Pass the world only once to handler tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.21.0...HEAD
 
+### Changed
+
+-  If the fixture is the same as the world in a Gherkin step, pass only one parameter. This changes the 
+signatures of handler tests.
+
 ## [0.21.0] - 2017-03-30
 
 [0.21.0]: https://github.com/atomist/rug/compare/0.20.0...0.21.0

--- a/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
@@ -138,7 +138,12 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
       case gn: GraphNode => new jsSafeCommittingProxy(gn, world.typeRegistry)
       case t => t
     }
-    val args = Seq(target, world) ++ sm.args
+    // Only include the target if it's different from the world.
+    val fixedParams: Seq[AnyRef] = target match {
+      case `world` => Seq(world)
+      case _ => Seq(target, world)
+    }
+    val args = fixedParams ++ sm.args
     allCatch.either(sm.jsVar.call("apply", args:_*))
   }
 

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -71,27 +71,32 @@ export interface EventHandlerScenarioWorld extends HandlerScenarioWorld {
 }
 
 
+// Callback for given and when steps
+type SetupCallback = (HandlerScenarioWorld, ...args) => void
+
+type ThenCallback = (HandlerScenarioWorld?, ...args) => Result | boolean | void
+
+
 interface Definitions {
 
-    Given(s: string, f: (Project, HandlerScenarioWorld?, ...args) => void): void
+    Given(s: string, f: SetupCallback): void
 
-    When(s: string, f: (Project, HandlerScenarioWorld?, ...args) => void): void
+    When(s: string, f: SetupCallback): void
 
-    Then(s: string, f: (Project, HandlerScenarioWorld?, ...args) => Result | boolean | void): void
+    Then(s: string, f: ThenCallback): void
 
 }
 
  // Registered with Nashorn by the test runner
 declare var com_atomist_rug_test_gherkin_GherkinRunner$_definitions: Definitions
 
-export function Given(s: string, f: (Project, HandlerScenarioWorld?, ...args) => void) {
+export function Given(s: string, f: SetupCallback) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f)
 }
 
-export function When(s: string, f: (Project, HandlerScenarioWorld?, ...args) => void) {
+export function When(s: string, f: SetupCallback) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f)
 }
-
 
 /**
  * A Then step can return a Result object, containing a result and details,
@@ -100,7 +105,7 @@ export function When(s: string, f: (Project, HandlerScenarioWorld?, ...args) => 
  * means failure. The void return style allows idiomatic use of assertion frameworks
  * such as chai.
  */
-export function Then(s: string, f: (Project, HandlerScenarioWorld?, ...args) => Result | boolean | void) {
+export function Then(s: string, f: ThenCallback) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f)
 }
 

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
@@ -2,9 +2,10 @@ import {Given, When, Then} from "./Core"
 
 // Register well-known steps
 
-Then("parameters were invalid", 
-    (p, world) => world.invalidParameters() != null)
+Then("parameters were invalid", world =>
+    world.invalidParameters() != null
+)
 
-Then("plan has no messages", (p,world) => {
+Then("plan has no messages", world => {
     return world.plan().messages().length == 0
 })

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/command/SingleMessageFeature1StepsWithMatchingPathExpression.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/command/SingleMessageFeature1StepsWithMatchingPathExpression.ts
@@ -3,7 +3,7 @@ import * as node from "../../../handlers/command/Nodes"
 
 Given("a sleepy country", f => {
 });
-When("a visionary leader enters", (rugContext, world) => {
+When("a visionary leader enters", world => {
     let handler = world.commandHandler("RunsMatchingPathExpressionCommandHandler");
     let c = new node.Commit().withMadeBy(new node.Person("Ebony"));
     world.addToRootContext(c);


### PR DESCRIPTION
We now only pass the world once to handler tests, by checking whether the fixture is in fact different. It _is_ different for project tests, but not for handler tests.