### PR TITLE
Make Command Handlers great again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Response.Status of instructions whose failure is handled by a ResponseHandler
     now have a status of `Handled` instead of `Failed`
 -   **BREAKING** Event and Command Handlers must return EventPlan and Command Plan
-    respectively to remove confusion as to the different capabilities
--   **BREAKING** Removed ability to add `command` instructions to the Plans 
+    respectively to remove confusion as to the different capabilities 
 -   Project test steps can now return `void`, as for handlers.
 
 ## [0.25.3] - 2017-04-13

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
@@ -27,6 +27,7 @@ object PlanUtils {
     val op = i match {
       case Generate(_) => "Generate"
       case Edit(_) => "Edit"
+      case Command(_) => "Command"
       case Execute(_) => "Execute"
       case Respond(_) => "Respond"
     }

--- a/src/main/scala/com/atomist/rug/spi/Handlers.scala
+++ b/src/main/scala/com/atomist/rug/spi/Handlers.scala
@@ -111,6 +111,7 @@ object Handlers {
         case "edit" => Edit(detail)
         case "execute" => Execute(detail)
         case "respond" => Respond(detail)
+        case "command" => Command(detail)
         case _ => throw new IllegalArgumentException(s"Cannot derive Instruction from '$name'.")
       }
     }
@@ -123,6 +124,8 @@ object Handlers {
     case class Edit(detail: Detail) extends RespondableInstruction
 
     case class Execute(detail: Detail) extends RespondableInstruction
+
+    case class Command(detail: Detail) extends NonrespondableInstruction
 
     case class Respond(detail: Detail) extends NonrespondableInstruction with Callback
 

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/AbstractHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/AbstractHandlerScenarioWorld.scala
@@ -7,7 +7,7 @@ import com.atomist.rug.kind.core.{ProjectMutableView, RepoResolver}
 import com.atomist.rug.runtime.CommandHandler
 import com.atomist.rug.runtime.js.interop.{NashornMapBackedGraphNode, jsPathExpressionEngine, jsScalaHidingProxy}
 import com.atomist.rug.runtime.js.{RugContext, SimpleContainerGraphNode}
-import com.atomist.rug.spi.Handlers.Instruction.{Edit, Generate}
+import com.atomist.rug.spi.Handlers.Instruction.{Command, Edit, Generate}
 import com.atomist.rug.spi.Handlers.Plan
 import com.atomist.rug.spi.TypeRegistry
 import com.atomist.rug.test.gherkin.{Definitions, GherkinExecutionListener, ScenarioWorld}
@@ -119,6 +119,9 @@ abstract class AbstractHandlerScenarioWorld(definitions: Definitions, rugs: Opti
         case Generate(detail) =>
           val knownGenerators: Seq[String] = rugs.map(_.generatorNames).getOrElse(Nil)
           !knownGenerators.contains(detail.name)
+        case Command(detail) =>
+          val knownCommandHandlers: Seq[String] = rugs.map(_.commandHandlerNames).getOrElse(Nil)
+          !knownCommandHandlers.contains(detail.name)
         // TODO there are probably more cases here
         case _ => false
       }

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Handlers.ts
@@ -7,7 +7,7 @@ export interface RugCoordinate {
   readonly artifact: string
 }
 
-type InstructionKind = "generate" | "edit" | "execute" | "respond"
+type InstructionKind = "generate" | "edit" | "execute" | "respond" | "command"
 
 export interface Instruction<T extends InstructionKind> {
   readonly name: string | RugCoordinate
@@ -21,7 +21,7 @@ export class EventRespondable<T extends Edit | Generate | Execute> {
   onError?: EventPlan | EventMessage | Respond
 }
 
-export class CommandRespondable<T extends Edit | Generate | Execute> {
+export class CommandRespondable<T extends Edit | Generate | Execute | Command> {
   instruction: T
   onSuccess?: CommandPlan | CommandMessage | Respond
   onError?: CommandPlan | CommandMessage | Respond
@@ -34,22 +34,16 @@ export class Presentable<T extends InstructionKind> {
 
 // Location to a project.
 // in the future, we could add things like github urls, orgs etc.
-interface ProjectReference {
-
-}
+interface ProjectReference {}
 
 export interface ProjectInstruction<T extends InstructionKind> extends Instruction<T> {
   project: string | ProjectReference
 }
 
-export interface Edit extends ProjectInstruction<"edit"> {
-
-}
+export interface Edit extends ProjectInstruction<"edit"> {}
 
 //extends ProjectInstruction because we need to know the project name
-export interface Generate extends ProjectInstruction<"generate"> {
-
-}
+export interface Generate extends ProjectInstruction<"generate"> {}
 
 //because in a message, we may not know project name yet
 export interface PresentableGenerate extends Instruction<"generate"> {
@@ -61,12 +55,11 @@ export interface PresentableEdit extends Instruction<"edit"> {
   project?: string | ProjectReference
 }
 
-export interface Execute extends Instruction<"execute"> {
-}
+export interface Execute extends Instruction<"execute"> {}
 
-export interface Respond extends Instruction<"respond"> {
+export interface Respond extends Instruction<"respond"> {}
 
-}
+export interface Command extends Instruction<"command"> {}
 
 export interface HandleCommand {
   handle(ctx: HandlerContext): CommandPlan


### PR DESCRIPTION
Now we have EventPlan and CommandPlans, it makes more sense to allow command handler invocation from Command Handlers.

As mentioned by @jessitron, it's quite normal to either want to reuse somebody else's command handler (over which there is not control and therefore little scope to extract the logic in to a separate module), or to not want to extract the logic in to a separate module, make an npm module etc.
