### PR TITLE
Match uses property access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.26.1...HEAD
 
+### Changed
+
+-   **BREAKING** TypeScript `Match` now uses property access, not function
+
 ## [0.26.1] - 2017-04-24
 
 [0.26.1]: https://github.com/atomist/rug/compare/0.26.0...0.26.1

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -3,9 +3,9 @@
  */
 interface Match<R extends GraphNode,N extends GraphNode> {
 
-    root(): R
+    root: R
 
-    matches(): N[]
+    matches: N[]
 }
 
 /**

--- a/src/main/typescript/node_modules/@atomist/rug/tree/TransformingPathExpressionEngine.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/TransformingPathExpressionEngine.ts
@@ -19,10 +19,8 @@ export class TransformingPathExpressionEngine implements PathExpressionEngine {
   evaluate<R extends TreeNode,N extends TreeNode>(root: R, expr: PathExpression<R,N> | string): Match<R,N> {
     let m1 = this.delegate.evaluate(root, expr)
     let m2 = {
-      root() { return this.nodeTransform(m1.root()) },
-      matches() {
-        return m1.matches().map(n => this.nodeTransform(n))
-      }
+      root: this.nodeTransform(m1.root) as R,
+      matches: m1.matches.map(n => this.nodeTransform(n)) as any
     }
     return m2
   }

--- a/src/test/resources/com/atomist/project/archive/MyHandlers.ts
+++ b/src/test/resources/com/atomist/project/archive/MyHandlers.ts
@@ -8,7 +8,7 @@ import {Project} from '@atomist/rug/model/Core'
 @Tags("github", "issues")
 class SimpleHandler implements HandleEvent<Issue,Issue>{
   handle(match: Match<Issue,Issue>): EventPlan {
-    let issue = match.root()
+    let issue = match.root
     let reopen = issue.reopen
     reopen.onSuccess = new DirectedMessage("blah", new ChannelAddress("#blah"))
     return new EventPlan().add(reopen)
@@ -63,7 +63,7 @@ class IssueLister implements HandleCommand{
 
   handle(ctx: HandlerContext) {
     var match: Match<Issue,Issue>; // ctx.pathExpressionEngine().evaluate<Issue,Issue>("/Repo()/Issue[@raisedBy='kipz']")
-    let issues = match.matches();
+    let issues = match.matches;
     if (issues.length > 0) {
               let attachments = `{"attachments": [` + issues.map(i => {
                  let text = JSON.stringify(`#${i.number}: ${i.title}`)

--- a/src/test/resources/com/atomist/rug/runtime/js/EditorInjectedWithPathExpression.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/EditorInjectedWithPathExpression.ts
@@ -1,0 +1,31 @@
+import {Project, File} from '@atomist/rug/model/Core'
+import {Match, PathExpression, PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Editor, Parameter, Tags} from '@atomist/rug/operations/Decorators'
+
+@Tags("java", "maven")
+@Editor("Constructed", "A nice little editor")
+class ConstructedEditor {
+
+    @Parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
+    packageName: string
+
+    edit(project: Project) {
+
+      let eng: PathExpressionEngine = project.context.pathExpressionEngine;
+      let pe = new PathExpression<Project,File>(`/File()[@name='pom.xml']`)
+      let m: Match<Project,File> = eng.evaluate(project, pe)
+
+      var t: string = `param=${this.packageName},filecount=${m.root.fileCount}`
+      for (let n of m.matches) {
+        t += `Matched file=${n.path}`;
+        n.append("randomness")
+      }
+
+        let s: string = ""
+
+        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
+        for (let f of project.files)
+            s = s + `File [${f.path}] containing [${f.content}]\n`
+    }
+  }
+  export let myeditor = new ConstructedEditor()

--- a/src/test/resources/com/atomist/rug/runtime/js/EditorInjectedWithPathExpressionUsingWith.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/EditorInjectedWithPathExpressionUsingWith.ts
@@ -1,0 +1,36 @@
+import {Project} from '@atomist/rug/model/Core'
+import {PathExpression} from '@atomist/rug/tree/PathExpression'
+import {PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+import {Match} from '@atomist/rug/tree/PathExpression'
+import {File} from '@atomist/rug/model/Core'
+import {Editor, Parameter, Tags} from '@atomist/rug/operations/Decorators'
+
+
+@Tags("java", "maven")
+@Editor("Constructed", "A nice little editor")
+class ConstructedEditor {
+
+    @Parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
+    packageName: string
+
+    edit(project: Project) {
+      let eng: PathExpressionEngine = project.context.pathExpressionEngine;
+      project.files.filter(t => false)
+      var t: string = `param=${this.packageName},filecount=${project.fileCount}`
+
+      eng.with<File>(project, "/*[@name='pom.xml']", n => {
+        t += `Matched file=${n.path}`;
+        n.append("randomness")
+      })
+
+        var s: string = ""
+
+        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
+        for (let f of project.files)
+            s = s + `File [${f.path}] containing [${f.content}]\n`
+
+        //`${t}\n\nEdited Project containing ${project.fileCount} files: \n${s}`)
+    }
+  }
+
+  export let myeditor = new ConstructedEditor()

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/517_Pulled.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/517_Pulled.ts
@@ -24,7 +24,7 @@ import { ChatChannel } from "@atomist/rug/cortex/ChatChannel"
 class Pulled implements HandleEvent<K8Pod, K8Pod> {
 
     handle(event: Match<K8Pod, K8Pod>): EventPlan {
-        const pod: K8Pod = event.root() as K8Pod
+        const pod: K8Pod = event.root as K8Pod
         const image: DockerImage = pod.images[0]
         const commit: Commit = image.tag.commit
         const repo: Repo = commit.repo

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlers.ts
@@ -34,7 +34,7 @@ export const handler2 = new ReturnsEmptyPlanEventHandler2();
 class ReturnsEmptyPlanEventHandler2a implements HandleEvent<GraphNode, GraphNode> {
 
     handle(m: Match<node.Commit, node.Person>) {
-        let peep = m.matches()[0];
+        let peep = m.matches[0];
         // console.log(`Match ${m}: peep=${peep}`);
         return new EventPlan();
     }
@@ -49,7 +49,7 @@ export const handler2a = new ReturnsEmptyPlanEventHandler2a();
 class ReturnsEmptyPlanEventHandler3 implements HandleEvent<node.Commit, node.GitHubId> {
 
     handle(m: Match<node.Commit, node.GitHubId>) {
-        let ghid: node.GitHubId = m.matches()[0]
+        let ghid: node.GitHubId = m.matches[0]
         if (ghid.id != "gogirl") throw new Error(`Unexpected github id ${ghid.id}`)
         //if (ghid.address != "/madeBy/gitHubId") throw new Error(`Unexpected address [${ghid.address}]`)
 

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/EventHandlersAgainstGenerated.ts
@@ -16,7 +16,7 @@ import {Push} from "@atomist/rug/cortex/Push"
 class ReturnsEmptyPlanEventHandlerGen1 implements HandleEvent<GraphNode, Build> {
 
     handle(m: Match<GraphNode, Build>) {
-        let b: Build = m.matches()[0]
+        let b: Build = m.matches[0]
         b.status + ""   // Evaluate this stringification doesn't break
         return new EventPlan();
     }
@@ -30,7 +30,7 @@ export const handler1 = new ReturnsEmptyPlanEventHandlerGen1();
 class ReturnsEmptyPlanEventHandlerGenWithArrays implements HandleEvent<GraphNode, Push> {
 
     handle(m: Match<GraphNode, Push>) {
-        let p: Push = m.matches()[0]
+        let p: Push = m.matches[0]
 
         if (p.commits.length != 1) throw new Error("No commits")
 

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PushProject.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/PushProject.ts
@@ -13,9 +13,9 @@ import { Push } from "@atomist/rug/cortex/Push";
 @Tags("github", "push")
 class NewPushAS implements HandleEvent<Push, Project> {
     public handle(event: Match<Push, Project>): EventPlan {
-        //console.log(`Handler matched ${event.root()}`);
+        //console.log(`Handler matched ${event.root}`);
 
-        const project: Project = event.matches()[0];
+        const project: Project = event.matches[0];
         const messageBody = `Found project with name ${project.name} with ${project.fileCount} files`;
         const channel = new ChannelAddress("#flood");
         const message = new DirectedMessage(messageBody, channel, "text/plain");

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -144,7 +144,7 @@ object JavaScriptEventHandlerTest {
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |
        |  handle(event: Match<TreeNode, TreeNode>) {
-       |     return new EventPlan().add(new LifecycleMessage(event.root(), "123"));
+       |     return new EventPlan().add(new LifecycleMessage(event.root, "123"));
        |  }
        |}
        |export let handler = new SimpleHandler();
@@ -160,7 +160,7 @@ object JavaScriptEventHandlerTest {
        |@Tags("github", "build")
        |class SimpleHandler implements HandleEvent<TreeNode,TreeNode> {
        |  handle(event: Match<TreeNode, TreeNode>){
-       |     return new EventPlan().add(new LifecycleMessage(event.root(), "123"));
+       |     return new EventPlan().add(new LifecycleMessage(event.root, "123"));
        |  }
        |}
        |export let handler = new SimpleHandler();


### PR DESCRIPTION
The TypeScript `Match` type used functions rather than property access. This was inconsistent with other usage and could produce extremely confusing error messages if property access syntax was used.