### PR TITLE
No longer create cortex combined Stubs.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.24.0...HEAD
 
-## Changed
+### Changed
 
 -   **BREAKING** Generated TypeScript project model types use
     properties rather than functions for no-arg operations marked with
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Improve release documentation
 
 [501]: https://github.com/atomist/rug/issues/501
+
+### Removed
+
+-   **BREAKING** The Stubs.ts file is no longer generated, use the
+    Types.ts instead
 
 ## [0.24.0] - 2017-04-04
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ named `target/typedoc`.
 Releasing Rug involves releasing the JVM artifacts to a Maven
 repository, the TypeScript module to NPM, and the documentation to
 GitHub pages for this repository, available at
-http://apidocs.atomist.com/.  Releasing Rug can be a multi-stepped
+http://apidocs.atomist.com/ .  Releasing Rug can be a multi-stepped
 process, depending on the changes that have been made.
 
 If there are no changes to the TypeScript API, to create a release

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -195,28 +195,4 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
 
     generatedTypes
   }
-
-  override protected def emitCombinedTypes(poa: ParameterValues): Option[FileArtifact] = {
-    val alreadyGenerated = ListBuffer.empty[GeneratedType]
-    val generatedTypes = allGeneratedTypes(typeRegistry.types.sortWith(typeSort))
-    val pathParam = poa.stringParamValue(AbstractTypeScriptGenerator.OutputPathParam)
-    val path = if (pathParam.contains("/")) StringUtils.substringBeforeLast(pathParam, "/") + "/" else ""
-    val output = new StringBuilder(config.licenseHeader)
-    output ++= config.separator
-    output ++= TypeGenerationConfig.TestStubImports
-
-    for {
-      t <- generatedTypes
-      if !alreadyGenerated.contains(t)
-    } {
-      output ++= t.specificImports
-      output ++= s"export { ${t.name} };"
-      output ++= config.separator
-      output ++= t.toString
-      output ++= config.separator
-      alreadyGenerated += t
-    }
-
-    Some(StringFileArtifact(s"${path}Stubs.ts", output.toString()))
-  }
 }


### PR DESCRIPTION
The Stubs.ts file essentially duplicates the capabilities of the
Types.ts file, less elegantly.  We should promote the use of the
Types.ts file since it imports all the classes and is symmetrical with
the Types.ts for the interfaces.