### PR TITLE
Property access now used for node navigation

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/DefaultTypeRegistry.scala
+++ b/src/main/scala/com/atomist/rug/kind/DefaultTypeRegistry.scala
@@ -1,6 +1,7 @@
 package com.atomist.rug.kind
 
 /**
-  * Load types using ServiceLoader
+  * Load types found on the classpath using ServiceLoader
+  * Does not include Cortex types.
   */
 object DefaultTypeRegistry extends ServiceLoaderTypeRegistry

--- a/src/main/scala/com/atomist/rug/kind/ServiceLoaderTypeRegistry.scala
+++ b/src/main/scala/com/atomist/rug/kind/ServiceLoaderTypeRegistry.scala
@@ -8,6 +8,9 @@ import com.atomist.util.ServiceLoaderBackedExtensionProvider
   * JAR files needs a META-INF/services/com.atomist.rug.spi.Typed file containing
   * the FQNs of the types it defines.
   *
+  * Does not include Cortex types: Only those backed by JVM objects
+  * available on the runtime classpath.
+  *
   * @see [[Type]]
   */
 class ServiceLoaderTypeRegistry(keyProvider: (Typed) => String = (r) => r.name)

--- a/src/main/typescript/node_modules/@atomist/rug/ast/scala/Types.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/scala/Types.ts
@@ -55,9 +55,9 @@ export type Source = SourceNav & SourceOps
 
 export interface DefnClassNav extends TextTreeNode {
 
-    typeName(): string
+    typeName: string
 
-    template(): TextTreeNode
+    template: TextTreeNode
      
 }
 
