### PR TITLE
Move to more specific message types in Plans #501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 marked with `@ExportFunction` when the new `exposeAsProperty` flag is true.
 - **BREAKING** All Generated TypeScript Cortex types use properties rather than functions for 
 all navigation
+- **BREAKING** Use specific message types in Plans for the different scenarios (directed, lifecycle and response) as 
+  per https://github.com/atomist/rug/issues/501
 
 ## [0.24.0] - 2017-04-04
 

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
@@ -1,6 +1,7 @@
 package com.atomist.rug.runtime.js
 
 import com.atomist.param.{Parameter, ParameterValues, ParameterizedSupport, Tag}
+import com.atomist.rug.runtime.js.interop.jsScalaHidingProxy
 import com.atomist.rug.{InvalidHandlerException, InvalidHandlerResultException}
 import com.atomist.rug.runtime.plans.{JsonResponseCoercer, NullResponseCoercer, ResponseCoercer}
 import com.atomist.rug.runtime.{ParameterizedRug, ResponseHandler, _}
@@ -54,7 +55,7 @@ class JavaScriptResponseHandler (jsc: JavaScriptContext,
     val validated = addDefaultParameterValues(params)
     validateParameters(validated)
     val coerced = responseCoercer.coerce(response)
-    invokeMemberFunction(jsc, handler, "handle", jsResponse(coerced.msg.orNull, coerced.code.getOrElse(-1), coerced.body.getOrElse(Nil)), validated) match {
+    invokeMemberFunction(jsc, handler, "handle", jsScalaHidingProxy(jsResponse(coerced.msg.orNull, coerced.code.getOrElse(-1), coerced.body.getOrElse(Nil))), validated) match {
       case plan: ScriptObjectMirror => ConstructPlan(plan)
       case other => throw new InvalidHandlerResultException(s"$name ResponseHandler did not return a recognized response ($other) when invoked with ${params.toString()}")
     }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsScalaHidingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsScalaHidingProxy.scala
@@ -4,7 +4,7 @@ import java.lang.reflect.{Method, Modifier}
 
 import com.atomist.rug.runtime.js.interop.jsScalaHidingProxy.MethodValidator
 import com.atomist.util.lang.JavaScriptArray
-import jdk.nashorn.api.scripting.AbstractJSObject
+import jdk.nashorn.api.scripting.{AbstractJSObject, ScriptObjectMirror}
 import jdk.nashorn.internal.runtime.ScriptRuntime
 import org.springframework.util.ReflectionUtils
 
@@ -66,7 +66,6 @@ class jsScalaHidingProxy private(
         }
     }
 
-    //println(s"Raw result for $name=[$r]")
     (r match {
       case seq: Seq[_] => new JavaScriptArray(
         seq.map(new jsScalaHidingProxy(_, methodsToHide, methodValidator, returnNotToProxy))
@@ -80,6 +79,7 @@ class jsScalaHidingProxy private(
       case s: String => s
       case i: Integer => i
       case fun: FunctionProxyToReflectiveInvocation => fun
+      case js: ScriptObjectMirror => js
       case x => jsScalaHidingProxy(x)
     }
   }

--- a/src/main/scala/com/atomist/rug/runtime/plans/LocalPlanRunner.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/LocalPlanRunner.scala
@@ -23,7 +23,8 @@ class LocalPlanRunner(messageDeliverer: MessageDeliverer,
   private val logger: Logger = loggerOption.getOrElse(LoggerFactory getLogger getClass.getName)
 
   override def run(plan: Plan, callbackInput: Option[Response]): Future[PlanResult] = {
-    val messageLog: Seq[MessageDeliveryError] = plan.messages.flatMap { message =>
+    val allMessages = plan.lifecycle ++ plan.local
+    val messageLog: Seq[MessageDeliveryError] = allMessages.flatMap { message =>
       Try(messageDeliverer.deliver(message, callbackInput)) match {
         case ScalaFailure(error) =>
           val msg = s"Failed to deliver message ${message.toDisplay} - ${error.getMessage}"

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
@@ -36,7 +36,7 @@ object PlanUtils {
   }
 
   private def messageToTree(m: Message) = {
-    val messageString = s"Message: ${m.body}${m.channelId.map(" to " + _).getOrElse("")}, like ${m.instructions}"
+    val messageString = s"Message: ${m.toDisplay}"
     BabyTree(messageString)
   }
   private def callbackToTree(name: String, c: Callback): BabyTree = BabyTree(name, Seq(c match {
@@ -59,9 +59,10 @@ object PlanUtils {
       }
     }
 
+    val allMessages = plan.local ++ plan.lifecycle
     BabyTree("Plan",
       plan.instructions.sortBy(_.toString).map(respondableToTree) ++
-        plan.messages.sortBy(_.toString).map(messageToTree))
+        allMessages.sortBy(_.toDisplay).map(messageToTree))
   }
 
   private def awaitAndTreeLogEvents(name: String, events: Seq[PlanLogEvent]): BabyTree = {

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -1,5 +1,5 @@
-import {GraphNode, TreeNode, PathExpressionEngine, PathExpression, Match} from "../tree/PathExpression"
-import {Parameter} from "./RugOperation"
+import { GraphNode, TreeNode, PathExpressionEngine, PathExpression, Match } from "../tree/PathExpression"
+import { Parameter } from "./RugOperation"
 
 interface RugCoordinate {
   readonly name: string
@@ -15,15 +15,15 @@ interface Instruction<T extends InstructionKind> {
   readonly kind: T
 }
 
-interface Plannable {}
+interface ImmediatelyRunnable { }
 
-class Respondable<T extends Review | Edit | Generate | Execute> implements Plannable {
+class Respondable<T extends Review | Edit | Generate | Execute> implements ImmediatelyRunnable {
   instruction: T
-  onSuccess?: Plan | Message | Respond
-  onError?: Plan | Message | Respond
+  onSuccess?: Plan | PlanMessage | Respond
+  onError?: Plan | PlanMessage | Respond
 }
 
-class NonRespondable<T extends Command | Respond> implements Plannable {
+class NonRespondable<T extends Command | Respond> implements ImmediatelyRunnable {
   instruction: T
 }
 
@@ -46,28 +46,28 @@ interface Review extends ProjectInstruction<"review"> {
 
 }
 
-interface Edit extends ProjectInstruction <"edit">{
+interface Edit extends ProjectInstruction<"edit"> {
 
 }
 
 //extends ProjectInstruction because we need to know the project name
-interface Generate extends ProjectInstruction <"generate"> {
+interface Generate extends ProjectInstruction<"generate"> {
 
 }
 
 //because in a message, we may not know project name yet
 interface PresentableGenerate extends Instruction<"generate"> {
-    project?: string | ProjectReference
+  project?: string | ProjectReference
 }
 
 //because in a message, we may not know project name yet
 interface PresentableEdit extends Instruction<"edit"> {
-    project?: string | ProjectReference
+  project?: string | ProjectReference
 }
 
 //because in a message, we may not know project name yet
 interface PresentableReview extends Instruction<"review"> {
-    project?: string | ProjectReference
+  project?: string | ProjectReference
 }
 
 interface Execute extends Instruction<"execute"> {
@@ -86,10 +86,10 @@ interface HandleCommand {
 }
 
 interface HandleEvent<R extends GraphNode, M extends GraphNode> {
-  handle(root: Match<R,M>): Plan
+  handle(root: Match<R, M>): Plan
 }
 
-interface HandleResponse<T>{
+interface HandleResponse<T> {
   handle(response: Response<T>): Plan
 }
 
@@ -121,13 +121,13 @@ enum Status {
 
 interface Response<T> {
 
-    msg(): string
+  msg(): string
 
-    code(): number
+  code(): number
 
-    status(): Status
+  status(): Status
 
-    body(): T
+  body(): T
 }
 
 /**
@@ -137,55 +137,118 @@ interface Response<T> {
  */
 class Plan {
 
-   messages: Message[] = [];
+  messages: PlanMessage[] = [];
 
-   instructions: Plannable[] = [];
+  instructions: ImmediatelyRunnable[] = [];
 
-   public add?(thing: Plannable | Message): this {
-     if(thing instanceof Message){
-       this.messages.push(thing)
-     }
-     else {
-        this.instructions.push(thing)
-     }
-     return this;
-   }
+  public add?(thing: ImmediatelyRunnable | PlanMessage): this {
+    if (thing instanceof ResponseMessage || thing instanceof DirectedMessage || thing instanceof LifecycleMessage) {
+      this.messages.push(thing)
+    }
+    else {
+      this.instructions.push(thing)
+    }
+    return this;
+  }
 
-   static ofMessage(m: Message): Plan {
-     return new Plan().add(m);
-   }
+  static ofMessage(m: PlanMessage): Plan {
+    return new Plan().add(m);
+  }
+}
+
+export type MessageMimeType = "application/x-atomist-slack+json" | "text/plain"
+
+export abstract class MessageMimetypes {
+  public static SLACK_JSON: MessageMimeType = "application/x-atomist-slack+json"
+  public static PLAIN_TEXT: MessageMimeType = "text/plain"
+}
+
+type MessageKind = "response" | "lifecycle" | "directed"
+
+interface Message<T extends MessageKind> {
+  kind: T
 }
 
 /**
- * Represents a Message to the bot.
- * Any rugs can contain unbound parameters, and the bot will try to fill them out
-*/
-class Message {
+ * Represents the response to the bot from a command
+ */
+export class ResponseMessage implements Message<"response"> {
 
+  kind: "response" = "response"
   body: string;
-  channelId?: string;
+  contentType: MessageMimeType = MessageMimetypes.PLAIN_TEXT
+  usernames?: string[] = [];
+  channelNames?: string[] = [];
+
+  constructor(body: string, contentType?: MessageMimeType) {
+    this.body = body;
+    if (contentType) {
+      this.contentType = contentType;
+    }
+  }
+
+  public addUser?(username: string): this {
+    this.usernames.push(username);
+    return this;
+  }
+
+  public addChannel?(channelName: string): this {
+    this.channelNames.push(channelName);
+    return this;
+  }
+}
+
+export class UserAddress {
+  constructor(public username: string) { }
+}
+
+export class ChannelAddress {
+  constructor(public channelName: string) { }
+}
+
+export type DirectedMessageAddress = UserAddress | ChannelAddress
+
+/**
+ * Uncorrelated message to the bot
+ */
+export class DirectedMessage implements Message<"directed"> {
+
+  kind: "directed" = "directed"
+  contentType: MessageMimeType = MessageMimetypes.PLAIN_TEXT
+  body: string;
+  usernames?: string[] = [];
+  channelNames?: string[] = [];
+
+  constructor(body: string, address: DirectedMessageAddress, contentType?: MessageMimeType, ) {
+    this.body = body;
+    if (contentType) {
+      this.contentType = contentType;
+    }
+    this.addAddress(address);
+  }
+
+  public addAddress?(address: DirectedMessageAddress): this {
+    if (address instanceof UserAddress) {
+      this.usernames.push(address.username);
+    }
+    else {
+      this.channelNames.push(address.channelName);
+    }
+    return this;
+  }
+}
+
+/**
+ * Correlated, updatable messages to the bot
+ */
+export class LifecycleMessage implements Message<"lifecycle">{
+
+  kind: "lifecycle" = "lifecycle"
+  node: GraphNode;
   instructions?: Presentable<any>[] = [];
 
-  node?: GraphNode;
-  correlationId?: string
-
-  public withCorrelationId?(id: string) : this {
-    this.correlationId = id;
-    return this;
-  }
-
-  public withNode?(node: GraphNode) : this {
+  constructor(node: GraphNode) {
     this.node = node;
-    return this;
-  }
-
-  public withChannelId?(chid: string) : this {
-    this.channelId = chid;
-    return this;
-  }
-
-  constructor(about?: string){
-    this.body = about;
   }
 
   public addAction?(instruction: Presentable<any>): this {
@@ -193,6 +256,8 @@ class Message {
     return this;
   }
 }
+
+export type PlanMessage = ResponseMessage | DirectedMessage | LifecycleMessage
 
 abstract class MappedParameters {
   static readonly GITHUB_REPO_OWNER: string = "atomist://github/repository/owner"
@@ -203,7 +268,7 @@ abstract class MappedParameters {
   static readonly GITHUB_WEBHOOK_URL: string = "atomist://github_webhook_url"
 }
 
-export {MappedParameters}
-export {Respond, Presentable, NonRespondable, Respondable, Instruction, Response, HandlerContext, Plan, Message, Execute}
-export {HandleResponse, HandleCommand, HandleEvent}
-export {Edit, ProjectInstruction}
+export { MappedParameters }
+export { Respond, Presentable, NonRespondable, Respondable, Instruction, Response, HandlerContext, Plan, Execute }
+export { HandleResponse, HandleCommand, HandleEvent }
+export { Edit, ProjectInstruction }

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -1,6 +1,6 @@
 import { ScenarioWorld } from "../ScenarioWorld"
 import { Result } from "../Result"
-import { Message, Plan } from "../../operations/Handlers"
+import { Plan } from "../../operations/Handlers"
 import { GraphNode } from "../../tree/PathExpression"
 
 /**

--- a/src/test/resources/com/atomist/rug/runtime/js/KittieFetcher.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/KittieFetcher.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, ResponseMessage, LifecycleMessage, ChannelAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -22,7 +22,19 @@ class KittieFetcher implements HandleCommand {
                  parameters: {method: "GET", url: "http://youtube.com?search=kitty&safe=true", as: "JSON"}
                },
                onSuccess: {kind: "respond", name: "Kitties"},
-               onError: {body: "No kitties for you today!"}})
+               onError: {body: "No kitties for you today!", kind: "response", contentType: "text/plain"}})
+
+
+    result.add({ instruction: {
+                                kind: "execute",
+                                name: "HTTP",
+                                parameters: {method: "GET", url: "http://youtube.com?search=kitty&safe=true", as: "JSON"}
+                              },
+                              onSuccess: {kind: "respond", name: "Kitties"},
+                              onError: new DirectedMessage("directed", new ChannelAddress("woot"))})
+
+    result.add(new DirectedMessage("directed", new ChannelAddress("engineering")));
+    result.add(new ResponseMessage("response"));
     return result;
   }
 }

--- a/src/test/resources/com/atomist/rug/runtime/js/KittieFetcherWithMappedParams.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/KittieFetcherWithMappedParams.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, ResponseMessage} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, MappedParameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/KittieFetcherWithSecrets.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/KittieFetcherWithSecrets.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Secrets, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerExecuteInstructionCallingRespondable.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerExecuteInstructionCallingRespondable.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, HandleResponse, Message, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningEmptyMessage.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningEmptyMessage.ts
@@ -1,11 +1,11 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties", "Search Youtube for kitty videos and post results to slack")
 class KittieFetcher implements HandleCommand{
 
   handle(ctx: HandlerContext) {
-    return new Plan().add(new Message());
+    return new Plan().add(new DirectedMessage("", "text/plain", new UserAddress("woot")));
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningMessage.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningMessage.ts
@@ -1,11 +1,11 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
 class KittieFetcher implements HandleCommand{
 
   handle(ctx: HandlerContext) : Plan {
-    return Plan.ofMessage(new Message("Up and at 'em!"));
+    return Plan.ofMessage({body: "Up and at 'em!", kind: "directed", contentType: "text/plain");
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithBadStubUse.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithBadStubUse.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 import {Build} from "@atomist/rug/cortex/stub/Build"
 
@@ -9,7 +9,7 @@ class SimpleCommandHandlerWithBadStubUse implements HandleCommand{
   handle(ctx: HandlerContext) {
       // This will fail
       let build = new Build().repo;
-      return Plan.ofMessage(new Message("foobar"));
+      return Plan.ofMessage(new DirectedMessage("foobar", new UserAddress("bob")));
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithNullDefault.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithNullDefault.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, Message} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, Plan, ResponseMessage} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -8,7 +8,7 @@ class KittieFetcher implements HandleCommand{
   test: string = null
 
   handle(ctx: HandlerContext) : Plan {
-    return new Plan().add(new Message());
+    return new Plan().add(new ResponseMessage("body"));
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandWithPresentable.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandWithPresentable.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, MappedParameters, Message, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, MappedParameters, ResponseMessage, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, MappedParameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -19,7 +19,7 @@ class KittieFetcher implements HandleCommand {
       throw new Error("This will not stand");
     }
     let result = new Plan()
-    let message = new Message("KittieFetcher");
+    let message = new ResponseMessage("KittieFetcher");
     message.addAction({ instruction: {
                  kind: "command",
                  name: "GetKitties"},

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
@@ -1,4 +1,4 @@
-import { HandleCommand, Instruction, Response, HandlerContext, Plan, Message } from '@atomist/rug/operations/Handlers'
+import { HandleCommand, Instruction, Response, HandlerContext, Plan, ResponseMessage } from '@atomist/rug/operations/Handlers'
 import { CommandHandler, Secrets, Parameter, Tags, Intent } from '@atomist/rug/operations/Decorators'
 
 import * as node from "./Nodes"
@@ -29,7 +29,7 @@ class ReturnsOneMessageCommandHandler implements HandleCommand {
         if (ctx.teamId == null)
             throw new Error("Cannot get at team id")
 
-        result.add(new Message("woot").withCorrelationId("dude"))
+        result.add(new ResponseMessage("woot"))
         // console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
         return result;
     }
@@ -50,7 +50,7 @@ class RunsPathExpressionCommandHandler implements HandleCommand {
         eng.with<node.Person>(ctx.contextRoot, findPerson, peep => {
             throw new Error(`Shouldn't have found a person but found ${peep}`)
         })
-        result.add(new Message("woot").withCorrelationId("dude"))
+        result.add(new ResponseMessage("woot"))
         // console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
         return result;
     }
@@ -70,7 +70,8 @@ class RunsMatchingPathExpressionCommandHandler implements HandleCommand {
         const findPerson = "/Commit/Person()[@name='Ebony']"
         eng.with<node.Person>(ctx.contextRoot, findPerson, peep => {
             // console.log(`Adding message with person name=${peep.name()},obj=${peep}`)
-            result.add(new Message(peep.name()).withCorrelationId("dude"))
+            result.add(
+                new ResponseMessage(peep.name()))
         })
         // console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
         return result;
@@ -91,7 +92,7 @@ class GoesOffGraph implements HandleCommand {
             // Deliberate error should throw exception
             peep.gitHubId().id()
             // console.log(`Adding message with person name=${peep.name()},obj=${peep}`)
-            result.add(new Message(peep.name()).withCorrelationId("dude"))
+            result.add(new ResponseMessage(peep.name()))
         })
         // console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
         return result;

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
@@ -1,4 +1,4 @@
-import { HandleEvent, Plan, Message } from '@atomist/rug/operations/Handlers'
+import { HandleEvent, Plan, DirectedMessage, ChannelAddress } from '@atomist/rug/operations/Handlers'
 import { GraphNode, Match, PathExpression } from '@atomist/rug/tree/PathExpression'
 
 import { EventHandler, Tags } from '@atomist/rug/operations/Decorators'
@@ -65,7 +65,8 @@ export const handler3 = new ReturnsEmptyPlanEventHandler3();
 class ReturnsAMessage implements HandleEvent<node.Commit, node.GitHubId> {
 
     handle(m: Match<GraphNode, GraphNode>) {
-        return new Plan().add(new Message("Hello there!").withChannelId("test-channel"))
+        return new Plan().add(new DirectedMessage("Hello there!",
+        new ChannelAddress("test-channel")))
     }
 }
 export const simpleMessageHandler = new ReturnsAMessage();
@@ -79,7 +80,8 @@ class AngryHandler implements HandleEvent<node.Commit, node.GitHubId> {
 
     handle(m: Match<GraphNode, GraphNode>) {
         if (23 > 0) throw new Error("I hate y'all")
-        return new Plan().add(new Message("Hello there!"))
+        return new Plan().add(new DirectedMessage("Hello there!",
+        new ChannelAddress("test-channel")))
     }
 }
 export const angry = new AngryHandler();

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
@@ -1,4 +1,4 @@
-import { HandleEvent, Plan, Message } from '@atomist/rug/operations/Handlers'
+import { HandleEvent, Plan } from '@atomist/rug/operations/Handlers'
 import { GraphNode, Match, PathExpression } from '@atomist/rug/tree/PathExpression'
 
 import { EventHandler, Tags } from '@atomist/rug/operations/Decorators'

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2d.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2d.ts
@@ -12,6 +12,7 @@ Then("excitement ensues", world => {
     // Void return is the same as returning true.
     // This enables us to use assertion frameworks such as Chai
     let m = world.plan().messages[0]
-    if (m.channelId != "test-channel")
-        throw new Error(`Unexpected channel for message: [${m.channelId}]`)
+    console.log("message=" + m + " " + m.body + " cnames=" + m.channelNames)
+    if (m.channelNames.indexOf("test-channel") == -1)
+        throw new Error(`Missing expected channel name for message: [${m.channelNames}]`)
 })

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
@@ -8,7 +8,8 @@ import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.TreeMaterializer
 import org.scalatest.{FlatSpec, Matchers}
 
-class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
+class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
+
   val atomistConfig: AtomistConfig = DefaultAtomistConfig
   val treeMaterializer: TreeMaterializer = TestTreeMaterializer
 
@@ -16,7 +17,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
   val kittyDesc = "Prints out kitty urls"
   val simpleResponseHandler =  StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-      |import {Respond, Instruction, Response, Plan, Message} from '@atomist/rug/operations/Handlers'
+      |import {Respond, Instruction, Response, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
       |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
       |import {EventHandler, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
       |import {Project} from '@atomist/rug/model/Core'
@@ -32,7 +33,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
       |  handle(response: Response<Object>) {
       |    if(this.name != "his dudeness") throw new Error("Not on the rug, man!");
       |    let results = response.body as any;
-      |    return new Plan().add(new Message("https://www.youtube.com/watch?v=fNodQpGVVyg"));
+      |    return new Plan().add(new DirectedMessage("https://www.youtube.com/watch?v=fNodQpGVVyg", new UserAddress("bob")));
       |  }
       |}
       |
@@ -42,7 +43,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
 
   val simpleResponseHandlerWithJsonCoercion =  StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {Respond, Instruction, Response, Plan, Message} from '@atomist/rug/operations/Handlers'
+       |import {Respond, Instruction, Response, Plan} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, ParseJson, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
        |import {Project} from '@atomist/rug/model/Core'
@@ -51,7 +52,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers{
        |@ResponseHandler("$kitties", "$kittyDesc")
        |class KittiesResponder implements HandleResponse<any>{
        | handle(@ParseJson response: Response<any>) : Plan {
-       |    let results = response.body() as any;
+       |    let results = response.body as any;
        |
        |    if(results.yaml != "is more annoying than json") { throw new Error("Rats: " + results.yaml)}
        |    results.reasons.map(reason => reason.main.length)

--- a/src/test/scala/com/atomist/rug/runtime/js/PlanBuilderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/PlanBuilderTest.scala
@@ -20,7 +20,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
   val simpleCommandWithObjectInstructionParamAsJson =
     StringFileArtifact(DefaultAtomistConfig.handlersRoot + "/Handler.ts",
       """
-        |import {HandleCommand, HandleResponse, Message, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+        |import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
         |import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
         |
         |@CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -43,7 +43,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
   val simpleCommandHandlerWithNullAndUndefinedParameterValues =
     StringFileArtifact(DefaultAtomistConfig.handlersRoot + "/Handler.ts",
       s"""
-        |import {HandleCommand, HandleResponse, Message, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+        |import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
         |import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
         |
         |@CommandHandler("show-me-the-kitties","Search Youtube for kitty videos and post results to slack")

--- a/src/test/scala/com/atomist/rug/runtime/plans/PlanResultInterpreterTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/PlanResultInterpreterTest.scala
@@ -14,9 +14,9 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
   val successfulInstructionResult = InstructionResult(Edit(Detail("edit1", None, Nil, None)), Response(Success))
   val failureInstructionResult = InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Failure))
   val errorInstructionResult = InstructionError(Edit(Detail("edit3", None, Nil, None)), new IllegalStateException("doh!"))
-  val successfulNestedPlan = NestedPlanRun(Plan(Nil, Nil), Future {PlanResult(Seq(successfulInstructionResult))})
-  val failureNestedPlan = NestedPlanRun(Plan(Nil, Nil), Future {PlanResult(Seq(failureInstructionResult))})
-  val errorNestedPlan = NestedPlanRun(Plan(Nil, Nil), Future {PlanResult(Seq(errorInstructionResult))})
+  val successfulNestedPlan = NestedPlanRun(Plan(Nil,Nil, Nil), Future {PlanResult(Seq(successfulInstructionResult))})
+  val failureNestedPlan = NestedPlanRun(Plan(Nil, Nil, Nil), Future {PlanResult(Seq(failureInstructionResult))})
+  val errorNestedPlan = NestedPlanRun(Plan(Nil, Nil, Nil), Future {PlanResult(Seq(errorInstructionResult))})
 
   it ("should interpret empty plan result as success") {
     val planResult = PlanResult(Nil)

--- a/src/test/scala/com/atomist/rug/runtime/plans/PlanResultLoggerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/PlanResultLoggerTest.scala
@@ -19,9 +19,9 @@ class PlanResultLoggerTest extends FunSpec with Matchers with DiagrammedAssertio
   val successfulInstructionResult = InstructionResult(Edit(Detail("edit1", None, Nil, None)), Response(Success))
   val failureInstructionResult = InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Failure))
   val errorInstructionResult = InstructionError(Edit(Detail("edit3", None, Nil, None)), new IllegalStateException("doh!"))
-  val successfulNestedPlan = NestedPlanRun(Plan(Nil, Nil), Future {PlanResult(Seq(successfulInstructionResult))})
-  val failureNestedPlan = NestedPlanRun(Plan(Nil, Nil), Future {PlanResult(Seq(failureInstructionResult))})
-  val errorNestedPlan = NestedPlanRun(Plan(Nil, Nil), Future {PlanResult(Seq(errorInstructionResult))})
+  val successfulNestedPlan = NestedPlanRun(Plan(Nil,Nil, Nil), Future {PlanResult(Seq(successfulInstructionResult))})
+  val failureNestedPlan = NestedPlanRun(Plan(Nil, Nil, Nil), Future {PlanResult(Seq(failureInstructionResult))})
+  val errorNestedPlan = NestedPlanRun(Plan(Nil, Nil, Nil), Future {PlanResult(Seq(errorInstructionResult))})
 
   it ("should interpret empty plan result as success") {
     val planResult = PlanResult(Nil)


### PR DESCRIPTION
There are now three distinct message types:

- DirectedMessage: body/address enforced
- LifecycleMessage: node enforced
- ResponseMessage: only body enforced
