### PR TITLE
Fixes #486 and #487: Improved TypeScript stub class generation

### DIFF
--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
@@ -2,12 +2,14 @@ package com.atomist.rug.runtime.js
 
 import com.atomist.graph.GraphNode
 import com.atomist.param.Tag
-import com.atomist.rug.runtime.js.interop.{jsContextMatch, jsSafeCommittingProxy}
+import com.atomist.rug.runtime.js.interop.{NashornMapBackedGraphNode, jsContextMatch, jsSafeCommittingProxy}
 import com.atomist.rug.runtime.{AddressableRug, EventHandler, RugSupport, SystemEvent}
 import com.atomist.rug.spi.Handlers.Plan
+import com.atomist.rug.spi.TypeRegistry
 import com.atomist.rug.{InvalidHandlerResultException, RugRuntimeException}
 import com.atomist.tree.TreeNode
 import com.atomist.tree.pathexpression.{NamedNodeTest, NodesWithTag, PathExpression, PathExpressionParser}
+import com.atomist.util.lang.JavaScriptArray
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 /**
@@ -65,8 +67,8 @@ class JavaScriptEventHandler(jsc: JavaScriptContext,
       case Right(Nil) => None
       case Right(matches) if matches.nonEmpty =>
         val cm = jsContextMatch(
-          jsSafeCommittingProxy.wrapOne(targetNode, ctx.typeRegistry),
-          jsSafeCommittingProxy.wrap(matches, ctx.typeRegistry),
+          wrapOne(targetNode, ctx.typeRegistry),
+          wrap(matches, ctx.typeRegistry),
           teamId = e.teamId)
         invokeMemberFunction(jsc, handler, "handle", jsMatch(cm)) match {
           case plan: ScriptObjectMirror => ConstructPlan(plan)
@@ -78,6 +80,18 @@ class JavaScriptEventHandler(jsc: JavaScriptContext,
           s"Error evaluating path expression $pathExpression: [$failure]")
     }
   }
+
+  private def wrapOne(n: GraphNode, typeRegistry: TypeRegistry): AnyRef = n match {
+    case nbgn: NashornMapBackedGraphNode =>
+      nbgn.scriptObject
+    case _ =>
+      jsSafeCommittingProxy.wrapOne(n, typeRegistry)
+  }
+
+  import scala.collection.JavaConverters._
+
+  private def wrap(nodes: Seq[GraphNode], typeRegistry: TypeRegistry): java.util.List[AnyRef] =
+    new JavaScriptArray(nodes.map(wrapOne(_, typeRegistry)).asJava)
 }
 
 /**
@@ -89,7 +103,7 @@ private case class jsMatch(cm: jsContextMatch) {
 
   def root(): Object = cm.root
 
-  def matches(): java.util.List[jsSafeCommittingProxy] = cm.matches
+  def matches(): java.util.List[AnyRef] = cm.matches
 
   override def toString: String = cm.toString
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptEventHandler.scala
@@ -101,7 +101,7 @@ class JavaScriptEventHandler(jsc: JavaScriptContext,
   */
 private case class jsMatch(cm: jsContextMatch) {
 
-  def root(): Object = cm.root
+  def root(): AnyRef = cm.root
 
   def matches(): java.util.List[AnyRef] = cm.matches
 

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsContextMatch.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsContextMatch.scala
@@ -2,9 +2,10 @@ package com.atomist.rug.runtime.js.interop
 
 /**
   * Fronts JavaScript Context object
+  * Detyped as a Nashorn objects may be passed that do not implement GraphNode
   */
-case class jsContextMatch(root: Object,
-                          matches: _root_.java.util.List[jsSafeCommittingProxy],
+case class jsContextMatch(root: AnyRef,
+                          matches: _root_.java.util.List[AnyRef],
                           teamId: String) {
 
   import scala.collection.JavaConverters._

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsPathExpressionEngine.scala
@@ -24,7 +24,8 @@ import scala.collection.JavaConverters._
   * @param root    root we evaluated path from
   * @param matches matches
   */
-case class jsMatch(root: GraphNode, matches: _root_.java.util.List[jsSafeCommittingProxy])
+case class jsMatch(root: GraphNode,
+                   matches: _root_.java.util.List[GraphNode])
 
 /**
   * JavaScript-friendly facade to an ExpressionEngine.
@@ -136,7 +137,7 @@ class jsPathExpressionEngine(
     * @param root root of Tree. SafeCommittingProxy wrapping a TreeNode
     * @param pe   path expression of object
     */
-  def scalar(root: GraphNode, pe: Object): jsSafeCommittingProxy = {
+  def scalar(root: GraphNode, pe: Object): GraphNode = {
     val res = evaluate(root, pe)
     val ms = res.matches
     ms.size() match {
@@ -171,7 +172,8 @@ class jsPathExpressionEngine(
   /**
     * Try to cast the given node to the required type.
     */
-  def as(root: GraphNode, name: String): jsSafeCommittingProxy = scalar(root, s"->$name")
+  def as(root: GraphNode, name: String): GraphNode =
+    scalar(root, s"->$name")
 
   /**
     * Find the children of the current node of the named type.
@@ -179,7 +181,7 @@ class jsPathExpressionEngine(
     * @param parent parent node we want to look under
     * @param name   name of the children we want to look for
     */
-  def children(parent: GraphNode, name: String): util.List[jsSafeCommittingProxy] = {
+  def children(parent: GraphNode, name: String): util.List[GraphNode] = {
     val rootTn = toUnderlyingTreeNode(parent)
     val typ = typeRegistry.findByName(name).getOrElse(
       throw new IllegalArgumentException(s"Unknown type")

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -177,7 +177,7 @@ class jsSafeCommittingProxy(
     override def call(thiz: scala.Any, args: AnyRef*): AnyRef = {
       import scala.language.reflectiveCalls
       val nodesAccessedThroughThisFunctionCall: Seq[GraphNode] = node.relatedNodesNamed(name)
-      println(s"${this}.call returned $nodesAccessedThroughThisFunctionCall")
+      //println(s"${this}.call returned $nodesAccessedThroughThisFunctionCall")
       nodesAccessedThroughThisFunctionCall.toList match {
         case Nil =>
           throw new RugRuntimeException(name,

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/AbstractHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/AbstractHandlerScenarioWorld.scala
@@ -93,16 +93,6 @@ abstract class AbstractHandlerScenarioWorld(definitions: Definitions, rugs: Opti
   def planCount: Int = recordedPlans.size
 
   /**
-    * Return the message or null if none was recorded
-    */
-  def message: jsScalaHidingProxy = {
-    recordedPlans.values.toList match {
-      case List(p) => p.messages.map(jsScalaHidingProxy.apply(_)).head
-      case _ => null
-    }
-  }
-
-  /**
     * Is the plan internally valid? Do the referenced handlers and other operations exist?
     */
   def planIsInternallyValid(): Boolean = {

--- a/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
@@ -79,6 +79,11 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
 
     def description: Option[String]
 
+    def returnsArray: Boolean = returnType.contains("[")
+
+    /** Return the underlying type if we return an array */
+    def underlyingType: String = returnType.stripSuffix("[]")
+
     def comment: String = {
       val builder = new StringBuilder(s"$indent/**\n")
       builder ++= s"$indent  * ${description.getOrElse("")}\n"

--- a/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
@@ -197,13 +197,6 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
   private def shouldEmit(top: TypeOperation) =
     !(top.parameters.exists(_.parameterType.contains("FunctionInvocationContext")) || "eval".equals(top.name))
 
-  protected def emitDocComment(description: String): String = {
-    s"""
-       |/*
-       | * ${description.replace("\n", "\n * ")}
-       | */""".stripMargin
-  }
-
   private def emitTypes(poa: ParameterValues): Seq[FileArtifact] = {
     val tsClassOrInterfaces = ListBuffer.empty[StringFileArtifact]
     val alreadyGenerated = ListBuffer.empty[GeneratedType]

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -38,7 +38,7 @@ class TypeScriptInterfaceGenerator(typeRegistry: TypeRegistry = DefaultTypeRegis
 
     override def toString: String = {
       val output = new StringBuilder
-      output ++= emitDocComment(description)
+      output ++= helper.toJsDoc(description)
       if (parent.isEmpty)
         output ++= s"\ninterface $name {${config.separator}"
       else

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -106,23 +106,25 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
             if (returnsArray) {
               // It's an array type. Create an "addX" method to add the value to the array,
               // initializing it if necessary
-              s"""
+              helper.indented(s"""
                  |
-                 |${indent}add${upperize(name)}($name: ${underlyingType}): $typeName {
-                 |$indent${indent}if (this.${toFieldName(this)} === undefined)
-                 |$indent$indent${indent}this.${toFieldName(this)} = [];
-                 |$indent${indent}this.${toFieldName(this)}.push($name);
-                 |$indent${indent}return this;
-                 |$indent}""".stripMargin
+                 |${helper.toJsDoc(s"Fluent builder method to add an element to the $name array")}
+                 |add${upperize(name)}($name: $underlyingType): $typeName {
+                 |${indent}if (this.${toFieldName(this)} === undefined)
+                 |$indent${indent}this.${toFieldName(this)} = [];
+                 |${indent}this.${toFieldName(this)}.push($name);
+                 |${indent}return this;
+                 |}""".stripMargin, 1)
             }
             else {
               // It's a scalar. Create a "withX" method to set the value
-              s"""
+              helper.indented(s"""
                  |
-                 |${indent}with${upperize(name)}($name: $returnType): $typeName {
-                 |$indent${indent}this.${toFieldName(this)} = $name;
-                 |$indent${indent}return this;
-                 |$indent}""".stripMargin
+                 |${helper.toJsDoc(s"Fluent builder method to set the $name property")}
+                 |with${upperize(name)}($name: $returnType): $typeName {
+                 |${indent}this.${toFieldName(this)} = $name;
+                 |${indent}return this;
+                 |}""".stripMargin, 1)
             }
           core + builderMethod
       }

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -12,6 +12,9 @@ private object TypeScriptStubClassGenerator {
     """
       |Generated class exposing Atomist Cortex.
       |Fluent builder style class for use in testing and query by example.""".stripMargin
+
+  val GraphNodeMethodImplementationDoc: String =
+    "Implementation of GraphNode interface method.\nFor infrastructure, not user use"
 }
 
 /**
@@ -24,6 +27,8 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
                                    override val tags: Seq[Tag] = Nil,
                                    val root: String = "GraphNode")
   extends AbstractTypeScriptGenerator(typeRegistry, config, true, tags) {
+
+  import TypeScriptStubClassGenerator._
 
   private case class ClassGeneratedType(name: String,
                                         description: String,
@@ -40,8 +45,7 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
 
     override def toString: String = {
       val output = new StringBuilder
-      output ++= emitDocComment(description + "\n" +
-        TypeScriptStubClassGenerator.DefaultTypedocBoilerplate)
+      output ++= helper.toJsDoc(description + "\n" + DefaultTypedocBoilerplate)
       output ++= s"\nclass $name "
       val implementation = s"implements $interfaceModuleImport.$name"
       output ++= (if (parent.head == root) {
@@ -61,16 +65,17 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
 
       // Emit methods from GraphNode We need a tag of "-dynamic" to allow dispatch in the proxy
       output ++=
-        s"""|${indent}nodeName(): string {
-            |${indent}${indent}return "$name";
-            |$indent}
-            |
-            |${indent}nodeTags(): string[] {
-            |${indent}${indent}return [ "$name", "-dynamic" ];
-            |$indent}
-            |
-            |""".stripMargin
-
+        helper.indented(
+          s"""|${helper.toJsDoc(GraphNodeMethodImplementationDoc)}
+              |nodeName(): string {
+              |${indent}return "$name";
+              |}
+              |
+              |${helper.toJsDoc(GraphNodeMethodImplementationDoc)}
+              |nodeTags(): string[] {
+              |${indent}return [ "$name", "-dynamic" ];
+              |}""".stripMargin, 1)
+      output ++= config.separator
       output ++= methods.map(_.toString).mkString(config.separator)
       output ++= s"${if (methods.isEmpty) "" else config.separator}}${indent.dropRight(1)}"
       output.toString

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -103,12 +103,27 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
                 |$indent${indent}return this.${toFieldName(this)};
                 |$indent}""".stripMargin
           val builderMethod =
-            s"""
-               |
-               |${indent}with${upperize(name)}($name: $returnType): $typeName {
-               |$indent${indent}this.${toFieldName(this)} = $name;
-               |$indent${indent}return this;
-               |$indent}""".stripMargin
+            if (returnsArray) {
+              // It's an array type. Create an "addX" method to add the value to the array,
+              // initializing it if necessary
+              s"""
+                 |
+                 |${indent}add${upperize(name)}($name: ${underlyingType}): $typeName {
+                 |$indent${indent}if (this.${toFieldName(this)} === undefined)
+                 |$indent$indent${indent}this.${toFieldName(this)} = [];
+                 |$indent${indent}this.${toFieldName(this)}.push($name);
+                 |$indent${indent}return this;
+                 |$indent}""".stripMargin
+            }
+            else {
+              // It's a scalar. Create a "withX" method to set the value
+              s"""
+                 |
+                 |${indent}with${upperize(name)}($name: $returnType): $typeName {
+                 |$indent${indent}this.${toFieldName(this)} = $name;
+                 |$indent${indent}return this;
+                 |$indent}""".stripMargin
+            }
           core + builderMethod
       }
 

--- a/src/main/scala/com/atomist/tree/TreeNode.scala
+++ b/src/main/scala/com/atomist/tree/TreeNode.scala
@@ -19,9 +19,9 @@ trait TreeNode extends GraphNode {
   @ExportFunction(readOnly = true, description = "Node content")
   def value: String
 
-  def relatedNodes: Seq[TreeNode] = childNodes
+  override def relatedNodes: Seq[GraphNode] = childNodes
 
-  def relatedNodesNamed(key: String): Seq[TreeNode] = childrenNamed(key)
+  override def relatedNodesNamed(key: String): Seq[GraphNode] = childrenNamed(key)
 
   def childrenNamed(key: String): Seq[TreeNode]
 

--- a/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
@@ -15,10 +15,9 @@ class TypeScriptGenerationHelper(indent: String = "    ")
     * Convert the block to a JsDoc style comment.
     */
   def toJsDoc(block: String): String = {
-    s"""
-       |/**
-       |   ${indented(block, 1)}
-       |*/""".stripMargin
+    s"""|/*
+        | * ${block.replace("\n", "\n * ")}
+        | */""".stripMargin
   }
 
   def javaTypeToTypeScriptType(jt: String, tr: TypeRegistry): String = {

--- a/src/main/scala/com/atomist/util/misc/SerializationFriendlyLazyLogging.scala
+++ b/src/main/scala/com/atomist/util/misc/SerializationFriendlyLazyLogging.scala
@@ -14,7 +14,7 @@ trait SerializationFriendlyLazyLogging {
 
   @Transient
   @JsonIgnore
-  private lazy val logger: Logger =
+  protected lazy val logger: Logger =
     Logger(LoggerFactory.getLogger(getClass.getName))
 
 }

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
@@ -4,9 +4,12 @@ import { GraphNode, Match, PathExpression } from '@atomist/rug/tree/PathExpressi
 import { EventHandler, Tags } from '@atomist/rug/operations/Decorators'
 
 import {Build} from "@atomist/rug/cortex/Build"
+import {Push} from "@atomist/rug/cortex/Push"
+
 import * as buildstub from "@atomist/rug/cortex/stub/Build"
 import * as repostub from "@atomist/rug/cortex/stub/Repo"
 import * as ccstub from "@atomist/rug/cortex/stub/ChatChannel"
+
 
 /**
  * Works against generated model
@@ -26,3 +29,19 @@ class ReturnsEmptyPlanEventHandlerGen1 implements HandleEvent<GraphNode, Build> 
     }
 }
 export const handler1 = new ReturnsEmptyPlanEventHandlerGen1();
+
+@EventHandler("ReturnsEmptyPlanEventHandlerGenWithArrays", "Handles a new Commit event",
+    new PathExpression<GraphNode, Push>(
+        `/Push()`))
+@Tags("push")
+class ReturnsEmptyPlanEventHandlerGenWithArrays implements HandleEvent<GraphNode, Push> {
+
+    handle(m: Match<GraphNode, Push>) {
+        let p: Push = m.matches()[0]
+
+        if (p.contains().length != 1) throw new Error("No contains")
+
+        return new Plan();
+    }
+}
+export const handler2 = new ReturnsEmptyPlanEventHandlerGenWithArrays();

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1StepsAgainstGeneratedWithArrays.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1StepsAgainstGeneratedWithArrays.ts
@@ -1,0 +1,17 @@
+import {Given,When,Then, HandlerScenarioWorld} from "@atomist/rug/test/handler/Core"
+
+import {Push} from "@atomist/rug/cortex/stub/Push"
+import {Commit} from "@atomist/rug/cortex/stub/Commit"
+
+ 
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   world.registerHandler("ReturnsEmptyPlanEventHandlerGenWithArrays")
+   let p = new Push().addContains(new Commit())
+   //console.log(`Contains are ${p.contains().length} `);
+   world.sendEvent(p)
+})
+Then("excitement ensues", world => {
+    return world.plan().messages.length == 0
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature2Steps1.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature2Steps1.ts
@@ -9,9 +9,9 @@ When("i call you", world => {
    world.sendEvent(new node.GitHubId("myId"))
 })
 Then("you call me", world => {
-    return world.message() != null
+    return world.plan().messages[0] != null
 })
 Then("to greet me", world => {
-    let message = world.message()
-    return (message.body.value == "Hello there!")
+    let message = world.plan().messages[0]
+    return (message.body === "Hello there!")
 })

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/event/GherkinRunnerEventHandlerTest.scala
@@ -111,8 +111,13 @@ class GherkinRunnerEventHandlerTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "use generated model" in
+  it should "use generated model"
     useGeneratedModel("PassingFeature1StepsAgainstGenerated.ts")
+
+
+  it should "#487: use generated model with arrays" in (
+    useGeneratedModel("PassingFeature1StepsAgainstGeneratedWithArrays.ts")
+  )
 
   private def useGeneratedModel(stepsFile: String): Unit = {
     val passingFeature1StepsFile = requiredFileInPackage(

--- a/src/test/scala/com/atomist/rug/ts/CortexTypeGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/ts/CortexTypeGeneratorTest.scala
@@ -27,8 +27,8 @@ class CortexTypeGeneratorTest extends FlatSpec with Matchers {
     val extendedModel = typeGen.toNodeModule(CortexJson)
       .withPathAbove(".atomist/rug")
      //println(ArtifactSourceUtils.prettyListFiles(as))
-//    extendedModel.allFiles.filter(_.name.endsWith(".ts")).foreach(f =>
-//      println(s"${f.path}\n${f.content}\n\n"))
+    extendedModel.allFiles.filter(_.name.endsWith(".ts")).foreach(f =>
+      println(s"${f.path}\n${f.content}\n\n"))
     val cas = TypeScriptBuilder.compiler.compile(extendedModel + TypeScriptBuilder.compileUserModel(Seq(
       TypeScriptBuilder.coreSource,
       extendedModel

--- a/src/test/scala/com/atomist/rug/ts/CortexTypeGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/ts/CortexTypeGeneratorTest.scala
@@ -27,8 +27,8 @@ class CortexTypeGeneratorTest extends FlatSpec with Matchers {
     val extendedModel = typeGen.toNodeModule(CortexJson)
       .withPathAbove(".atomist/rug")
      //println(ArtifactSourceUtils.prettyListFiles(as))
-    extendedModel.allFiles.filter(_.name.endsWith(".ts")).foreach(f =>
-      println(s"${f.path}\n${f.content}\n\n"))
+//    extendedModel.allFiles.filter(_.name.endsWith(".ts")).foreach(f =>
+//      println(s"${f.path}\n${f.content}\n\n"))
     val cas = TypeScriptBuilder.compiler.compile(extendedModel + TypeScriptBuilder.compileUserModel(Seq(
       TypeScriptBuilder.coreSource,
       extendedModel


### PR DESCRIPTION
- Fixes #486. Makes generated code easier for users to understand. Also polishes generation of TypeDoc.
- Fixes #487: Array types can now be populated in stub classes, and the values retrieved.
- Reduces coupling to `jsSafeCommittingProxy` throughout codebase.