@@ -68,7 +68,7 @@ export class DefnClassOps extends TextTreeNodeOps<DefnClassNav> {
      */
     addToStartOfBody(what: string) {
         // TODO what if type body is empty?
-        let firstStatement = this.node.template().children()[0] as TextTreeNode
+        let firstStatement = this.node.template.children()[0] as TextTreeNode
         firstStatement.update(`${what}\n\n${firstStatement.value()}`)
     }
     
@@ -89,12 +89,11 @@ export class TermApplyOps extends TextTreeNodeOps<TermApplyNav> {
 export type TermApply = TermApplyNav & TermApplyOps
 
 
-
 export interface TermApplyInfixNav extends TextTreeNode {
      
-    termSelect(): any
+    termSelect: any
 
-    termApply(): any
+    termApply: any
 
 }
 
@@ -102,10 +101,10 @@ export class TermApplyInfixOps extends TextTreeNodeOps<TermApplyInfix> {
 
     reverseShould() {
         //console.log(`Containing file=${this.containingFile()}`)
-        let termSelect = this.node.termSelect();
-        let termApply = this.node.termApply();
+        let termSelect = this.node.termSelect;
+        let termApply = this.node.termApply;
 
-        if (termApply != null && ["be", "equal"].indexOf(termApply.termName().value()) > -1) {
+        if (termApply != null && ["be", "equal"].indexOf(termApply.termName.value()) > -1) {
           let newValue = `assert(${termSelect.value()} === ${termApply.children()[1].value()})`;
           //console.log(`Replacing [${shouldTerm.value()}] with [${newValue}]`)
           this.node.update(newValue)

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -158,7 +158,7 @@ class Plan {
 
 export type MessageMimeType = "application/x-atomist-slack+json" | "text/plain"
 
-export abstract class MessageMimetypes {
+export abstract class MessageMimeTypes {
   public static SLACK_JSON: MessageMimeType = "application/x-atomist-slack+json"
   public static PLAIN_TEXT: MessageMimeType = "text/plain"
 }
@@ -176,7 +176,7 @@ export class ResponseMessage implements Message<"response"> {
 
   kind: "response" = "response"
   body: string;
-  contentType: MessageMimeType = MessageMimetypes.PLAIN_TEXT
+  contentType: MessageMimeType = MessageMimeTypes.PLAIN_TEXT
   usernames?: string[] = [];
   channelNames?: string[] = [];
 
@@ -187,13 +187,13 @@ export class ResponseMessage implements Message<"response"> {
     }
   }
 
-  public addUser?(username: string): this {
-    this.usernames.push(username);
-    return this;
-  }
-
-  public addChannel?(channelName: string): this {
-    this.channelNames.push(channelName);
+  public addAddress?(address: MessageAddress): this {
+    if (address instanceof UserAddress) {
+      this.usernames.push(address.username);
+    }
+    else {
+      this.channelNames.push(address.channelName);
+    }
     return this;
   }
 }
@@ -206,7 +206,7 @@ export class ChannelAddress {
   constructor(public channelName: string) { }
 }
 
-export type DirectedMessageAddress = UserAddress | ChannelAddress
+export type MessageAddress = UserAddress | ChannelAddress
 
 /**
  * Uncorrelated message to the bot
@@ -214,12 +214,12 @@ export type DirectedMessageAddress = UserAddress | ChannelAddress
 export class DirectedMessage implements Message<"directed"> {
 
   kind: "directed" = "directed"
-  contentType: MessageMimeType = MessageMimetypes.PLAIN_TEXT
+  contentType: MessageMimeType = MessageMimeTypes.PLAIN_TEXT
   body: string;
   usernames?: string[] = [];
   channelNames?: string[] = [];
 
-  constructor(body: string, address: DirectedMessageAddress, contentType?: MessageMimeType, ) {
+  constructor(body: string, address: MessageAddress, contentType?: MessageMimeType) {
     this.body = body;
     if (contentType) {
       this.contentType = contentType;
@@ -227,7 +227,7 @@ export class DirectedMessage implements Message<"directed"> {
     this.addAddress(address);
   }
 
-  public addAddress?(address: DirectedMessageAddress): this {
+  public addAddress?(address: MessageAddress): this {
     if (address instanceof UserAddress) {
       this.usernames.push(address.username);
     }

--- a/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
@@ -29,7 +29,7 @@ class ChangeException implements ProjectEditor {
         if (cc.formatInfo.start.lineNumberFrom1 < 5 || cc.formatInfo.start.lineNumberFrom1 > 100)
           throw new Error(`Format info values are wacky in ${cc.formatInfo}`)
         let c2 = cc as any // We need to do this to get to the children
-        let classType = c2.class_type()
+        let classType = c2.class_type
         if (classType.parent().value() != cc.value())
           throw new Error(`Unexpected value for parent of ${classType.nodeName()}: ${classType.parent()}`)
         classType.update(this.newException)

--- a/src/test/resources/com/atomist/rug/kind/csharp/NavigateTree.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/NavigateTree.ts
@@ -27,7 +27,7 @@ class NavigateTree implements ProjectEditor {
         if (cc.formatInfo.start.lineNumberFrom1 < 5 || cc.formatInfo.start.lineNumberFrom1 > 100)
           throw new Error(`Format info values are wacky in ${cc.formatInfo}`)
         let c2 = cc as any // We need to do this to get to the children using functions
-        let classType = c2.class_type()
+        let classType = c2.class_type
         if (classType.parent().value() != cc.value())
           throw new Error(`Unexpected value for parent of ${classType.nodeName()}: ${classType.parent()}`)
 

--- a/src/test/resources/com/atomist/rug/kind/scala/EqualsToSymbol.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/EqualsToSymbol.ts
@@ -40,7 +40,7 @@ class EqualsToSymbol implements ProjectEditor {
       eng.with<any>(project, oldAssertion, termApply => {
         //console.log(`Operating on ${termApply}`);
         if (termApply.children().length == 2) { // Should go in path expression when we have "count"
-          let leftTerm = termApply.termSelect().children()[0]
+          let leftTerm = termApply.termSelect.children()[0]
           let rightTerm = termApply.children()[1]
 
           if (leftTerm && rightTerm) {

--- a/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
+++ b/src/test/resources/com/atomist/rug/kind/scala/UpgradeScalaTestAssertions.ts
@@ -33,8 +33,8 @@ class UpgradeScalaTestAssertions implements ProjectEditor {
       eng.with<scala.TermApplyInfix>(project, oldAssertion, shouldTerm => {
         //console.log(`ShouldTerm=${shouldTerm}`)
 
-        let termSelect = shouldTerm.termSelect();
-        let termApply = shouldTerm.termApply();
+        let termSelect = shouldTerm.termSelect;
+        let termApply = shouldTerm.termApply;
 
         if (termSelect == null)
           throw new Error(`termSelect should be navigable and non-null`)

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
@@ -69,9 +69,9 @@ class RunsMatchingPathExpressionCommandHandler implements HandleCommand {
 
         const findPerson = "/Commit/Person()[@name='Ebony']"
         eng.with<node.Person>(ctx.contextRoot, findPerson, peep => {
-            // console.log(`Adding message with person name=${peep.name()},obj=${peep}`)
+            // console.log(`Adding message with person name=${peep.name},obj=${peep}`)
             result.add(
-                new ResponseMessage(peep.name()))
+                new ResponseMessage(peep.name))
         })
         // console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
         return result;
@@ -90,9 +90,9 @@ class GoesOffGraph implements HandleCommand {
         const findPerson = "/Commit/Person()[@name='Ebony']"
         eng.with<node.Person>(ctx.contextRoot, findPerson, peep => {
             // Deliberate error should throw exception
-            peep.gitHubId().id()
-            // console.log(`Adding message with person name=${peep.name()},obj=${peep}`)
-            result.add(new ResponseMessage(peep.name()))
+            peep.gitHubId.id
+            // console.log(`Adding message with person name=${peep.name},obj=${peep}`)
+            result.add(new ResponseMessage(peep.name))
         })
         // console.log(`The constructed plan messages were ${result.messages()},size=${result.messages().length}`)
         return result;

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
@@ -50,8 +50,8 @@ class ReturnsEmptyPlanEventHandler3 implements HandleEvent<node.Commit, node.Git
 
     handle(m: Match<node.Commit, node.GitHubId>) {
         let ghid: node.GitHubId = m.matches()[0]
-        if (ghid.id() != "gogirl") throw new Error(`Unexpected github id ${ghid.id()}`)
-        //if (ghid.address() != "/madeBy/gitHubId") throw new Error(`Unexpected address [${ghid.address()}]`)
+        if (ghid.id != "gogirl") throw new Error(`Unexpected github id ${ghid.id}`)
+        //if (ghid.address != "/madeBy/gitHubId") throw new Error(`Unexpected address [${ghid.address}]`)
 
         return new Plan();
     }

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/Nodes.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/Nodes.ts
@@ -26,9 +26,9 @@ export class Commit implements GraphNode {
         return this;
     }
 
-    sha() { return this._sha }
+    get sha() { return this._sha }
 
-    madeBy(): Person { return this._madeBy }
+    get madeBy(): Person { return this._madeBy }
 
 }
 
@@ -43,9 +43,9 @@ export class Person implements GraphNode {
 
     nodeTags(): string[] { return [ "Person", "-dynamic" ] }
 
-    name(): string {  return this._name }
+    get name(): string {  return this._name }
 
-    gitHubId() { return this._gitHubId } 
+    get gitHubId() { return this._gitHubId }
 
     withGitHubId(g: GitHubId): Person {
         this._gitHubId = g
@@ -62,6 +62,6 @@ export class GitHubId implements GraphNode {
 
     nodeTags(): string[] { return [ "GitHubId", "-dynamic" ] }
 
-    id(): string {  return this._id }
+    get id(): string {  return this._id }
 
 }

--- a/src/test/resources/com/atomist/rug/tree/context/text/MicrogrammarTypeScriptSampleEditor.ts
+++ b/src/test/resources/com/atomist/rug/tree/context/text/MicrogrammarTypeScriptSampleEditor.ts
@@ -33,7 +33,7 @@ class MicrogrammarTypeScriptSampleEditor {
         let eng: PathExpressionEngine = project.context.pathExpressionEngine.addType(mg)
 
         eng.with<any>(project, `//File()/strictMatchCall()`, n => {
-            n.update(`val ${n.outputVar().value()} = strictMatchAndFakeAFile(${n.mg().value()}, ${n.inputString().value()})`)
+            n.update(`val ${n.outputVar.value()} = strictMatchAndFakeAFile(${n.mg.value()}, ${n.inputString.value()})`)
         })
 
     }

--- a/src/test/resources/com/atomist/rug/tree/context/text/MicrogrammarTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/rug/tree/context/text/MicrogrammarTypeScriptTest.ts
@@ -10,14 +10,12 @@ import {Match} from '@atomist/rug/tree/PathExpression'
 class MicrogrammarTypeScriptTest {
 
     edit(project: Project) {
-
         let mg = new Microgrammar('oldObject', 'object $oldObjectName:§TheTestWillChangeThis§ {');
         let eng: PathExpressionEngine = project.context.pathExpressionEngine.addType(mg)
 
         eng.with<any>(project, "//File()/oldObject()/oldObjectName", n => {
             n.update("TheTestHasChangedThis")
         })
-
     }
 }
 export let editor = new MicrogrammarTypeScriptTest();

--- a/src/test/resources/com/atomist/tree/content/text/OverwritableTextTreeNodeTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/tree/content/text/OverwritableTextTreeNodeTypeScriptTest.ts
@@ -5,8 +5,8 @@ import {Microgrammar, PathExpressionEngine, PathExpression, TextTreeNode} from '
 /*
  * Used in com/atomist/tree/content/text/OverwritableTextTreeNodeChild.scala
  */
-@Editor("OverwriteableTextTreeNodeTypeScriptTest", "Uses OverwriteableTextTreeNode from TypeScript")
-class OverwriteableTextTreeNodeTypeScriptTest {
+@Editor("OverwritableTextTreeNodeTypeScriptTest", "Uses OverwritableTextTreeNode from TypeScript")
+class OverwritableTextTreeNodeTypeScriptTest {
 
     edit(project: Project) {
 
@@ -35,18 +35,17 @@ $whateverElse
 
         let eng: PathExpressionEngine = project.context.pathExpressionEngine.addType(mg)
 
-
         let mgNode = `/File()[@name="pom.xml"]/parent()`
 
         eng.with<any>(project, mgNode, parent => {
             //console.log(`I matched: ${parent}`);
-            let versionNumber = parent.version();
+            let versionNumber = parent.version;
             parent.update("Everything under me is now invalidated! wahaha!");
             versionNumber.update("This should fail!!")
         })
 
         pom.replace('dependency', 'dependenciesAreForBirds');
-
     }
 }
-export let editor = new OverwriteableTextTreeNodeTypeScriptTest();
+
+export const editor = new OverwritableTextTreeNodeTypeScriptTest();

--- a/src/test/resources/com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/tree/content/text/microgrammar/MultipleUseOfSubmatcherTypeScriptTest.ts
@@ -6,7 +6,6 @@ import { PathExpressionEngine, Microgrammar } from '@atomist/rug/tree/PathExpres
 class MultipleUseOfSubmatcherTypeScriptTest {
 
     edit(project: Project) {
-
         let mg = new Microgrammar('things', 'I like $something, $something, $something, and $something.',
             { something: '§[a-z]+§'});
 
@@ -14,7 +13,7 @@ class MultipleUseOfSubmatcherTypeScriptTest {
 
         eng.with<any>(project, `/File()[@name="targetFile"]/things()`, things => {
 
-            let somethings = things.something();
+            let somethings = things.something;
             // console.log(`the whole thing is ${things} and the somethings are ${somethings}`);
 
             somethings[0].update("(1) " + somethings[0].value());

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptStubClassGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptStubClassGeneratorTest.scala
@@ -1,11 +1,12 @@
 package com.atomist.rug.rugdoc
 
 import com.atomist.param.SimpleParameterValues
-import com.atomist.rug.spi.SimpleTypeRegistry
+import com.atomist.rug.spi.{SimpleTypeRegistry, TypeRegistry}
+import com.atomist.rug.ts.CortexTypeGenerator._
+import com.atomist.rug.ts.DefaultTypeGeneratorConfig.CortexJson
 import com.atomist.rug.ts._
 import com.atomist.source.{ArtifactSource, FileArtifact, FileEditor}
 import org.scalatest.{FlatSpec, Matchers}
-import CortexTypeGenerator._
 
 object TypeScriptStubClassGeneratorTest {
 
@@ -35,17 +36,21 @@ object TypeScriptStubClassGeneratorTest {
     val withoutImport = TypeScriptStubClassGeneratorTest.withoutImports(output)
     tsc.compile(withoutImport)
   }
+
+  lazy val cortexTypeRegistry: TypeRegistry = {
+    val types = new CortexTypeGenerator(DefaultCortexDir, DefaultCortexStubDir).extract(CortexJson)
+    new SimpleTypeRegistry(types)
+  }
 }
 
 class TypeScriptStubClassGeneratorTest extends FlatSpec with Matchers {
 
-  import DefaultTypeGeneratorConfig.CortexJson
+  import TypeScriptStubClassGeneratorTest._
 
   // Note, only external model is relevant.
   // We don't need to test against project types like File
   it should "generate compilable typescript classes" in {
-    val types = new CortexTypeGenerator(DefaultCortexDir, DefaultCortexStubDir).extract(CortexJson)
-    val tr = new SimpleTypeRegistry(types)
+    val tr = cortexTypeRegistry
 
     // Classes won't compile without the interfaces they implement
     val tid = new TypeScriptInterfaceGenerator(tr)

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -28,7 +28,7 @@ object JavaScriptEventHandlerTest {
 
   val reOpenCloseIssueProgram = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {HandleEvent, Plan, LifecycleMessage, DirectedMessage, MessageMimetypes, ChannelAddress} from '@atomist/rug/operations/Handlers'
+       |import {HandleEvent, Plan, LifecycleMessage, DirectedMessage, MessageMimeTypes, ChannelAddress} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
        |
@@ -49,7 +49,7 @@ object JavaScriptEventHandlerTest {
        |                 parameters: {method: "GET", url: "http://youtube.com?search=kitty&safe=true", as: "JSON"}
        |               },
        |               onSuccess: {kind: "respond", name: "Kitties"},
-       |               onError: {body: "No kitties for you today!", kind: "directed", contentType: MessageMimetypes.PLAIN_TEXT, usernames: ["w00t"]}
+       |               onError: {body: "No kitties for you today!", kind: "directed", contentType: MessageMimeTypes.PLAIN_TEXT, usernames: ["w00t"]}
        |             });
        |
        |    const anEmptyPlan = new Plan()
@@ -69,7 +69,7 @@ object JavaScriptEventHandlerTest {
        |                 parameters: {message: "planception"}
        |               },
        |               onSuccess: aPlansPlan,
-       |               onError: {body: "error", kind: "directed", contentType: MessageMimetypes.PLAIN_TEXT, usernames: ["w00t"]}
+       |               onError: {body: "error", kind: "directed", contentType: MessageMimeTypes.PLAIN_TEXT, usernames: ["w00t"]}
        |             });
        |    return plan;
        |  }

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxyTest.scala
@@ -42,10 +42,7 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
       SimpleTerminalTreeNode("bar", "baz"))
       .withTag(TreeNode.Dynamic)
     val sc = new jsSafeCommittingProxy(c, DefaultTypeRegistry)
-    val jso = sc.getMember("bar").asInstanceOf[JSObject]
-    assert(jso.isFunction)
-    val invoked = jso.call(null)
-    assert(invoked === "baz")
+    assert(sc.getMember("bar") === "baz")
   }
 
   it should "recognize cardinality of single value with array marker" in {
@@ -53,10 +50,8 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
       SimpleTerminalTreeNode("bar", "baz", Set(Cardinality.One2Many)))
       .withTag(TreeNode.Dynamic)
     val sc = new jsSafeCommittingProxy(c, DefaultTypeRegistry)
-    val jso = sc.getMember("bar").asInstanceOf[JSObject]
-    assert(jso.isFunction)
-    val invoked = jso.call(null)
-    invoked match {
+    val value = sc.getMember("bar")
+    value match {
       case jsa: JavaScriptArray[_] =>
         assert(jsa.size === 1)
       //assert(jsa.lyst === util.Arrays.asList("baz", "baz2"))
@@ -71,10 +66,8 @@ class jsSafeCommittingProxyTest extends FlatSpec with Matchers {
       Set(TreeNode.Dynamic)
     )
     val sc = new jsSafeCommittingProxy(c, DefaultTypeRegistry)
-    val jso = sc.getMember("bar").asInstanceOf[JSObject]
-    assert(jso.isFunction)
-    val invoked = jso.call(null)
-    invoked match {
+    val value = sc.getMember("bar")
+    value match {
       case jsa: JavaScriptArray[_] =>
         assert(jsa.size === 2)
        //assert(jsa.lyst === util.Arrays.asList("baz", "baz2"))

--- a/src/test/scala/com/atomist/rug/tree/context/text/MicrogrammarTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/rug/tree/context/text/MicrogrammarTypeScriptTest.scala
@@ -36,7 +36,6 @@ class MicrogrammarTypeScriptTest extends FlatSpec with Matchers {
 
       case boo => fail(s"Modification was not successful: $boo")
     }
-
   }
 
   it should "Apply a sample editor " in {

--- a/src/test/scala/com/atomist/rug/ts/CortexTypeGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/ts/CortexTypeGeneratorTest.scala
@@ -6,8 +6,6 @@ import com.atomist.util.Utils
 import org.apache.commons.io.IOUtils
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.util.matching.Regex
-
 class CortexTypeGeneratorTest extends FlatSpec with Matchers {
 
   import CortexTypeGenerator._

--- a/src/test/scala/com/atomist/tree/content/text/OverwritableTextTreeNodeTypeScriptTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/OverwritableTextTreeNodeTypeScriptTest.scala
@@ -8,11 +8,10 @@ import com.atomist.rug.ts.TypeScriptBuilder
 import com.atomist.source.file.ClassPathArtifactSource
 import org.scalatest.{FlatSpec, Matchers}
 
-class OverwriteableTextTreeNodeTypeScriptTest extends FlatSpec with Matchers {
+class OverwritableTextTreeNodeTypeScriptTest extends FlatSpec with Matchers {
 
-  it should "use OverwriteableTextTreeNode from TypeScript" in {
-    // RUN THIS EDITOR
-    val tsEditorResource = "com/atomist/tree/content/text/OverwriteableTextTreeNodeTypeScriptTest.ts"
+  it should "use OverwritableTextTreeNode from TypeScript" in {
+    val tsEditorResource = "com/atomist/tree/content/text/OverwritableTextTreeNodeTypeScriptTest.ts"
     val parameters = SimpleParameterValues.Empty
 
     // ON THIS PROJECT

--- a/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
+++ b/src/test/scala/com/atomist/tree/content/text/microgrammar/dsl/TypeScriptMicrogrammarTest.scala
@@ -164,7 +164,7 @@ class TypeScriptMicrogrammarTest extends FlatSpec with Matchers {
       |
       |      eng.with<any>(project, "//File()/method()", n => {
       |        //console.log(`Type=${n.nodeType()},value=${n.value()}`)
-      |        n.update(n.type().value() + "_x") // replace the whole method with its type and a suffix. It doesn't make sense
+      |        n.update(n.type.value() + "_x") // replace the whole method with its type and a suffix. It doesn't make sense
       |      })
       |    }
       |  }

--- a/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/LinkedJsonTreeDeserializerTest.scala
@@ -108,7 +108,7 @@ class LinkedJsonTreeDeserializerTest extends FlatSpec with Matchers {
      |      "timestamp":"2017-01-17T17:18:52.943Z",
      |      "nodeId":4766,
      |      "type":[
-     |         "Push"
+     |         "Push", "-dynamic"
      |      ]
      |   },
      |   {

--- a/src/test/scala/com/atomist/tree/marshal/ProxyAgainstDeserializedNodeTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/ProxyAgainstDeserializedNodeTest.scala
@@ -1,0 +1,40 @@
+package com.atomist.tree.marshal
+
+import com.atomist.graph.GraphNode
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.rugdoc.TypeScriptStubClassGeneratorTest
+import com.atomist.rug.runtime.js.interop.jsSafeCommittingProxy
+import com.atomist.rug.spi.TypeRegistry
+import org.scalatest.{FlatSpec, Matchers}
+
+class ProxyAgainstDeserializedNodeTest extends FlatSpec with Matchers {
+
+  private val IssueNode =
+    """[{"updatedAt":"2017-04-10T21:01:16Z","body":"test","createdAt":"2017-04-10T21:01:16Z","closedAt":"","id":"220769383","timestamp":"2017-04-10T21:01:16Z","nodeId":8684,"action":"opened","number":307,"title":"teset","type":["Issue"],"state":"open"},
+      |{"name":"Christian Dupuis","login":"cdupuis","nodeId":2453,"type":["GitHubId"]},
+      |{"owner":"atomisthqa","name":"handlers","nodeId":7444,"type":["Repo"]},
+      |{"name":"handlers","id":"C31PNRDNV","nodeId":7451,"type":["ChatChannel","SlackChannel"]},{"forename":"Christian","surname":"Dupuis","nodeId":1564,"type":["Person"]},
+      |{"id":"U1L22E3SA","screenName":"cd","nodeId":1562,"type":["ChatId","SlackId"]},{"startNodeId":8684,"endNodeId":2453,"type":"openedBy","cardinality":"1:1"},
+      |{"startNodeId":8684,"endNodeId":7444,"type":"repo","cardinality":"1:1"},{"startNodeId":7444,"endNodeId":8684,"type":"issue","cardinality":"1:M"},
+      |{"startNodeId":7444,"endNodeId":7451,"type":"channels","cardinality":"1:M"},{"startNodeId":7451,"endNodeId":7444,"type":"repos","cardinality":"1:M"},
+      |{"startNodeId":1564,"endNodeId":2453,"type":"gitHubId","cardinality":"1:1"},{"startNodeId":2453,"endNodeId":1564,"type":"person","cardinality":"1:1"},
+      |{"startNodeId":1564,"endNodeId":1562,"type":"chatId","cardinality":"1:1"},{"startNodeId":1562,"endNodeId":1564,"type":"person","cardinality":"1:1"}]
+      |""".stripMargin
+
+  "proxy against deserialized node" should "handle simple case without type information" in
+    handleSimpleCase(DefaultTypeRegistry)
+
+  it should "handle simple case with type information" in
+    handleSimpleCase(DefaultTypeRegistry + TypeScriptStubClassGeneratorTest.cortexTypeRegistry)
+
+  private def handleSimpleCase(tr: TypeRegistry): Unit = {
+    val gn: GraphNode = LinkedJsonTreeDeserializer.fromJson(IssueNode)
+    val proxy = new jsSafeCommittingProxy(gn, tr)
+    // It's a JVM invocation
+    //assert(proxy.getMember("nodeName") === "Issue")
+    proxy.getMember("number") match {
+      case x => assert(x.toString === "307")
+    }
+  }
+
+}

--- a/src/test/scala/com/atomist/tree/marshal/ProxyAgainstDeserializedNodeTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/ProxyAgainstDeserializedNodeTest.scala
@@ -3,19 +3,23 @@ package com.atomist.tree.marshal
 import com.atomist.graph.GraphNode
 import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.rugdoc.TypeScriptStubClassGeneratorTest
-import com.atomist.rug.runtime.js.interop.jsSafeCommittingProxy
+import com.atomist.rug.runtime.js.interop.{NashornUtilsTest, jsSafeCommittingProxy}
 import com.atomist.rug.spi.TypeRegistry
+import com.atomist.util.lang.JavaScriptArray
 import org.scalatest.{FlatSpec, Matchers}
 
 class ProxyAgainstDeserializedNodeTest extends FlatSpec with Matchers {
 
   private val IssueNode =
-    """[{"updatedAt":"2017-04-10T21:01:16Z","body":"test","createdAt":"2017-04-10T21:01:16Z","closedAt":"","id":"220769383","timestamp":"2017-04-10T21:01:16Z","nodeId":8684,"action":"opened","number":307,"title":"teset","type":["Issue"],"state":"open"},
+    """[{"updatedAt":"2017-04-10T21:01:16Z","body":"test","createdAt":"2017-04-10T21:01:16Z",
+      |"closedAt":"","id":"220769383","timestamp":"2017-04-10T21:01:16Z","nodeId":8684,
+      |"action":"opened","number":307,"title":"teset","type":["Issue"],"state":"open"},
       |{"name":"Christian Dupuis","login":"cdupuis","nodeId":2453,"type":["GitHubId"]},
       |{"owner":"atomisthqa","name":"handlers","nodeId":7444,"type":["Repo"]},
       |{"name":"handlers","id":"C31PNRDNV","nodeId":7451,"type":["ChatChannel","SlackChannel"]},{"forename":"Christian","surname":"Dupuis","nodeId":1564,"type":["Person"]},
       |{"id":"U1L22E3SA","screenName":"cd","nodeId":1562,"type":["ChatId","SlackId"]},{"startNodeId":8684,"endNodeId":2453,"type":"openedBy","cardinality":"1:1"},
-      |{"startNodeId":8684,"endNodeId":7444,"type":"repo","cardinality":"1:1"},{"startNodeId":7444,"endNodeId":8684,"type":"issue","cardinality":"1:M"},
+      |{"startNodeId":8684,"endNodeId":7444,"type":"repo","cardinality":"1:1"},
+      |{"startNodeId":7444,"endNodeId":8684,"type":"issue","cardinality":"1:M"},
       |{"startNodeId":7444,"endNodeId":7451,"type":"channels","cardinality":"1:M"},{"startNodeId":7451,"endNodeId":7444,"type":"repos","cardinality":"1:M"},
       |{"startNodeId":1564,"endNodeId":2453,"type":"gitHubId","cardinality":"1:1"},{"startNodeId":2453,"endNodeId":1564,"type":"person","cardinality":"1:1"},
       |{"startNodeId":1564,"endNodeId":1562,"type":"chatId","cardinality":"1:1"},{"startNodeId":1562,"endNodeId":1564,"type":"person","cardinality":"1:1"}]
@@ -30,11 +34,21 @@ class ProxyAgainstDeserializedNodeTest extends FlatSpec with Matchers {
   private def handleSimpleCase(tr: TypeRegistry): Unit = {
     val gn: GraphNode = LinkedJsonTreeDeserializer.fromJson(IssueNode)
     val proxy = new jsSafeCommittingProxy(gn, tr)
-    // It's a JVM invocation
-    //assert(proxy.getMember("nodeName") === "Issue")
     proxy.getMember("number") match {
       case x => assert(x.toString === "307")
     }
+    val eng = NashornUtilsTest.createEngine
+    eng.put("issue", proxy)
+    assert(eng.eval("issue.number").toString === "307")
+    assert(eng.eval("issue.repo.name").toString === "handlers")
+    eng.eval("issue.repo.channels") match {
+      case jsa: JavaScriptArray[_] =>
+        assert(jsa.size === 1)
+      case f => fail(s"Unexpected: $f")
+    }
+    assert(eng.eval("issue.repo.channels[0].name") === "handlers")
+    assert(eng.eval("issue.repo.channels[0].id") === "C31PNRDNV")
+    assert(eng.eval("issue.repo.channels.length") === 1)
   }
 
 }


### PR DESCRIPTION
Fixes bug where navigation of graph (vs invocation of properties defined on a JVM-backed type) did not support property access. This had not shown up because use of the generated model was tested only via Gherkin support, which does not serialize or deserialize nodes.

The fixed behavior is in `jsSafeCommittingProxy`. Most of the changes relate to updating the test suite.

Added tests to verify correct behavior with deserialized ingester nodes and prevent regression.