### PR TITLE
Introduce Handled status for use when instruction errors are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   Response.Status of instructions whose failure is handled by a ResponseHandler
+    now have a status of `Handled` instead of `Failed`
 -   **BREAKING** Event and Command Handlers must return EventPlan and Command Plan
     respectively to remove confusion as to the different capabilities
 -   **BREAKING** Removed ability to add `command` instructions to the Plans 

--- a/src/main/scala/com/atomist/rug/runtime/plans/LocalPlanRunner.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/LocalPlanRunner.scala
@@ -85,8 +85,8 @@ class LocalPlanRunner(messageDeliverer: MessageDeliverer,
           }
         }
         //ensure handled errors don't return failure https://github.com/atomist/rug/issues/531
-        (response, callbackResults) match {
-          case (Response(Failure,_,_,_), Some(logs)) if !PlanResultInterpreter.hasLogFailure(logs) =>
+        (response, callbackResults, callbackOption) match {
+          case (Response(Failure,_,_,_), Some(logs), Some(callback)) if !PlanResultInterpreter.hasLogFailure(logs) && callback.isInstanceOf[Respond] =>
             val handled = Response(Status.Handled, response.msg, response.code, response.body)
             Seq(callbackResults, Some(Seq(InstructionResult(plannable.instruction, handled)))).flatten.flatten
           case _ =>

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanResultInterpreter.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanResultInterpreter.scala
@@ -21,7 +21,7 @@ object PlanResultInterpreter {
   }
 
   @tailrec
-  private def hasLogFailure(log: Seq[PlanLogEvent]): Boolean = {
+  def hasLogFailure(log: Seq[PlanLogEvent]): Boolean = {
     log.headOption match {
       case Some(head) =>
         head match {
@@ -35,5 +35,4 @@ object PlanResultInterpreter {
       case None => false
     }
   }
-
 }

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
@@ -27,7 +27,6 @@ object PlanUtils {
     val op = i match {
       case Generate(_) => "Generate"
       case Edit(_) => "Edit"
-      case Review(_) => "Review"
       case Execute(_) => "Execute"
       case Respond(_) => "Respond"
     }

--- a/src/main/scala/com/atomist/rug/spi/Handlers.scala
+++ b/src/main/scala/com/atomist/rug/spi/Handlers.scala
@@ -122,8 +122,6 @@ object Handlers {
 
     case class Edit(detail: Detail) extends RespondableInstruction
 
-    case class Review(detail: Detail) extends RespondableInstruction
-
     case class Execute(detail: Detail) extends RespondableInstruction
 
     case class Respond(detail: Detail) extends NonrespondableInstruction with Callback

--- a/src/main/scala/com/atomist/rug/spi/Handlers.scala
+++ b/src/main/scala/com/atomist/rug/spi/Handlers.scala
@@ -176,10 +176,13 @@ object Handlers {
 
     case object Failure extends Status
 
+    case object Handled extends Status
+
     def from(name: String): Status = {
       name match {
         case "success" => Success
         case "failure" => Failure
+        case "handled" => Handled
         case _ => throw new IllegalArgumentException(s"Cannot derive Status from '$name'.")
       }
     }

--- a/src/test/resources/com/atomist/rug/kind/java23/ClassAnnotated.ts
+++ b/src/test/resources/com/atomist/rug/kind/java23/ClassAnnotated.ts
@@ -18,7 +18,7 @@ class ClassAnnotated implements EditProject {
         eng.with<JavaSource>(project, '//JavaSource()', j => {
             eng.with<JavaType>(j, '//JavaType()', c => {
                 eng.with<JavaField>(c, '//JavaField()', f => {
-                    console.log(`f.type.name = [${f.type.name}]`)
+                    //console.log(`f.type.name = [${f.type.name}]`)
                     if (f.nodeName().indexOf("Field") > -1 && f.type.name.indexOf("Dog") > -1) {
                         f.addAnnotation("com.someone", "FooBar")
                     }

--- a/src/test/resources/com/atomist/rug/runtime/plans/HandlerThatHandlesAnError.ts
+++ b/src/test/resources/com/atomist/rug/runtime/plans/HandlerThatHandlesAnError.ts
@@ -1,0 +1,32 @@
+import {HandleCommand, Instruction, Response, HandleResponse, HandlerContext, CommandPlan, DirectedMessage, LifecycleMessage, ChannelAddress} from '@atomist/rug/operations/Handlers'
+import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+
+@CommandHandler("ShowMeTheKitties","Search Youtube for kitty videos and post results to slack")
+@Tags("kitty", "youtube", "slack")
+@Intent("show me kitties","cats please")
+class KittieFetcher implements HandleCommand {
+
+  handle(ctx: HandlerContext) : CommandPlan {
+    let result = new CommandPlan()
+    result.add({ instruction: {
+                                kind: "execute",
+                                name: "ExampleFunction",
+                                parameters: {fail: "true", thingy: "rats"}
+                              },
+                  onError: {kind: "respond", name: "HandleIt", parameters: this}})
+
+    return result;
+  }
+}
+
+export const command = new KittieFetcher()
+
+@ResponseHandler("HandleIt", "dummy error handler")
+class HandleIt implements HandleResponse<any> {
+
+    handle(response: Response<any>)  {
+        return new CommandPlan();
+    }
+}
+
+export const response = new HandleIt();

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2d.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PassingFeature1Steps2d.ts
@@ -12,7 +12,7 @@ Then("excitement ensues", world => {
     // Void return is the same as returning true.
     // This enables us to use assertion frameworks such as Chai
     let m = world.plan().messages[0]
-    console.log("message=" + m + " " + m.body + " cnames=" + m.channelNames)
+    //console.log("message=" + m + " " + m.body + " cnames=" + m.channelNames)
     if (m.channelNames.indexOf("test-channel") == -1)
         throw new Error(`Missing expected channel name for message: [${m.channelNames}]`)
 })

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,9 +16,8 @@
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <logger name="com.atomist.rug.runtime.plans.LocalPlanRunner" level="fatal" additivity="false">
-
-    </logger>
+    <logger name="com.atomist.rug.runtime.plans.LocalPlanRunner" level="fatal" additivity="false"/>
+    <logger name="com.atomist.rug.test.gherkin" level="fatal" additivity="false"/>
     <logger name="com.atomist" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,6 +16,9 @@
         <appender-ref ref="STDOUT" />
     </logger>
 
+    <logger name="com.atomist.rug.runtime.plans.LocalPlanRunner" level="fatal" additivity="false">
+
+    </logger>
     <logger name="com.atomist" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -13,6 +13,7 @@ import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.marshal.{EmptyContainerGraphNode, JsonBackedContainerGraphNode}
 import com.atomist.tree.pathexpression.PathExpression
 import com.atomist.tree.{TerminalTreeNode, TreeMaterializer}
+import com.typesafe.scalalogging.Logger
 import org.scalatest.{DiagrammedAssertions, FlatSpec, Matchers}
 
 import scala.concurrent.Await

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -13,7 +13,6 @@ import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
 import com.atomist.tree.marshal.{EmptyContainerGraphNode, JsonBackedContainerGraphNode}
 import com.atomist.tree.pathexpression.PathExpression
 import com.atomist.tree.{TerminalTreeNode, TreeMaterializer}
-import com.typesafe.scalalogging.Logger
 import org.scalatest.{DiagrammedAssertions, FlatSpec, Matchers}
 
 import scala.concurrent.Await

--- a/src/test/scala/com/atomist/rug/runtime/plans/ExampleRugFunction.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/ExampleRugFunction.scala
@@ -11,7 +11,11 @@ class ExampleRugFunction
   extends RugFunction
   with SecretSupport {
 
-  override def parameters = Seq(new Parameter("thingy"))
+  val failure = new Parameter("fail")
+  failure.setRequired(false)
+  failure.setDefaultValue("false")
+
+  override def parameters = Seq(new Parameter("thingy"), failure)
 
   override def secrets: Seq[Secret] = {
     if (ExampleRugFunction.clearSecrets) {
@@ -26,7 +30,11 @@ class ExampleRugFunction
     */
   override def run(parameters: ParameterValues): FunctionResponse = {
     validateParameters(parameters)
-    FunctionResponse(Status.Success,Some("It worked! :p"), Some(204), StringBodyOption(parameters.parameterValues.head.getValue.toString))
+    if(parameters.parameterValueMap.contains("fail") && parameters.parameterValueMap("fail").getValue == "true"){
+      FunctionResponse(Status.Failure,Some("Something went wrong :("), Some(500), StringBodyOption(parameters.parameterValueMap("fail").getValue.toString))
+    }else{
+      FunctionResponse(Status.Success,Some("It worked! :p"), Some(204), StringBodyOption(parameters.parameterValueMap("thingy").getValue.toString))
+    }
   }
 
   /**

--- a/src/test/scala/com/atomist/rug/runtime/plans/LocalPlanRunnerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/LocalPlanRunnerTest.scala
@@ -2,26 +2,24 @@ package com.atomist.rug.runtime.plans
 
 import com.atomist.param._
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
-import com.atomist.project.edit.{Applicability, ModificationAttempt, ProjectEditor}
+import com.atomist.project.edit.ProjectEditor
 import com.atomist.rug.SimpleRugResolver
 import com.atomist.rug.TestUtils.contentOf
 import com.atomist.rug.runtime.CommandHandler
-import com.atomist.rug.runtime.js.{JavaScriptCommandHandlerFinder, JavaScriptContext}
 import com.atomist.rug.spi.Handlers.Instruction._
 import com.atomist.rug.spi.Handlers.Status._
 import com.atomist.rug.spi.Handlers._
 import com.atomist.rug.spi.Secret
 import com.atomist.rug.ts.TypeScriptBuilder
-import com.atomist.source.{ArtifactSource, SimpleFileBasedArtifactSource, StringFileArtifact}
-import org.mockito.Matchers._
+import com.atomist.source.{SimpleFileBasedArtifactSource, StringFileArtifact}
+import org.mockito.Matchers.{eq => expected, _}
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest._
+import org.scalatest.mockito.MockitoSugar
 import org.slf4j.Logger
-import org.mockito.Matchers.{eq => expected}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -37,7 +35,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
 
   val planRunner = new LocalPlanRunner(messageDeliverer, instructionRunner, Some(nestedPlanRunner), Some(logger))
 
-  it ("should run empty plan") {
+  it("should run empty plan") {
     val plan = Plan(null, Nil, Nil, Nil)
 
     val actualPlanResult = Await.result(planRunner.run(plan, None), 10.seconds)
@@ -47,34 +45,34 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     verifyNoMoreInteractions(messageDeliverer, instructionRunner, nestedPlanRunner, logger)
   }
 
-  it ("should run a fully populated plan") {
+  it("should run a fully populated plan") {
     val plan = Plan(
-        Some(editor),
-        Nil,
-        Seq(LocallyRenderedMessage("message1", "text/plain", Nil, Nil)),
-        Seq(
-          Respondable(
-            Edit(Detail("edit1", None, Nil, None)),
-            None,
-            None
-          ),
-          Respondable(
-            Edit(Detail("edit2", None, Nil, None)),
-            Some(LocallyRenderedMessage("pass", "text/plain", Nil, Nil)),
-            Some(LocallyRenderedMessage("fail", "text/plain", Nil, Nil))
-          ),
-          Respondable(
-            Edit(Detail("edit3", None, Nil, None)),
-            Some(Respond(Detail("respond1", None, Nil, None))),
-            None
-          ),
-          Respondable(
-            Edit(Detail("edit4", None, Nil, None)),
-            Some(Plan(None, Nil, Seq(LocallyRenderedMessage("nested plan", "text/plain", Nil, Nil)), Nil)),
-            None
-          )
+      Some(editor),
+      Nil,
+      Seq(LocallyRenderedMessage("message1", "text/plain", Nil, Nil)),
+      Seq(
+        Respondable(
+          Edit(Detail("edit1", None, Nil, None)),
+          None,
+          None
+        ),
+        Respondable(
+          Edit(Detail("edit2", None, Nil, None)),
+          Some(LocallyRenderedMessage("pass", "text/plain", Nil, Nil)),
+          Some(LocallyRenderedMessage("fail", "text/plain", Nil, Nil))
+        ),
+        Respondable(
+          Edit(Detail("edit3", None, Nil, None)),
+          Some(Respond(Detail("respond1", None, Nil, None))),
+          None
+        ),
+        Respondable(
+          Edit(Detail("edit4", None, Nil, None)),
+          Some(Plan(None, Nil, Seq(LocallyRenderedMessage("nested plan", "text/plain", Nil, Nil)), Nil)),
+          None
         )
       )
+    )
     val instructionNameAsSuccessResponseBody = new Answer[Response]() {
       def answer(invocation: InvocationOnMock) = {
         val input = invocation.getArgumentAt(0, classOf[Instruction]).detail.name
@@ -92,10 +90,10 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
       InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Success, Some("edit2"), Some(0), None)),
       InstructionResult(Edit(Detail("edit3", None, Nil, None)), Response(Success, Some("edit3"), Some(0), None)),
       InstructionResult(Edit(Detail("edit4", None, Nil, None)), Response(Success, Some("edit4"), Some(0), None)),
-      InstructionResult(Respond(Detail("respond1", None, Nil, None)),Response(Success, Some("respond1"), Some(0), None)),
+      InstructionResult(Respond(Detail("respond1", None, Nil, None)), Response(Success, Some("respond1"), Some(0), None)),
       NestedPlanRun(Plan(None, Nil, Seq(LocallyRenderedMessage("nested plan", "text/plain", Nil, Nil)), Nil),
         Future(PlanResult(List(MessageDeliveryError(LocallyRenderedMessage("nested plan", "text/plain", Nil, Nil), null)))))
-      )
+    )
 
     assert(makeEventsComparable(actualPlanResult.log.toSet) == makeEventsComparable(expectedPlanLog))
 
@@ -127,7 +125,45 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     verifyNoMoreInteractions(messageDeliverer, instructionRunner, nestedPlanRunner, logger)
   }
 
-  it ("should run a plan with failing response") {
+  it("should run a plan with handled failing response") {
+    val plan = Plan(Some(editor), Nil, Nil,
+      Seq(
+        Respondable(
+          Edit(Detail("edit2", None, Nil, None)),
+          None,
+          Some(Respond(Detail("respond1", None, Nil, None)))
+        )
+      )
+    )
+    val failure = new Answer[Response]() {
+      def answer(invocation: InvocationOnMock) = {
+        Response(Failure, Some("edit2"), Some(0), None)
+      }
+    }
+
+    val success = new Answer[Response]() {
+      def answer(invocation: InvocationOnMock) = {
+        Response(Success, Some("respond1"), None, None)
+      }
+    }
+
+    when(instructionRunner.run(Edit(Detail("edit2", None, Nil, None)), None)).thenAnswer(failure)
+    when(instructionRunner.run(Respond(Detail("respond1", None, Nil, None)), Some(Response(Failure, Some("edit2"), Some(0), None)))).thenAnswer(success)
+
+    val actualPlanResult = Await.result(planRunner.run(plan, None), 120.seconds)
+    val expectedPlanLog = Set(
+      InstructionResult(Respond(Detail("respond1", None, List(), None)), Response(Success, Some("respond1"), None, None)),
+      InstructionResult(Edit(Detail("edit2", None, List(), None)), Response(Handled, Some("edit2"), Some(0), None))
+    )
+    assert(actualPlanResult.log.toSet == expectedPlanLog)
+
+    val inOrder = Mockito.inOrder(messageDeliverer, instructionRunner, nestedPlanRunner)
+    inOrder.verify(instructionRunner).run(Edit(Detail("edit2", None, Nil, None)), None)
+
+    verify(logger).debug("Ran Edit edit2() and then Failure:0:edit2")
+  }
+
+  it("should run a plan with failing response and dispatch messages") {
     val plan = Plan(Some(editor), Nil, Nil,
       Seq(
         Respondable(
@@ -147,7 +183,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
 
     val actualPlanResult = Await.result(planRunner.run(plan, None), 120.seconds)
     val expectedPlanLog = Set(
-      InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Handled, Some("edit2"), Some(0), None))
+      InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Failure, Some("edit2"), Some(0), None))
     )
     assert(actualPlanResult.log.toSet == expectedPlanLog)
 
@@ -172,7 +208,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     case CallbackError(c, e) => (c, e.getMessage)
   }
 
-  it ("should handle error during message delivery") {
+  it("should handle error during message delivery") {
     val plan = Plan(Some(editor), Nil,
       Seq(
         LocallyRenderedMessage(
@@ -197,7 +233,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     verifyNoMoreInteractions(instructionRunner, nestedPlanRunner, logger)
   }
 
-  it ("should handle error during respondable instruction execution") {
+  it("should handle error during respondable instruction execution") {
     val plan = Plan(None, Nil,
       Nil,
       Seq(
@@ -221,13 +257,13 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     verifyNoMoreInteractions(messageDeliverer, nestedPlanRunner, logger)
   }
 
-  it ("should handle failing respondable callback") {
+  it("should handle failing respondable callback") {
     val plan = Plan(None, Nil,
       Nil,
       Seq(
         Respondable(
           Edit(Detail("edit", None, Nil, None)),
-          Some(Plan(None,Nil,Seq(LocallyRenderedMessage("fail", "text/plain", Nil, Nil)), Nil)),
+          Some(Plan(None, Nil, Seq(LocallyRenderedMessage("fail", "text/plain", Nil, Nil)), Nil)),
           None
         )
       )
@@ -243,7 +279,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     assert(makeEventsComparable(actualPlanResult.log.toSet) === makeEventsComparable(expectedPlanLog))
 
     verify(logger).debug("Ran Edit edit() and then Success")
-    verify(logger).error(expected( "Failed to invoke Plan[channels: , usernames: , type: text/plain, body: fail] after Edit edit() - Uh oh!"), any(classOf[Throwable]))
+    verify(logger).error(expected("Failed to invoke Plan[channels: , usernames: , type: text/plain, body: fail] after Edit edit() - Uh oh!"), any(classOf[Throwable]))
 
     verifyNoMoreInteractions(messageDeliverer, logger)
   }
@@ -258,9 +294,9 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     val resolver = SimpleRugResolver(rugArchive)
 
     val handlers = resolver.resolvedDependencies.resolvedRugs
-    val handler = handlers.collect{case i: CommandHandler => i}.head
+    val handler = handlers.collect { case i: CommandHandler => i }.head
     val runner = new LocalPlanRunner(null, new LocalInstructionRunner(handlers.head, null, null, new TestSecretResolver(handler) {
-      override def resolveSecrets(secrets: Seq[Secret]): Seq[ParameterValue] =  {
+      override def resolveSecrets(secrets: Seq[Secret]): Seq[ParameterValue] = {
         assert(secrets.size === 1)
         assert(secrets.head.name === "very")
         assert(secrets.head.path === "/secret/thingy")
@@ -269,7 +305,7 @@ class LocalPlanRunnerTest extends FunSpec with Matchers with OneInstancePerTest 
     }, rugResolver = Some(resolver)))
 
     val result = Await.result(runner.run(handler.handle(null, SimpleParameterValues.Empty).get, None), 10.seconds)
-    val results = result.log.collect{case i: InstructionResult => i}
+    val results = result.log.collect { case i: InstructionResult => i }
     assert(results.head.instruction.detail.name === "HandleIt")
     assert(results.head.response.status === Status.Success)
     assert(results(1).instruction.detail.name === "ExampleFunction")


### PR DESCRIPTION
Currently handled errors returned by executed Plan.Instructions are logged and interpreted as failed plans. Now a `Handled` status is set on instructions responses if their failure is handled by a response handler. I'm a little concerned that I may have missed some cases, so I'd appreciate the once over from @claymccoy if possible.

Also, reduce logging/noise from some tests as per #498.