### PR TITLE
Add lifecycleId to LifecycleMessage

### DIFF
--- a/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
@@ -89,7 +89,12 @@ class PlanBuilder {
           case t: GraphNode => t
           case _ => throw new InvalidHandlerResultException("Lifecycle messages must contain a GraphNode")
         }
-        LifecycleMessage(node,instructions)
+
+        val id = jsMessage.getMember("lifecycleId") match {
+          case s: String => s
+          case _ => throw new InvalidHandlerResultException("Lifecycle messages must contain a lifecycleId")
+        }
+        LifecycleMessage(node,instructions,id)
 
       case _: Undefined => throw new InvalidHandlerResultException(s"A message must have a kind: $jsMessage")
     }

--- a/src/main/scala/com/atomist/rug/spi/Handlers.scala
+++ b/src/main/scala/com/atomist/rug/spi/Handlers.scala
@@ -36,7 +36,8 @@ object Handlers {
 
   case class LifecycleMessage(
                                node: GraphNode,
-                               actions: Seq[Presentable])
+                               actions: Seq[Presentable],
+                               lifecycleId: String)
     extends Callback
       with Message {
 

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -246,13 +246,15 @@ export class LifecycleMessage implements Message<"lifecycle">{
   kind: "lifecycle" = "lifecycle"
   node: GraphNode;
   instructions?: Presentable<any>[] = [];
+  lifecycleId: string;
 
-  constructor(node: GraphNode) {
+  constructor(node: GraphNode, lifecycleId: string) {
     this.node = node;
+    this.lifecycleId = lifecycleId;
   }
 
   public addAction?(instruction: Presentable<any>): this {
-    this.instructions.push(instruction)
+    this.instructions.push(instruction);
     return this;
   }
 }

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -122,7 +122,7 @@ object JavaScriptEventHandlerTest {
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |
        |  handle(event: Match<TreeNode, TreeNode>) {
-       |     return new Plan().add(new LifecycleMessage(event.root()));
+       |     return new Plan().add(new LifecycleMessage(event.root(), "123"));
        |  }
        |}
        |export let handler = new SimpleHandler();
@@ -138,7 +138,7 @@ object JavaScriptEventHandlerTest {
        |@Tags("github", "build")
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |  handle(event: Match<TreeNode, TreeNode>){
-       |     return new Plan().add(new LifecycleMessage(event.root()));
+       |     return new Plan().add(new LifecycleMessage(event.root(), "123"));
        |  }
        |}
        |export let handler = new SimpleHandler();


### PR DESCRIPTION
EventHandlers must set this so that the bot can correlate the messages.