### PR TITLE
More specific typings for handler responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   **BREAKING** Event and Command Handlers must return EventPlan and Command Plan
+    respectively to remove confusion as to the different capabilities
 -   **BREAKING** Removed ability to add `command` instructions to the Plans 
 -   Project test steps can now return `void`, as for handlers.
 

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -1,7 +1,7 @@
 import { GraphNode, TreeNode, PathExpressionEngine, PathExpression, Match } from "../tree/PathExpression"
 import { Parameter } from "./RugOperation"
 
-interface RugCoordinate {
+export interface RugCoordinate {
   readonly name: string
   readonly group: string
   readonly artifact: string
@@ -9,21 +9,25 @@ interface RugCoordinate {
 
 type InstructionKind = "generate" | "edit" | "execute" | "respond"
 
-interface Instruction<T extends InstructionKind> {
+export interface Instruction<T extends InstructionKind> {
   readonly name: string | RugCoordinate
   readonly parameters?: {}
   readonly kind: T
 }
 
-interface ImmediatelyRunnable { }
-
-class Respondable<T extends Edit | Generate | Execute> implements ImmediatelyRunnable {
+export class EventRespondable<T extends Edit | Generate | Execute> {
   instruction: T
-  onSuccess?: Plan | PlanMessage | Respond
-  onError?: Plan | PlanMessage | Respond
+  onSuccess?: EventPlan | EventMessage | Respond
+  onError?: EventPlan | EventMessage | Respond
 }
 
-class Presentable<T extends InstructionKind> {
+export class CommandRespondable<T extends Edit | Generate | Execute> {
+  instruction: T
+  onSuccess?: CommandPlan | CommandMessage | Respond
+  onError?: CommandPlan | CommandMessage | Respond
+}
+
+export class Presentable<T extends InstructionKind> {
   instruction: Instruction<T> | PresentableGenerate | PresentableEdit
   label?: string
 }
@@ -34,46 +38,46 @@ interface ProjectReference {
 
 }
 
-interface ProjectInstruction<T extends InstructionKind> extends Instruction<T> {
+export interface ProjectInstruction<T extends InstructionKind> extends Instruction<T> {
   project: string | ProjectReference
 }
 
-interface Edit extends ProjectInstruction<"edit"> {
+export interface Edit extends ProjectInstruction<"edit"> {
 
 }
 
 //extends ProjectInstruction because we need to know the project name
-interface Generate extends ProjectInstruction<"generate"> {
+export interface Generate extends ProjectInstruction<"generate"> {
 
 }
 
 //because in a message, we may not know project name yet
-interface PresentableGenerate extends Instruction<"generate"> {
+export interface PresentableGenerate extends Instruction<"generate"> {
   project?: string | ProjectReference
 }
 
 //because in a message, we may not know project name yet
-interface PresentableEdit extends Instruction<"edit"> {
+export interface PresentableEdit extends Instruction<"edit"> {
   project?: string | ProjectReference
 }
 
-interface Execute extends Instruction<"execute"> {
+export interface Execute extends Instruction<"execute"> {
 }
 
-interface Respond extends Instruction<"respond"> {
+export interface Respond extends Instruction<"respond"> {
 
 }
 
-interface HandleCommand {
-  handle(ctx: HandlerContext): Plan
+export interface HandleCommand {
+  handle(ctx: HandlerContext): CommandPlan
 }
 
-interface HandleEvent<R extends GraphNode, M extends GraphNode> {
-  handle(root: Match<R, M>): Plan
+export interface HandleEvent<R extends GraphNode, M extends GraphNode> {
+  handle(root: Match<R, M>): EventPlan
 }
 
-interface HandleResponse<T> {
-  handle(response: Response<T>): Plan
+export interface HandleResponse<T> {
+  handle(response: Response<T>): EventPlan | CommandPlan
 }
 
 /**
@@ -81,7 +85,7 @@ interface HandleResponse<T> {
  * Exposes a context root from which queries can be run,
  * using the given PathExpressionEngine
  */
-interface HandlerContext {
+export interface HandlerContext {
 
   /**
    * Id of the team we're working on behalf of
@@ -97,41 +101,71 @@ interface HandlerContext {
   contextRoot: GraphNode
 }
 
-enum Status {
+export enum Status {
   failure,
   success
 }
 
-interface Response<T> {
+export interface Response<T> {
   msg: string
   code: number
   status: Status
   body: T
 }
 
+type Respondable = EventRespondable<any> | CommandRespondable<any>
+
 /**
  * A bunch of stuff to do asynchronously
- * Messages got to the bot.
- * Rugs are run straight away
+ * PlanMessages got to the bot.
+ * ImmediatelyRunnables are run straight away
  */
-class Plan {
+export abstract class Plan {
+
+  instructions: Respondable[] = [];
 
   messages: PlanMessage[] = [];
 
-  instructions: ImmediatelyRunnable[] = [];
-
-  public add?(thing: ImmediatelyRunnable | PlanMessage): this {
+  public add?(thing: Respondable | PlanMessage): this {
     if (thing instanceof ResponseMessage || thing instanceof DirectedMessage || thing instanceof LifecycleMessage) {
-      this.messages.push(thing)
-    }
-    else {
-      this.instructions.push(thing)
+      this.messages.push(thing);
+    } else {
+      this.instructions.push(thing);
     }
     return this;
   }
+}
 
-  static ofMessage(m: PlanMessage): Plan {
-    return new Plan().add(m);
+
+type EventMessage = LifecycleMessage | DirectedMessage
+
+type CommandMessage = ResponseMessage | DirectedMessage
+
+/**
+ * For returning from Event Handlers
+ */
+export class EventPlan extends Plan {
+
+  public add?(msg: EventMessage | EventRespondable<any>): this {
+    return super.add(msg);
+  }
+
+  static ofMessage(m: EventMessage): EventPlan {
+    return new EventPlan().add(m);
+  }
+}
+
+/**
+ * Plans returned from Command Handlers
+ */
+export class CommandPlan extends Plan {
+
+  public add?(msg: CommandMessage | CommandRespondable<any>): this {
+    return super.add(msg);
+  }
+
+  static ofMessage(m: CommandMessage): CommandPlan {
+    return new CommandPlan().add(m);
   }
 }
 
@@ -240,7 +274,7 @@ export class LifecycleMessage implements Message<"lifecycle">{
 
 export type PlanMessage = ResponseMessage | DirectedMessage | LifecycleMessage
 
-abstract class MappedParameters {
+export abstract class MappedParameters {
   static readonly GITHUB_REPO_OWNER: string = "atomist://github/repository/owner"
   static readonly GITHUB_REPOSITORY: string = "atomist://github/repository"
   static readonly SLACK_CHANNEL: string = "atomist://slack/channel"
@@ -249,7 +283,3 @@ abstract class MappedParameters {
   static readonly GITHUB_WEBHOOK_URL: string = "atomist://github_webhook_url"
 }
 
-export { MappedParameters }
-export { Respond, Presentable, Respondable, Instruction, Response, HandlerContext, Plan, Execute }
-export { HandleResponse, HandleCommand, HandleEvent }
-export { Edit, ProjectInstruction }

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -1,6 +1,6 @@
 import { ScenarioWorld } from "../ScenarioWorld"
 import { Result } from "../Result"
-import { Plan } from "../../operations/Handlers"
+import { CommandPlan, EventPlan, Plan } from "../../operations/Handlers"
 import { GraphNode } from "../../tree/PathExpression"
 import { Project } from "../../model/Core"
 
@@ -8,7 +8,7 @@ import { Project } from "../../model/Core"
  * All handler scenario worlds expose the plan,
  * if constructed by code under test.
  */
-export interface HandlerScenarioWorld extends ScenarioWorld {
+export interface HandlerScenarioWorld<T extends Plan> extends ScenarioWorld {
 
     /**
      * Return an empty project. Useful in creating fake repos.
@@ -29,12 +29,12 @@ export interface HandlerScenarioWorld extends ScenarioWorld {
     /**
      * Return a single plan. Throws an exception if no plan was recorded
      */
-    plan(): Plan
+    plan(): T
 
     /**
      * Return the plan recorded for the handler with this name, or null
      */
-    planFor(handlerName: string): Plan
+    planFor(handlerName: string): T
 
     /**
      * Return the number of plans recorded for this scenario
@@ -52,7 +52,7 @@ export interface HandlerScenarioWorld extends ScenarioWorld {
  * Subinterface of ScenarioWorld specific to
  * scenarios testing project operations
  */
-export interface CommandHandlerScenarioWorld extends HandlerScenarioWorld {
+export interface CommandHandlerScenarioWorld extends HandlerScenarioWorld<CommandPlan>  {
 
     /**
      * Return the CommandHandler with the given name, or null if none is found.
@@ -67,7 +67,7 @@ export interface CommandHandlerScenarioWorld extends HandlerScenarioWorld {
 
 }
 
-export interface EventHandlerScenarioWorld extends HandlerScenarioWorld {
+export interface EventHandlerScenarioWorld extends HandlerScenarioWorld<EventPlan> {
 
     /**
      * Register the named handler to respond to input

--- a/src/test/resources/com/atomist/rug/runtime/js/KittieFetcher.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/KittieFetcher.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, ResponseMessage, LifecycleMessage, ChannelAddress} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan, DirectedMessage, ResponseMessage, LifecycleMessage, ChannelAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -9,13 +9,13 @@ class KittieFetcher implements HandleCommand {
   @Parameter({description: "his dudeness", pattern: "^.*$"})
   name: string
 
-  handle(ctx: HandlerContext) : Plan {
+  handle(ctx: HandlerContext) : CommandPlan {
     let pxe = ctx.pathExpressionEngine
 
     if(this.name != "el duderino") {
       throw new Error("This will not stand");
     }
-    let result = new Plan()
+    let result = new CommandPlan()
     result.add({ instruction: {
                  kind: "execute",
                  name: "HTTP",

--- a/src/test/resources/com/atomist/rug/runtime/js/KittieFetcherWithMappedParams.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/KittieFetcherWithMappedParams.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, ResponseMessage} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan, ResponseMessage} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, MappedParameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -9,12 +9,12 @@ class KittieFetcher implements HandleCommand{
   @MappedParameter("atomist/repo")
   name: string
 
-  handle(ctx: HandlerContext) : Plan {
+  handle(ctx: HandlerContext) : CommandPlan {
 
     if(this.name != "el duderino") {
       throw new Error("This will not stand");
     }
-    let result = new Plan()
+    let result = new CommandPlan()
     return result;
   }
 }

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/KittieFetcherWithSecrets.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/KittieFetcherWithSecrets.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Secrets, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -7,9 +7,9 @@ import {CommandHandler, Secrets, Parameter, Tags, Intent} from '@atomist/rug/ope
 @Secrets("atomist/user_token", "atomist/showmethemoney")
 class KittieFetcher implements HandleCommand{
 
-  handle(ctx: HandlerContext) : Plan {
+  handle(ctx: HandlerContext) : CommandPlan {
 
-    let result = new Plan()
+    let result = new CommandPlan()
     result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "woot"}}})
     return result;
   }

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerExecuteInstructionCallingRespondable.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerExecuteInstructionCallingRespondable.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -6,9 +6,9 @@ import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist
 @Intent("show me kitties","cats please")
 class KittieFetcher implements HandleCommand{
 
-  handle(ctx: HandlerContext) : Plan {
+  handle(ctx: HandlerContext) : CommandPlan {
 
-    let result = new Plan()
+    let result = new CommandPlan()
     result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "woot"}},
                 onSuccess: {name: "SimpleResponseHandler", kind: "respond"} });
     return result;
@@ -17,8 +17,8 @@ class KittieFetcher implements HandleCommand{
 
 @ResponseHandler("SimpleResponseHandler", "Checks response is equal to passed in parameter")
 class Responder implements HandleResponse<String> {
-  handle(response: Response<string>) : Plan {
-    return new Plan();
+  handle(response: Response<string>) : CommandPlan {
+    return new CommandPlan();
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningEmptyMessage.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningEmptyMessage.ts
@@ -1,11 +1,11 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties", "Search Youtube for kitty videos and post results to slack")
 class KittieFetcher implements HandleCommand{
 
   handle(ctx: HandlerContext) {
-    return new Plan().add(new DirectedMessage("", "text/plain", new UserAddress("woot")));
+    return new CommandPlan().add(new DirectedMessage("", "text/plain", new UserAddress("woot")));
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningMessage.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerReturningMessage.ts
@@ -1,11 +1,11 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
 class KittieFetcher implements HandleCommand{
 
-  handle(ctx: HandlerContext) : Plan {
-    return Plan.ofMessage({body: "Up and at 'em!", kind: "directed", contentType: "text/plain");
+  handle(ctx: HandlerContext) : CommandPlan {
+    return CommandPlan.ofMessage({body: "Up and at 'em!", kind: "directed", contentType: "text/plain");
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithBadStubUse.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithBadStubUse.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 import {Build} from "@atomist/rug/cortex/stub/Build"
 
@@ -9,7 +9,7 @@ class SimpleCommandHandlerWithBadStubUse implements HandleCommand{
   handle(ctx: HandlerContext) {
       // This will fail
       let build = new Build().repo;
-      return Plan.ofMessage(new DirectedMessage("foobar", new UserAddress("bob")));
+      return CommandPlan.ofMessage(new DirectedMessage("foobar", new UserAddress("bob")));
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithNullDefault.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithNullDefault.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, ResponseMessage} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan, ResponseMessage} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -7,8 +7,8 @@ class KittieFetcher implements HandleCommand{
   @Parameter({description: "test", pattern: "@any", required: false})
   test: string = null
 
-  handle(ctx: HandlerContext) : Plan {
-    return new Plan().add(new ResponseMessage("body"));
+  handle(ctx: HandlerContext) : CommandPlan {
+    return new CommandPlan().add(new ResponseMessage("body"));
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithSameParametersConfig.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandHandlerWithSameParametersConfig.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, Instruction, Response, HandlerContext, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, Instruction, Response, HandlerContext, CommandPlan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 import {Build} from "@atomist/rug/cortex/stub/Build"
 
@@ -14,7 +14,7 @@ class SameConfig implements HandleCommand{
   bar: number
 
   handle(ctx: HandlerContext) {
-      return new Plan();
+      return new CommandPlan();
   }
 }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandWithPresentable.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleCommandWithPresentable.ts
@@ -1,4 +1,4 @@
-import {HandleCommand, MappedParameters, ResponseMessage, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+import {HandleCommand, MappedParameters, ResponseMessage, Instruction, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
 import {CommandHandler, Parameter, MappedParameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
 
 @CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -12,13 +12,13 @@ class KittieFetcher implements HandleCommand {
   @MappedParameter(MappedParameters.GITHUB_REPO_OWNER)
   owner: string
 
-  handle(ctx: HandlerContext) : Plan {
+  handle(ctx: HandlerContext) : CommandPlan {
     let pxe = ctx.pathExpressionEngine
 
     if(this.name != "el duderino") {
       throw new Error("This will not stand");
     }
-    let result = new Plan()
+    let result = new CommandPlan()
     let message = new ResponseMessage("KittieFetcher");
     message.addAction({ instruction: {
                  kind: "command",

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/command/CommandHandlers.ts
@@ -1,4 +1,4 @@
-import { HandleCommand, Instruction, Response, HandlerContext, Plan, ResponseMessage } from '@atomist/rug/operations/Handlers'
+import { HandleCommand, Instruction, Response, HandlerContext, CommandPlan, ResponseMessage } from '@atomist/rug/operations/Handlers'
 import { CommandHandler, Secrets, Parameter, Tags, Intent } from '@atomist/rug/operations/Decorators'
 import { Project } from "@atomist/rug/model/Project"
 
@@ -10,8 +10,8 @@ import * as node from "./Nodes"
 @Secrets("atomist/user_token", "atomist/showmethemoney")
 class ReturnsEmptyPlanCommandHandler implements HandleCommand {
 
-    handle(ctx: HandlerContext): Plan {
-        let result = new Plan();
+    handle(ctx: HandlerContext): CommandPlan {
+        let result = new CommandPlan();
         // result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "woot"}}});
         return result;
     }
@@ -25,8 +25,8 @@ export const command1 = new ReturnsEmptyPlanCommandHandler();
 @Secrets("atomist/user_token", "atomist/showmethemoney")
 class ReturnsOneMessageCommandHandler implements HandleCommand {
 
-    handle(ctx: HandlerContext): Plan {
-        let result = new Plan()
+    handle(ctx: HandlerContext): CommandPlan {
+        let result = new CommandPlan()
         if (ctx.teamId == null)
             throw new Error("Cannot get at team id")
 
@@ -42,8 +42,8 @@ export const command2 = new ReturnsOneMessageCommandHandler();
 @Tags("path_expression")
 class RunsPathExpressionCommandHandler implements HandleCommand {
 
-    handle(ctx: HandlerContext): Plan {
-        let result = new Plan()
+    handle(ctx: HandlerContext): CommandPlan {
+        let result = new CommandPlan()
         let eng = ctx.pathExpressionEngine
 
         const findPerson = "/Commit/Person()[@name='Ebony']"
@@ -64,8 +64,8 @@ export const command3 = new RunsPathExpressionCommandHandler();
 @Tags("path_expression")
 class RunsMatchingPathExpressionCommandHandler implements HandleCommand {
 
-    handle(ctx: HandlerContext): Plan {
-        let result = new Plan()
+    handle(ctx: HandlerContext): CommandPlan {
+        let result = new CommandPlan()
         const eng = ctx.pathExpressionEngine
 
         const findPerson = "/Commit/Person()[@name='Ebony']"
@@ -84,8 +84,8 @@ export const command4 = new RunsMatchingPathExpressionCommandHandler();
 @Tags("path_expression")
 class GoesOffGraph implements HandleCommand {
 
-    handle(ctx: HandlerContext): Plan {
-        let result = new Plan()
+    handle(ctx: HandlerContext): CommandPlan {
+        let result = new CommandPlan()
         const eng = ctx.pathExpressionEngine
 
         const findPerson = "/Commit/Person()[@name='Ebony']"
@@ -106,8 +106,8 @@ export const command5 = new GoesOffGraph();
 @Tags("path_expression")
 class LooksInProjects implements HandleCommand {
 
-    handle(ctx: HandlerContext): Plan {
-        let result = new Plan()
+    handle(ctx: HandlerContext): CommandPlan {
+        let result = new CommandPlan()
         const eng = ctx.pathExpressionEngine
 
         // Find all Maven projects

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/517_Pulled.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/517_Pulled.ts
@@ -1,4 +1,4 @@
-import { HandleEvent, ChannelAddress, DirectedMessage, LifecycleMessage, MessageMimeTypes, ResponseMessage, Plan } from '@atomist/rug/operations/Handlers'
+import { HandleEvent, ChannelAddress, DirectedMessage, LifecycleMessage, MessageMimeTypes, ResponseMessage, EventPlan } from '@atomist/rug/operations/Handlers'
 import { GraphNode, Match, PathExpression } from '@atomist/rug/tree/PathExpression'
 import { EventHandler, Tags } from '@atomist/rug/operations/Decorators'
 import { K8Pod } from "@atomist/rug/cortex/stub/K8Pod"
@@ -23,7 +23,7 @@ import { ChatChannel } from "@atomist/rug/cortex/ChatChannel"
 @Tags("kubernetes")
 class Pulled implements HandleEvent<K8Pod, K8Pod> {
 
-    handle(event: Match<K8Pod, K8Pod>): Plan {
+    handle(event: Match<K8Pod, K8Pod>): EventPlan {
         const pod: K8Pod = event.root() as K8Pod
         const image: DockerImage = pod.images[0]
         const commit: Commit = image.tag.commit
@@ -32,7 +32,7 @@ class Pulled implements HandleEvent<K8Pod, K8Pod> {
         const lifecycleId: string = "commit_event/" + repo.owner + "/" + repo.name + "/" + commit.sha
         let message: LifecycleMessage = new LifecycleMessage(pod, lifecycleId)
 
-        return Plan.ofMessage(message)
+        return EventPlan.ofMessage(message)
     }
 }
 

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
@@ -1,4 +1,4 @@
-import { HandleEvent, Plan, DirectedMessage, ChannelAddress } from '@atomist/rug/operations/Handlers'
+import { HandleEvent, EventPlan, DirectedMessage, ChannelAddress } from '@atomist/rug/operations/Handlers'
 import { GraphNode, Match, PathExpression } from '@atomist/rug/tree/PathExpression'
 
 import { EventHandler, Tags } from '@atomist/rug/operations/Decorators'
@@ -11,7 +11,7 @@ import * as node from "./Nodes"
 class ReturnsEmptyPlanEventHandler implements HandleEvent<GraphNode, GraphNode> {
 
     handle(event: Match<GraphNode, GraphNode>) {
-        return new Plan();
+        return new EventPlan();
     }
 }
 export const handler = new ReturnsEmptyPlanEventHandler()
@@ -22,7 +22,7 @@ export const handler = new ReturnsEmptyPlanEventHandler()
 class ReturnsEmptyPlanEventHandler2 implements HandleEvent<GraphNode, GraphNode> {
 
     handle(event: Match<GraphNode, GraphNode>) {
-        return new Plan();
+        return new EventPlan();
     }
 }
 export const handler2 = new ReturnsEmptyPlanEventHandler2();
@@ -36,7 +36,7 @@ class ReturnsEmptyPlanEventHandler2a implements HandleEvent<GraphNode, GraphNode
     handle(m: Match<node.Commit, node.Person>) {
         let peep = m.matches()[0];
         // console.log(`Match ${m}: peep=${peep}`);
-        return new Plan();
+        return new EventPlan();
     }
 }
 export const handler2a = new ReturnsEmptyPlanEventHandler2a();
@@ -53,7 +53,7 @@ class ReturnsEmptyPlanEventHandler3 implements HandleEvent<node.Commit, node.Git
         if (ghid.id != "gogirl") throw new Error(`Unexpected github id ${ghid.id}`)
         //if (ghid.address != "/madeBy/gitHubId") throw new Error(`Unexpected address [${ghid.address}]`)
 
-        return new Plan();
+        return new EventPlan();
     }
 }
 export const handler3 = new ReturnsEmptyPlanEventHandler3();
@@ -65,7 +65,7 @@ export const handler3 = new ReturnsEmptyPlanEventHandler3();
 class ReturnsAMessage implements HandleEvent<node.Commit, node.GitHubId> {
 
     handle(m: Match<GraphNode, GraphNode>) {
-        return new Plan().add(new DirectedMessage("Hello there!",
+        return new EventPlan().add(new DirectedMessage("Hello there!",
         new ChannelAddress("test-channel")))
     }
 }
@@ -80,7 +80,7 @@ class AngryHandler implements HandleEvent<node.Commit, node.GitHubId> {
 
     handle(m: Match<GraphNode, GraphNode>) {
         if (23 > 0) throw new Error("I hate y'all")
-        return new Plan().add(new DirectedMessage("Hello there!",
+        return new EventPlan().add(new DirectedMessage("Hello there!",
         new ChannelAddress("test-channel")))
     }
 }

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
@@ -1,4 +1,4 @@
-import { HandleEvent, Plan } from '@atomist/rug/operations/Handlers'
+import { HandleEvent, EventPlan } from '@atomist/rug/operations/Handlers'
 import { GraphNode, Match, PathExpression } from '@atomist/rug/tree/PathExpression'
 
 import { EventHandler, Tags } from '@atomist/rug/operations/Decorators'
@@ -18,7 +18,7 @@ class ReturnsEmptyPlanEventHandlerGen1 implements HandleEvent<GraphNode, Build> 
     handle(m: Match<GraphNode, Build>) {
         let b: Build = m.matches()[0]
         b.status + ""   // Evaluate this stringification doesn't break
-        return new Plan();
+        return new EventPlan();
     }
 }
 export const handler1 = new ReturnsEmptyPlanEventHandlerGen1();
@@ -34,7 +34,7 @@ class ReturnsEmptyPlanEventHandlerGenWithArrays implements HandleEvent<GraphNode
 
         if (p.commits.length != 1) throw new Error("No commits")
 
-        return new Plan();
+        return new EventPlan();
     }
 }
 export const handler2 = new ReturnsEmptyPlanEventHandlerGenWithArrays();

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -28,7 +28,7 @@ object JavaScriptEventHandlerTest {
 
   val reOpenCloseIssueProgram = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {HandleEvent, Plan, LifecycleMessage, DirectedMessage, MessageMimeTypes, ChannelAddress} from '@atomist/rug/operations/Handlers'
+       |import {HandleEvent, EventPlan, LifecycleMessage, DirectedMessage, MessageMimeTypes, ChannelAddress} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
        |
@@ -37,7 +37,7 @@ object JavaScriptEventHandlerTest {
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |  handle(event: Match<TreeNode, TreeNode>){
        |    let issue = event.root
-       |    let plan = new Plan()
+       |    let plan = new EventPlan()
        |
        |    const message = new DirectedMessage("message1", new ChannelAddress("w00t"))
        |
@@ -52,8 +52,8 @@ object JavaScriptEventHandlerTest {
        |               onError: {body: "No kitties for you today!", kind: "directed", contentType: MessageMimeTypes.PLAIN_TEXT, usernames: ["w00t"]}
        |             });
        |
-       |    const anEmptyPlan = new Plan()
-       |    const aPlansPlan = new Plan()
+       |    const anEmptyPlan = new EventPlan()
+       |    const aPlansPlan = new EventPlan()
        |    aPlansPlan.add(new DirectedMessage("this is a plan that is in another plan", new ChannelAddress("w00t")))
        |
        |    aPlansPlan.add({ instruction: {
@@ -79,7 +79,7 @@ object JavaScriptEventHandlerTest {
 
   val noPlanBuildHandler = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {HandleEvent, Plan} from '@atomist/rug/operations/Handlers'
+       |import {HandleEvent, EventPlan} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
        |
@@ -88,7 +88,7 @@ object JavaScriptEventHandlerTest {
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |  handle(event: Match<TreeNode, TreeNode>){
        |    let issue = event.root
-       |    return new Plan();
+       |    return new EventPlan();
        |  }
        |}
        |export let handler = new SimpleHandler();
@@ -96,7 +96,7 @@ object JavaScriptEventHandlerTest {
 
   val nodesWithTagBuildHandler = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {HandleEvent, Plan} from '@atomist/rug/operations/Handlers'
+       |import {HandleEvent, EventPlan} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
        |
@@ -105,7 +105,7 @@ object JavaScriptEventHandlerTest {
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |  handle(event: Match<TreeNode, TreeNode>){
        |    let issue = event.root
-       |    return new Plan();
+       |    return new EventPlan();
        |  }
        |}
        |export let handler = new SimpleHandler();
@@ -113,7 +113,7 @@ object JavaScriptEventHandlerTest {
 
   val eventHandlerWithTreeNode = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {HandleEvent, Plan, LifecycleMessage} from '@atomist/rug/operations/Handlers'
+       |import {HandleEvent, EventPlan, LifecycleMessage} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
        |
@@ -122,7 +122,7 @@ object JavaScriptEventHandlerTest {
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |
        |  handle(event: Match<TreeNode, TreeNode>) {
-       |     return new Plan().add(new LifecycleMessage(event.root(), "123"));
+       |     return new EventPlan().add(new LifecycleMessage(event.root(), "123"));
        |  }
        |}
        |export let handler = new SimpleHandler();
@@ -130,7 +130,7 @@ object JavaScriptEventHandlerTest {
 
   val eventHandlerWithEmptyMatches = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {HandleEvent, Plan, LifecycleMessage} from '@atomist/rug/operations/Handlers'
+       |import {HandleEvent, EventPlan, LifecycleMessage} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, Tags} from '@atomist/rug/operations/Decorators'
        |
@@ -138,7 +138,7 @@ object JavaScriptEventHandlerTest {
        |@Tags("github", "build")
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |  handle(event: Match<TreeNode, TreeNode>){
-       |     return new Plan().add(new LifecycleMessage(event.root(), "123"));
+       |     return new EventPlan().add(new LifecycleMessage(event.root(), "123"));
        |  }
        |}
        |export let handler = new SimpleHandler();

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
@@ -17,7 +17,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
   val kittyDesc = "Prints out kitty urls"
   val simpleResponseHandler =  StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-      |import {Respond, Instruction, Response, Plan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
+      |import {Respond, Instruction, Response, CommandPlan, DirectedMessage, UserAddress} from '@atomist/rug/operations/Handlers'
       |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
       |import {EventHandler, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
       |import {Project} from '@atomist/rug/model/Core'
@@ -36,7 +36,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
       |    if(results != "woot") {
       |       throw new Error("This will not stand");
       |    }
-      |    return new Plan().add(new DirectedMessage("https://www.youtube.com/watch?v=fNodQpGVVyg", new UserAddress("bob")));
+      |    return new CommandPlan().add(new DirectedMessage("https://www.youtube.com/watch?v=fNodQpGVVyg", new UserAddress("bob")));
       |  }
       |}
       |
@@ -46,7 +46,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
 
   val simpleResponseHandlerWithJsonCoercion =  StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
     s"""
-       |import {Respond, Instruction, Response, Plan} from '@atomist/rug/operations/Handlers'
+       |import {Respond, Instruction, Response, CommandPlan} from '@atomist/rug/operations/Handlers'
        |import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
        |import {EventHandler, ParseJson, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
        |import {Project} from '@atomist/rug/model/Core'
@@ -54,7 +54,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
        |
        |@ResponseHandler("$kitties", "$kittyDesc")
        |class KittiesResponder implements HandleResponse<any>{
-       | handle(@ParseJson response: Response<any>) : Plan {
+       | handle(@ParseJson response: Response<any>) : CommandPlan {
        |    let results = response.body as any;
        |
        |    let stringed = "Thing " + response;
@@ -63,7 +63,7 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
        |
        |    if(results.yaml != "is more annoying than json") { throw new Error("Rats: " + results.yaml)}
        |    results.reasons.map(reason => reason.main.length)
-       |    return new Plan();
+       |    return new CommandPlan();
        |  }
        |}
        |

--- a/src/test/scala/com/atomist/rug/runtime/js/PlanBuilderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/PlanBuilderTest.scala
@@ -20,7 +20,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
   val simpleCommandWithObjectInstructionParamAsJson =
     StringFileArtifact(DefaultAtomistConfig.handlersRoot + "/Handler.ts",
       """
-        |import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+        |import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
         |import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
         |
         |@CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
@@ -28,9 +28,9 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
         |@Intent("show me kitties","cats please")
         |class KittieFetcher implements HandleCommand{
         |
-        |  handle(ctx: HandlerContext) : Plan {
+        |  handle(ctx: HandlerContext) : CommandPlan {
         |
-        |    let result = new Plan()
+        |    let result = new CommandPlan()
         |    result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {jsonparam: {mucho: "coolness"}}}});
         |    return result;
         |  }
@@ -43,7 +43,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
   val simpleCommandHandlerWithNullAndUndefinedParameterValues =
     StringFileArtifact(DefaultAtomistConfig.handlersRoot + "/Handler.ts",
       s"""
-        |import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, Plan} from '@atomist/rug/operations/Handlers'
+        |import {HandleCommand, HandleResponse, Instruction, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
         |import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
         |
         |@CommandHandler("show-me-the-kitties","Search Youtube for kitty videos and post results to slack")
@@ -51,8 +51,8 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
         |@Intent("show me kitties","cats please")
         |class KittieFetcher implements HandleCommand{
         |
-        |  handle(ctx: HandlerContext) : Plan {
-        |    let result = new Plan()
+        |  handle(ctx: HandlerContext) : CommandPlan {
+        |    let result = new CommandPlan()
         |    result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "blah"}},
         |                onSuccess: {name: "simple-response-handler", kind: "respond", parameters: {one: null, two: undefined}} });
         |    return result;
@@ -68,7 +68,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
         |  @Parameter({description: "blah", pattern: "@any", required: false})
         |  two: string
         |
-        |  handle(response: Response<string>) : Plan {
+        |  handle(response: Response<string>) : CommandPlan {
         |
         |    if(this.one != null) {
         |       throw new Error("One is not null: " + this.one)
@@ -77,7 +77,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
         |    if(this.two != undefined) {
         |       throw new Error("Two is not undefined: " + this.two)
         |    }
-        |    return new Plan();
+        |    return new CommandPlan();
         |  }
         |}
         |


### PR DESCRIPTION
**BREAKING at version uptake/compile time**

* EventPlan extends Plan (now abstract) and is returned from Event Handlers
* CommandPlan extends Plan and is returned from Command Handlers
* ResponseHandlers can now return EventPlan | CommandPlan (not ideal, but progress as it enforces a choice).
