### PR TITLE
Various improvements for project testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.25.3...HEAD
 
+### Changed
+
+- Project test steps can now return `void`, as for handlers.
+
 ## [0.25.3] - 2017-04-13
 
 [0.25.3]: https://github.com/atomist/rug/compare/0.25.2...0.25.3

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
@@ -49,28 +49,34 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
     editorsRun(): number
 }
 
+// Callback for given and when steps
+type SetupCallback = (Project, ProjectScenarioWorld?, ...args) => void
+
+type ThenCallback = (Project, ProjectScenarioWorld?, ...args) => Result | boolean | void
+
+
 interface Definitions {
 
-    Given(s: string, f: (Project, ProjectScenarioWorld?, ...args) => void): void
+    Given(s: string, f: SetupCallback): void
 
-    When(s: string, f: (Project, ProjectScenarioWorld?, ...args) => void): void
+    When(s: string, f: SetupCallback): void
 
-    Then(s: string, f: (Project, ProjectScenarioWorld?, ...args) => Result | boolean): void
+    Then(s: string, f: ThenCallback): void
 
 }
 
  // Registered with Nashorn by the test runner
 declare var com_atomist_rug_test_gherkin_GherkinRunner$_definitions: Definitions
 
-export function Given(s: string, f: (Project, ProjectScenarioWorld?, ...args) => void) {
+export function Given(s: string, f: SetupCallback) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f)
 }
 
-export function When(s: string, f: (Project, ProjectScenarioWorld?, ...args) => void) {
+export function When(s: string, f: SetupCallback) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f)
 }
 
-export function Then(s: string, f: (Project, ProjectScenarioWorld?, ...args) => Result | boolean) {
+export function Then(s: string, f: ThenCallback) {
     com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f)
 }
 

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
@@ -17,6 +17,13 @@ Given("the archive root", p => {
 });
 
 /**
+ * The contents of this archive, excluding Atomist content
+ */
+Given("archive non Atomist content", p => {
+    p.copyEditorBackingProject("");
+});
+
+/**
  * Editor made changes
  */
 Then("changes were made", (p, world) => {
@@ -43,6 +50,22 @@ Then("parameters were valid", (p, world) => {
 Then("parameters were invalid", (p, world) => {
     return world.invalidParameters() != null;
 });
+
+Then("file at ([^ ]+) should exist", (p, w, path: string) => {
+    const f = p.findFile(path);
+    if (f == null)
+        throw new Error(`File at [${path}] expected, but not found`);
+});
+
+Then("file at ([^ ]+) should contain (.*)", (p, w, path: string, lookFor: string) => {
+    const f = p.findFile(path);
+    if (f == null)
+        throw new Error(`File at [${path}] expected, but not found`)
+    const idx = f.content.indexOf(lookFor);
+    if (idx == -1)
+        throw new Error(`File at [${path}] did not contain [${lookFor}]. Content was\n${f.content}`)
+});
+
 
 /**
  * When step should fail

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/CorruptionTestSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/CorruptionTestSteps.ts
@@ -22,3 +22,5 @@ Then("we have comments", (p, world) => {
     let rr = world.get("review");
     return rr.comments.length == 1;
 });
+Then("we can succeed by returning void", p => {
+});

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
@@ -51,6 +51,7 @@ object ProjectTestTargets {
       |    Then we have Anders
       |    Then we have file from start project
       |    Then the project name is correct
+      |    Then we can succeed by returning void
       |""".stripMargin
 
   val GenerationFeatureFile = StringFileArtifact(
@@ -82,6 +83,7 @@ object ProjectTestTargets {
        |Then("the project name is correct", p => {
        |    return p.name == "$projectName";
        |});
+       |Then("we can succeed by returning void", p => {});
        |""".stripMargin
 
   val GenerationBadParameterFeature =

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
@@ -49,6 +49,8 @@ object ProjectTestTargets {
       |    When run simple generator
       |    Then parameters were valid
       |    Then we have Anders
+      |    Then file at src/from/typescript should exist
+      |    Then file at src/from/typescript should contain Anders
       |    Then we have file from start project
       |    Then the project name is correct
       |    Then we can succeed by returning void
@@ -83,7 +85,8 @@ object ProjectTestTargets {
        |Then("the project name is correct", p => {
        |    return p.name == "$projectName";
        |});
-       |Then("we can succeed by returning void", p => {});
+       |Then("we can succeed by returning void", p => {
+       |});
        |""".stripMargin
 
   val GenerationBadParameterFeature =


### PR DESCRIPTION
- Project test steps can now return `void` to be consistent with handlers
- Additional convenience methods in `wellKnownSteps` to look for file content, using regular expressions
- New `copyEditorBackingProject ` method on `ProjectMutableView` to copy non-Atomist content conveniently.
