### PR TITLE
Clean and document build and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 
-- **BREAKING** Generated TypeScript project model types use properties rather than functions for no-arg operations
-marked with `@ExportFunction` when the new `exposeAsProperty` flag is true.
-- **BREAKING** All Generated TypeScript Cortex types use properties rather than functions for 
-all navigation
-- **BREAKING** Use specific message types in Plans for the different scenarios (directed, lifecycle and response) as 
-  per https://github.com/atomist/rug/issues/501
+-   **BREAKING** Generated TypeScript project model types use
+    properties rather than functions for no-arg operations marked with
+    `@ExportFunction` when the new `exposeAsProperty` flag is true
+-   **BREAKING** All Generated TypeScript Cortex types use properties
+    rather than functions for all navigation
+-   **BREAKING** Use specific message types in Plans for the different
+    scenarios (directed, lifecycle and response) as per [#501][501]
+-   Improved build
+-   Make TypeScript generator for rug more like that for cortex
+-   Improve release documentation
+
+[501]: https://github.com/atomist/rug/issues/501
 
 ## [0.24.0] - 2017-04-04
 
@@ -26,13 +32,12 @@ The one TS to rule all stubs
 
 ### Changed
 
-- Model stubs are generated in one uber file
-- Generally refined TS generation
+-   Model stubs are generated in one uber file
+-   Generally refined TS generation
 
 ### Added
 
-- Set the channel id on a message with `withChannelId`
-
+-   Set the channel id on a message with `withChannelId`
 
 ## [0.23.0] - 2017-03-31
 
@@ -42,7 +47,8 @@ TypeScript stub generation and proxy improvement release
 
 ### Changed
 
-- Now generating `add` instead of `with` methods to handle arrays in TypeScript code generation
+-   Now generating `add` instead of `with` methods to handle arrays in
+    TypeScript code generation
 
 ## [0.22.0] - 2017-03-31
 
@@ -50,7 +56,7 @@ TypeScript stub generation and proxy improvement release
 ### Changed
 
 -   **BREAKING** internal API for resolving and loading Rugs has changed to deal with
-    more complex dependency resolution scenarios. Also removal of AddressableRug and 
+    more complex dependency resolution scenarios. Also removal of AddressableRug and
     RugSupport traits.
 
 [0.22.0]: https://github.com/atomist/rug/compare/0.21.0...0.22.0
@@ -60,8 +66,8 @@ Back from the future release
 ### Changed
 
 -   Removed use of `Futures` in `LocalPlanRunner`
--   Changed `ServiceLoader`-based registries to not use caching 
--  If the fixture is the same as the world in a Gherkin step, pass only one parameter. This changes the 
+-   Changed `ServiceLoader`-based registries to not use caching
+-  If the fixture is the same as the world in a Gherkin step, pass only one parameter. This changes the
 signatures of handler tests.
 
 ## [0.21.0] - 2017-03-30

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ If you find a problem, please create an [issue][].
 
 ## Development
 
-You can build, test, and install the project locally with [maven][].
+You can build, test, and install the project locally
+with [Maven][maven].
 
 [maven]: https://maven.apache.org/
 
@@ -98,28 +99,83 @@ You can build, test, and install the project locally with [maven][].
 $ mvn install
 ```
 
-To create a new release of the project, simply push a tag of the form
-`M.N.P` where `M`, `N`, and `P` are integers that form the next
-appropriate [semantic version][semver] for release.  For example:
+This will build, test, and locally install the Rug library.  To build
+the Rug TypeScript `@atomist/rug` and `@atomist/cortex` modules, the
+"npm-release" profile must be used.  Unlike the [cortex][] build, the
+cortex model is not downloaded dynamically because Rug tracks the
+latest, perhaps unreleased, version of the model.
 
-```
-$ git tag -a 1.2.3
-```
-
-The Travis CI build (see badge at the top of this page) will
-automatically create a GitHub release using the tag name for the
-release and the comment provided on the annotated tag as the contents
-of the release notes.  It will also automatically upload the needed
-artifacts.
-
-[semver]: http://semver.org
-
-The Rug extension documentation is created as part of running the
-Maven lifecycle `test` phase under the `npm-release` profile.
+To build the TypeScript modules and their documentation, generated
+from the TypeScript modules using [TypeDoc][typedoc], execute at least
+through the Maven lifecycle `test` phase using the `npm-release`
+profile.
 
 ```
 $ mvn -P npm-release test
 ```
 
 The documentation for all of the Rug extensions will be in a directory
-named `target/.atomist/node_modules/@atomist/rug/typedoc`.
+named `target/typedoc`.
+
+[typedoc]: http://typedoc.org/
+
+## Release
+
+Releasing Rug involves releasing the JVM artifacts to a Maven
+repository, the TypeScript module to NPM, and the documentation to
+GitHub pages for this repository, available at
+http://apidocs.atomist.com/.  Releasing Rug can be a multi-stepped
+process, depending on the changes that have been made.
+
+If there are no changes to the TypeScript API, to create a release
+simply push a tag of the form `M.N.P` where `M`, `N`, and `P` are
+integers that form the next appropriate [semantic version][semver] for
+release.  For example:
+
+```
+$ git tag -a 1.2.3
+```
+
+The Travis CI build (see badge at the top of this page) will upload
+the needed artifacts and automatically create a GitHub release using
+the tag name for the release and the comment provided on the annotated
+tag as the contents of the release notes.  The released artifacts are:
+
+-   Maven rug artifacts
+-   [`@atomist/rug`][rug-npm] Node module to [NPM][npm]
+-   TypeDoc for `@atomist/rug` and [`@atomist/cortex`][cortex-npm] to
+    the gh-pages branch of this repository, available under
+    http://apidocs.atomist.com/typedoc/
+
+Note that while the `@atomist/cortex` module is built as part of the
+rug build, it is published by the [cortex][]
+repository [build][cortex-build].  The cortex release process also
+publishes the cortex TypeDoc to http://cortex.atomist.com .  So if the
+API of cortex has changed at all, you will need to initiate a release
+of that repository.  This confusion will need to be resolved at some
+point in the future.
+
+[semver]: http://semver.org
+[rug-npm]: https://www.npmjs.com/package/@atomist/rug
+[npm]: https://www.npmjs.com/
+[cortex-npm]: https://www.npmjs.com/package/@atomist/cortex
+[cortex]: https://github.com/atomist/cortex
+[cortex-build]: https://travis-ci.org/atomist/cortex
+
+If there have been changes to either the `@atomist/rug` or
+`@atomist/cortex` TypeScript APIs, you will need to update the
+dependencies in the [rugs][] repository `package.json` and initiate a
+new release of that repository to publish a new version of the
+`@atomist/rugs` TypeScript module, which is the dependency everyone
+uses to bring in rug and cortex.  This should all be automated,
+perhaps in a separate repository or by chaining events to span
+repositories.
+
+[rugs]: https://github.com/atomist/rugs
+
+---
+Created by [Atomist][atomist].
+Need Help?  [Join our Slack team][slack].
+
+[atomist]: https://www.atomist.com/
+[slack]: https://join.atomist.com/

--- a/pom.xml
+++ b/pom.xml
@@ -428,8 +428,8 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <installDirectory>target/</installDirectory>
-                            <workingDirectory>target/</workingDirectory>
+                            <installDirectory>${project.build.directory}</installDirectory>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -445,13 +445,13 @@
                                 <phase>process-test-resources</phase>
                                 <configuration>
                                     <target>
-                                        <exec executable="target/node_modules/typescript/bin/tsc" failonerror="true">
+                                        <exec executable="${project.build.directory}/node_modules/typescript/bin/tsc" failonerror="true">
                                             <arg value="-p"/>
-                                            <arg value="target/.atomist/node_modules/@atomist/rug"/>
+                                            <arg value="${project.build.directory}/.atomist/node_modules/@atomist/rug"/>
                                         </exec>
-                                        <exec executable="target/node_modules/typescript/bin/tsc" failonerror="true">
+                                        <exec executable="${project.build.directory}/node_modules/typescript/bin/tsc" failonerror="true">
                                             <arg value="-p"/>
-                                            <arg value="target/.atomist/node_modules/@atomist/cortex"/>
+                                            <arg value="${project.build.directory}/.atomist/node_modules/@atomist/cortex"/>
                                         </exec>
                                     </target>
                                 </configuration>
@@ -464,7 +464,7 @@
                                 <phase>generate-sources</phase>
                                 <configuration>
                                     <target>
-                                        <mkdir dir="target/.atomist"/>
+                                        <mkdir dir="${project.build.directory}/.atomist"/>
                                     </target>
                                 </configuration>
                             </execution>
@@ -476,45 +476,45 @@
                                 <phase>generate-sources</phase>
                                 <configuration>
                                     <target>
-                                        <copy todir="target/.atomist">
+                                        <copy todir="${project.build.directory}/.atomist">
                                             <fileset dir="src/main/typescript"/>
                                         </copy>
                                     </target>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>mkdir</id>
+                                <id>mkdir-rug-model</id>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <phase>generate-sources</phase>
                                 <configuration>
                                     <target>
-                                        <mkdir dir="target/.atomist/node_modules/@atomist/rug/model"/>
+                                        <mkdir dir="${project.build.directory}/.atomist/node_modules/@atomist/rug/model"/>
                                     </target>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>mkdir_cortex</id>
+                                <id>mkdir-cortex</id>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <phase>generate-sources</phase>
                                 <configuration>
                                     <target>
-                                        <mkdir dir="target/.atomist/node_modules/@atomist/cortex"/>
+                                        <mkdir dir="${project.build.directory}/.atomist/node_modules/@atomist/cortex"/>
                                     </target>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>mkdir_cortex_stub</id>
+                                <id>mkdir-cortex-stub</id>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <phase>generate-sources</phase>
                                 <configuration>
                                     <target>
-                                        <mkdir dir="target/.atomist/node_modules/@atomist/cortex/stub"/>
+                                        <mkdir dir="${project.build.directory}/.atomist/node_modules/@atomist/cortex/stub"/>
                                     </target>
                                 </configuration>
                             </execution>
@@ -534,7 +534,7 @@
                                 <configuration>
                                     <mainClass>com.atomist.rug.ts.TypeScriptInterfaceGenerator</mainClass>
                                     <arguments>
-                                        <argument>target/.atomist/node_modules/@atomist/rug/model/Core.ts</argument>
+                                        <argument>${project.build.directory}/.atomist/node_modules/@atomist</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -547,7 +547,7 @@
                                 <configuration>
                                     <mainClass>com.atomist.rug.ts.CortexTypeGeneratorApp</mainClass>
                                     <arguments>
-                                        <argument>target/.atomist/node_modules/@atomist/</argument>
+                                        <argument>${project.build.directory}/.atomist/node_modules/@atomist</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
@@ -21,6 +21,8 @@ object AbstractTypeScriptGenerator {
 
   val DefaultFilename = "model/Core.ts"
 
+  val OutputPathParam = "output_path"
+
 }
 
 /**
@@ -35,8 +37,6 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
     with ProjectEditor {
 
   import AbstractTypeScriptGenerator._
-
-  val outputPathParam = "output_path"
 
   protected val indent = "    "
   protected val helper = new TypeScriptGenerationHelper()
@@ -153,9 +153,9 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
     }
   }
 
-  override def parameters: Seq[Parameter] = Seq(Parameter(outputPathParam, ".*")
+  override def parameters: Seq[Parameter] = Seq(Parameter(OutputPathParam, ".*")
     .setRequired(false)
-    .setDisplayName("Path for created doc")
+    .setDisplayName("Path for consolidated exports file")
     .setDefaultValue(DefaultFilename))
 
   @throws[InvalidParametersException](classOf[InvalidParametersException])
@@ -225,7 +225,7 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
     val tsClassOrInterfaces = ListBuffer.empty[StringFileArtifact]
     val alreadyGenerated = ListBuffer.empty[GeneratedType]
     val generatedTypes = allGeneratedTypes(typeRegistry.types.sortWith(typeSort))
-    val pathParam = poa.stringParamValue(outputPathParam)
+    val pathParam = poa.stringParamValue(OutputPathParam)
     val path = if (pathParam.contains("/")) StringUtils.substringBeforeLast(pathParam, "/") + "/" else ""
 
     for {

--- a/src/main/scala/com/atomist/rug/ts/CortexTypeGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/CortexTypeGenerator.scala
@@ -26,6 +26,8 @@ object CortexTypeGenerator {
   */
 class CortexTypeGenerator(basePackage: String, baseClassPackage: String) {
 
+  import AbstractTypeScriptGenerator._
+
   private val mapper = new ObjectMapper() with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
 
@@ -35,8 +37,8 @@ class CortexTypeGenerator(basePackage: String, baseClassPackage: String) {
     //types.foreach(println(_))
     val tig = new TypeScriptInterfaceGenerator(typeRegistry, root = "GraphNode")
     val tcg = new TypeScriptStubClassGenerator(typeRegistry)
-    tig.generate("types", SimpleParameterValues("output_path", "Types.ts")).withPathAbove(basePackage) +
-      tcg.generate("types", SimpleParameterValues("output_path", "Types.ts")).withPathAbove(baseClassPackage)
+    tig.generate("cortex-interfaces", SimpleParameterValues(OutputPathParam, "Types.ts")).withPathAbove(basePackage) +
+      tcg.generate("cortex-class-stubs", SimpleParameterValues(OutputPathParam, "Types.ts")).withPathAbove(baseClassPackage)
   }
 
   /**

--- a/src/main/scala/com/atomist/rug/ts/CortexTypeGeneratorApp.scala
+++ b/src/main/scala/com/atomist/rug/ts/CortexTypeGeneratorApp.scala
@@ -23,7 +23,7 @@ object CortexTypeGeneratorApp extends App {
 
   // TODO could take second argument as URL of endpoint
 
-  val target = if (args.length < 1) "target/.atomist/node_modules/@atomist/" else args.head
+  val target = if (args.length < 1) "target/.atomist/node_modules/@atomist" else args.head
   val tsig = new CortexTypeGenerator(DefaultCortexDir, DefaultCortexStubDir)
   val output = tsig.toNodeModule(CortexJson)
   println(s"Generated Type module")

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -11,10 +11,15 @@ import scala.collection.mutable.ListBuffer
 
 object TypeScriptInterfaceGenerator extends App {
 
-  val target = if (args.length < 1) "target/Core.ts" else args.head
+  import AbstractTypeScriptGenerator._
+
+  val DefaultRugDir = "rug"
+
+  val target = if (args.length < 1) "target/.atomist/node_modules/@atomist" else args.head
   val generator = new TypeScriptInterfaceGenerator
-  val output = generator.generate("", SimpleParameterValues(Map(generator.outputPathParam -> target)))
-  output.allFiles.foreach(f => Utils.withCloseable(new PrintWriter(f.path))(_.write(f.content)))
+  val output = generator.generate("rug-ts-interfaces",
+    SimpleParameterValues(OutputPathParam, DefaultFilename)).withPathAbove(DefaultRugDir)
+  output.allFiles.foreach(f => Utils.withCloseable(new PrintWriter(target + "/" + f.path))(_.write(f.content)))
 }
 
 /**

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -199,7 +199,7 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
   override protected def emitCombinedTypes(poa: ParameterValues): Option[FileArtifact] = {
     val alreadyGenerated = ListBuffer.empty[GeneratedType]
     val generatedTypes = allGeneratedTypes(typeRegistry.types.sortWith(typeSort))
-    val pathParam = poa.stringParamValue(outputPathParam)
+    val pathParam = poa.stringParamValue(AbstractTypeScriptGenerator.OutputPathParam)
     val path = if (pathParam.contains("/")) StringUtils.substringBeforeLast(pathParam, "/") + "/" else ""
     val output = new StringBuilder(config.licenseHeader)
     output ++= config.separator

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGen.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGen.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.rugdoc
 
 import com.atomist.param.SimpleParameterValues
-import com.atomist.rug.ts.TypeScriptInterfaceGenerator
+import com.atomist.rug.ts.{AbstractTypeScriptGenerator, TypeScriptInterfaceGenerator}
 
 /**
   * Use this to actually generate interfaces. Of course, we
@@ -12,7 +12,7 @@ object TypeScriptInterfaceGen extends App {
   val td = new TypeScriptInterfaceGenerator()
   // Make it puts the generated files where our compiler will look for them
   val output = td.generate("", SimpleParameterValues(
-    Map(td.outputPathParam -> ".atomist/editors/Interfaces.ts")))
+    Map(AbstractTypeScriptGenerator.OutputPathParam -> ".atomist/editors/Interfaces.ts")))
   val d = output.allFiles.head
   // println(d.content)
 }

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptInterfaceGeneratorTest.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.rugdoc
 
 import com.atomist.param.SimpleParameterValues
-import com.atomist.rug.ts.{TypeGenerationConfig, TypeScriptBuilder, TypeScriptInterfaceGenerator}
+import com.atomist.rug.ts.{AbstractTypeScriptGenerator, TypeGenerationConfig, TypeScriptBuilder, TypeScriptInterfaceGenerator}
 import com.atomist.source.{ArtifactSource, FileArtifact, FileEditor}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -44,7 +44,7 @@ class TypeScriptInterfaceGeneratorTest extends FlatSpec with Matchers {
     val td = new TypeScriptInterfaceGenerator
     // Make it put the generated files where our compiler will look for them
     val output = td.generate("", SimpleParameterValues(
-      Map(td.outputPathParam -> ".atomist/editors/Interfaces.ts")))
+      Map(AbstractTypeScriptGenerator.OutputPathParam -> ".atomist/editors/Interfaces.ts")))
     assert(output.allFiles.size > 1)
 
     val compiled = TypeScriptInterfaceGeneratorTest.compile(output)

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptStubClassGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptStubClassGeneratorTest.scala
@@ -51,12 +51,12 @@ class TypeScriptStubClassGeneratorTest extends FlatSpec with Matchers {
     val tid = new TypeScriptInterfaceGenerator(tr)
     // Make it put the generated files where our compiler will look for them
     val interfaces = tid.generate("", SimpleParameterValues(
-      Map(tid.outputPathParam -> ".atomist/editors/Interfaces.ts")))
+      Map(AbstractTypeScriptGenerator.OutputPathParam -> ".atomist/editors/Interfaces.ts")))
 
     val td = new TypeScriptStubClassGenerator(tr)
     // Make it put the generated files where our compiler will look for them
     val output = td.generate("", SimpleParameterValues(
-      Map(td.outputPathParam -> ".atomist/editors/stubs/Interfaces.ts")))
+      Map(AbstractTypeScriptGenerator.OutputPathParam -> ".atomist/editors/stubs/Interfaces.ts")))
     assert(output.allFiles.size > 1)
 
     val compiled = TypeScriptStubClassGeneratorTest.compile(interfaces + output)

--- a/src/test/scala/com/atomist/rug/ts/TypeScriptBuilder.scala
+++ b/src/test/scala/com/atomist/rug/ts/TypeScriptBuilder.scala
@@ -52,7 +52,7 @@ object TypeScriptBuilder {
 
   val coreSource: ArtifactSource = {
     val generator = new TypeScriptInterfaceGenerator
-    generator.generate("stuff", SimpleParameterValues(Map(generator.outputPathParam -> "Core.ts")))
+    generator.generate("stuff", SimpleParameterValues(Map(AbstractTypeScriptGenerator.OutputPathParam -> "Core.ts")))
       .withPathAbove(".atomist/rug/model")
   }
 


### PR DESCRIPTION
Use Maven properties in POM where possible.

Make the generation of rug TypeScript more similar to the cortex
TypeScript generation, providing the root path on the command line
rather than the combined file.  Move `outputPathParam` instance val to
static object val `OutputPathParam`.

More fully document release process, which has become significantly
more complicated.