### PR TITLE
Added repo cloning support to handler testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/0.26.1...HEAD
 
+### Added
+
+-   Support for cloning a repo from GitHub in Gherkin tests, via `ScenarioWorld`
+
 ### Changed
 
 -   **BREAKING** TypeScript `Match` now uses property access, not function

--- a/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
@@ -17,7 +17,8 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
                                                               val definition: FeatureDefinition,
                                                               val definitions: Definitions,
                                                               val rugs: Option[Rugs],
-                                                              listeners: Seq[GherkinExecutionListener] = Nil)
+                                                              listeners: Seq[GherkinExecutionListener],
+                                                              config: GherkinRunnerConfig)
   extends LazyLogging {
 
   def execute(): FeatureResult = {

--- a/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/DefaultExecutableFeatureFactory.scala
@@ -17,18 +17,14 @@ object DefaultExecutableFeatureFactory extends ExecutableFeatureFactory {
 
   private val atomistConfig = DefaultAtomistConfig
 
-  override def executableFeatureFor(f: FeatureDefinition,
-                                    definitions: Definitions,
-                                    rugAs: ArtifactSource,
-                                    rugs: Option[Rugs],
-                                    listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_] = {
+  override def executableFeatureFor(f: FeatureDefinition, definitions: Definitions, rugAs: ArtifactSource, rugs: Option[Rugs], listeners: Seq[GherkinExecutionListener], config: GherkinRunnerConfig): AbstractExecutableFeature[_] = {
     // TODO clean up name of test directory
     if (f.definition.path.contains(s"${atomistConfig.testsDirectory}/project"))
-      new ProjectManipulationFeature(f, definitions, rugAs, rugs, listeners)
+      new ProjectManipulationFeature(f, definitions, rugAs, rugs, listeners, config)
     else if (f.definition.path.contains(s"${atomistConfig.testsDirectory}/${atomistConfig.handlersDirectory}/command"))
-      new CommandHandlerFeature(f, definitions, rugAs, rugs, listeners)
+      new CommandHandlerFeature(f, definitions, rugAs, rugs, listeners, config)
     else if (f.definition.path.contains(s"${atomistConfig.testsDirectory}/${atomistConfig.handlersDirectory}/event"))
-      new EventHandlerFeature(f, definitions, rugAs, rugs, listeners)
+      new EventHandlerFeature(f, definitions, rugAs, rugs, listeners, config)
     else {
       throw new IllegalArgumentException(s"Cannot handle path [${f.definition.path}]: Paths must be of form [${atomistConfig.testsDirectory}/project] or [${atomistConfig.testsDirectory}/handlers]")
     }

--- a/src/main/scala/com/atomist/rug/test/gherkin/ExecutableFeatureFactory.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/ExecutableFeatureFactory.scala
@@ -8,9 +8,5 @@ import com.atomist.source.ArtifactSource
   */
 trait ExecutableFeatureFactory {
 
-  def executableFeatureFor(f: FeatureDefinition,
-                           definitions: Definitions,
-                           rugAs: ArtifactSource,
-                           rugs: Option[Rugs],
-                           listeners: Seq[GherkinExecutionListener]): AbstractExecutableFeature[_]
+  def executableFeatureFor(f: FeatureDefinition, definitions: Definitions, rugAs: ArtifactSource, rugs: Option[Rugs], listeners: Seq[GherkinExecutionListener], config: GherkinRunnerConfig): AbstractExecutableFeature[_]
 }

--- a/src/main/scala/com/atomist/rug/test/gherkin/GherkinRunner.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/GherkinRunner.scala
@@ -1,21 +1,29 @@
 package com.atomist.rug.test.gherkin
 
-import com.atomist.graph.GraphNode
 import com.atomist.project.archive.Rugs
 import com.atomist.rug.runtime.js.JavaScriptContext
-import com.atomist.rug.test.gherkin.project.ProjectManipulationFeature
 import com.typesafe.scalalogging.LazyLogging
-import gherkin.ast.{ScenarioDefinition, Step}
+
+/**
+  * Config to use when running tests. Tokens etc.
+  *
+  * @param oAuthToken token to use for Git cloning
+  */
+case class GherkinRunnerConfig(oAuthToken: Option[String] = None)
 
 /**
   * Combine Gherkin DSL BDD definitions with JavaScript backing code
   * and provide the ability to execute the tests
   *
   * @param jsc       JavaScript backed by a Rug archive
-  * @param rugs      other Rugs from the achive
+  * @param rugs      other Rugs from the archive
   * @param listeners optional execution listeners
+  * @param config    config to use for test running
   */
-class GherkinRunner(jsc: JavaScriptContext, rugs: Option[Rugs] = None, listeners: Seq[GherkinExecutionListener] = Nil)
+class GherkinRunner(jsc: JavaScriptContext,
+                    rugs: Option[Rugs] = None,
+                    listeners: Seq[GherkinExecutionListener] = Nil,
+                    config: GherkinRunnerConfig = GherkinRunnerConfig())
   extends LazyLogging {
 
   import GherkinRunner._
@@ -38,16 +46,16 @@ class GherkinRunner(jsc: JavaScriptContext, rugs: Option[Rugs] = None, listeners
   val features: Seq[FeatureDefinition] = GherkinReader.findFeatures(jsc.rugAs)
 
   private val executableFeatures = features.map(f =>
-    featureFactory.executableFeatureFor(f, definitions, jsc.rugAs, rugs, listeners))
+    featureFactory.executableFeatureFor(f, definitions, jsc.rugAs, rugs, listeners, config))
 
   /**
     * Execute all the tests in this archive that pass provided filter
     *
     * @param filter callback to filter features that should execute
     */
-  def execute(filter: (FeatureDefinition) => Boolean = (fd) => true): ArchiveTestResult = {
+  def execute(filter: (FeatureDefinition) => Boolean = _ => true): ArchiveTestResult = {
     logger.info(s"Execute on $this")
-    ArchiveTestResult(executableFeatures.filter(pmf => filter.apply(pmf.definition)).map(ef => jsc.withEnhancedExceptions {
+    ArchiveTestResult(executableFeatures.filter(pmf => filter(pmf.definition)).map(ef => jsc.withEnhancedExceptions {
       listeners.foreach(_.featureStarting(ef.definition))
       val result = ef.execute()
       listeners.foreach(_.featureCompleted(ef.definition, result))

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerFeature.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.test.gherkin.handler.command
 
 import com.atomist.project.archive.Rugs
-import com.atomist.rug.test.gherkin.{AbstractExecutableFeature, Definitions, FeatureDefinition, GherkinExecutionListener}
+import com.atomist.rug.test.gherkin._
 import com.atomist.source.ArtifactSource
 
 class CommandHandlerFeature(
@@ -9,10 +9,11 @@ class CommandHandlerFeature(
                       definitions: Definitions,
                       rugArchive: ArtifactSource,
                       rugs: Option[Rugs],
-                      listeners: Seq[GherkinExecutionListener])
-  extends AbstractExecutableFeature[CommandHandlerScenarioWorld](definition, definitions, rugs, listeners) {
+                      listeners: Seq[GherkinExecutionListener],
+                      config: GherkinRunnerConfig)
+  extends AbstractExecutableFeature[CommandHandlerScenarioWorld](definition, definitions, rugs, listeners, config) {
 
   override protected def createWorldForScenario(): CommandHandlerScenarioWorld = {
-    new CommandHandlerScenarioWorld(definitions, rugs, listeners)
+    new CommandHandlerScenarioWorld(definitions, rugs, listeners, config)
   }
 }

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/command/CommandHandlerScenarioWorld.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.test.gherkin.handler.command
 
 import com.atomist.project.archive.Rugs
 import com.atomist.rug.runtime.CommandHandler
-import com.atomist.rug.test.gherkin.{Definitions, GherkinExecutionListener}
+import com.atomist.rug.test.gherkin.{Definitions, GherkinExecutionListener, GherkinRunnerConfig}
 import com.atomist.rug.test.gherkin.handler.AbstractHandlerScenarioWorld
 import com.atomist.tree.IdentityTreeMaterializer
 
@@ -10,8 +10,8 @@ import com.atomist.tree.IdentityTreeMaterializer
   * Scenario world for use to test command handlers.
   * Allows us to invoke a registered command handler explicitly
   */
-class CommandHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = None, listeners: Seq[GherkinExecutionListener])
-  extends AbstractHandlerScenarioWorld(definitions, rugs, listeners) {
+class CommandHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = None, listeners: Seq[GherkinExecutionListener], config: GherkinRunnerConfig)
+  extends AbstractHandlerScenarioWorld(definitions, rugs, listeners, config) {
 
   def invokeHandler(handler: CommandHandler, params: Any): Unit = {
     val maybePlan = handler.handle(createRugContext(IdentityTreeMaterializer), parameters(params))

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerFeature.scala
@@ -1,7 +1,7 @@
 package com.atomist.rug.test.gherkin.handler.event
 
 import com.atomist.project.archive.Rugs
-import com.atomist.rug.test.gherkin.{AbstractExecutableFeature, Definitions, FeatureDefinition, GherkinExecutionListener}
+import com.atomist.rug.test.gherkin._
 import com.atomist.source.ArtifactSource
 
 class EventHandlerFeature(
@@ -9,10 +9,11 @@ class EventHandlerFeature(
                       definitions: Definitions,
                       rugArchive: ArtifactSource,
                       rugs: Option[Rugs],
-                      listeners: Seq[GherkinExecutionListener])
-  extends AbstractExecutableFeature[EventHandlerScenarioWorld](definition, definitions, rugs, listeners) {
+                      listeners: Seq[GherkinExecutionListener],
+                      config: GherkinRunnerConfig)
+  extends AbstractExecutableFeature[EventHandlerScenarioWorld](definition, definitions, rugs, listeners, config) {
 
   override protected def createWorldForScenario(): EventHandlerScenarioWorld = {
-    new EventHandlerScenarioWorld(definitions, rugs, listeners)
+    new EventHandlerScenarioWorld(definitions, rugs, listeners, config)
   }
 }

--- a/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/handler/event/EventHandlerScenarioWorld.scala
@@ -6,7 +6,7 @@ import com.atomist.rug.RugNotFoundException
 import com.atomist.rug.runtime.js.{JavaScriptEventHandler, RugContext}
 import com.atomist.rug.runtime.js.interop.NashornMapBackedGraphNode
 import com.atomist.rug.runtime.{EventHandler, SystemEvent}
-import com.atomist.rug.test.gherkin.{Definitions, GherkinExecutionListener, PathExpressionEvaluation}
+import com.atomist.rug.test.gherkin.{Definitions, GherkinExecutionListener, GherkinRunnerConfig, PathExpressionEvaluation}
 import com.atomist.rug.test.gherkin.handler.AbstractHandlerScenarioWorld
 import com.atomist.tree.TreeMaterializer
 import com.atomist.tree.pathexpression.PathExpression
@@ -17,8 +17,8 @@ import scala.collection.mutable.ListBuffer
   * World implementation for testing event handlers. Allows us to pump in events
   * and test the reaction
   */
-class EventHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = None, listeners: Seq[GherkinExecutionListener] = Nil)
-  extends AbstractHandlerScenarioWorld(definitions, rugs, listeners) {
+class EventHandlerScenarioWorld(definitions: Definitions, rugs: Option[Rugs] = None, listeners: Seq[GherkinExecutionListener], config: GherkinRunnerConfig)
+  extends AbstractHandlerScenarioWorld(definitions, rugs, listeners, config) {
 
   private val registeredHandlers = ListBuffer.empty[EventHandler]
 

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectManipulationFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectManipulationFeature.scala
@@ -13,10 +13,11 @@ class ProjectManipulationFeature(
                                   definitions: Definitions,
                                   rugArchive: ArtifactSource,
                                   rugs: Option[Rugs],
-                                  listeners: Seq[GherkinExecutionListener] = Nil)
-  extends AbstractExecutableFeature[ProjectScenarioWorld](definition, definitions, rugs, listeners) {
+                                  listeners: Seq[GherkinExecutionListener],
+                                  config: GherkinRunnerConfig)
+  extends AbstractExecutableFeature[ProjectScenarioWorld](definition, definitions, rugs, listeners, config) {
 
-  override protected def createWorldForScenario: ScenarioWorld = {
-    new ProjectScenarioWorld(definitions, rugs)
+  override protected def createWorldForScenario(): ScenarioWorld = {
+    new ProjectScenarioWorld(definitions, rugs, config)
   }
 }

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
@@ -17,12 +17,13 @@ import com.atomist.source.EmptyArtifactSource
   */
 class ProjectScenarioWorld(
                             definitions: Definitions,
-                            rugs: Option[Rugs] = None)
-  extends ScenarioWorld(definitions, rugs) {
+                            rugs: Option[Rugs],
+                            config: GherkinRunnerConfig)
+  extends ScenarioWorld(definitions, rugs, config) {
 
   private var editorResults: Seq[Either[Throwable, ModificationAttempt]] = Nil
 
-  val project = new ProjectMutableView(rugAs = definitions.jsc.rugAs, originalBackingObject = EmptyArtifactSource("project-scenario-world"))
+  private var project = new ProjectMutableView(rugAs = definitions.jsc.rugAs, originalBackingObject = EmptyArtifactSource("project-scenario-world"))
 
   override def target: AnyRef = project
 
@@ -39,6 +40,10 @@ class ProjectScenarioWorld(
         }
       case _ => throw new RugNotFoundException("No context provided")
     }
+  }
+
+  def setProject(p: ProjectMutableView): Unit = {
+    project = p
   }
 
   /**

--- a/src/main/typescript/node_modules/@atomist/rug/test/ScenarioWorld.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/ScenarioWorld.ts
@@ -1,4 +1,6 @@
 
+import { Project } from "../model/Project";
+
 /**
  * Superinterface for all worlds: Isolated contexts
  * available during scenario execution
@@ -8,32 +10,89 @@ export interface ScenarioWorld {
     /**
      * Get the value of the given key in the scenario, or null
      */
-    get(key: string): any
+    get(key: string): any;
 
     /**
      * Bind the value to the given key in the scenario
      */
-    put(key: string, what: any): void
+    put(key: string, what: any): void;
 
     /**
      * Clear the value of the given key in the scenario
      */
-    clear(key: string): void
+    clear(key: string): void;
 
     /**
      * Abort execution of the current scenario. This will cause failure.
      */
-    abort(): void
+    abort(): void;
 
     /**
      * Was execution of the current scenario aborted?
      */
-    aborted(): boolean
+    aborted(): boolean;
 
     /**
      * Did the last operation fail due to invalid parameters?
      * Otherwise null
      */
-    invalidParameters(): any
+    invalidParameters(): any;
 
+    /**
+     * Clone the given repo and provide a reference to the project
+     */
+    cloneRepo(cloneInfo: CloneInfo): Project;
+
+}
+
+/**
+ * Identifies a repo
+ */
+export interface RepoId {
+
+    branch: string;
+
+    sha: string;
+
+    owner: string;
+
+    name: string;
+
+}
+
+
+/**
+ * Information necessary to clone a repo
+ */
+export class CloneInfo implements RepoId {
+
+    public branch = "master";
+
+    public sha: string;
+
+    public depth: number = 10;
+
+    public remote: string;
+
+    constructor(public owner: string, public name: string) {}
+
+    public withBranch(branch: string): CloneInfo {
+        this.branch = branch;
+        return this;
+    }
+
+    public withSha(sha: string): CloneInfo {
+        this.sha = sha;
+        return this;
+    }
+
+    public withDepth(depth: number): CloneInfo {
+        this.depth = depth;
+        return this;
+    }
+
+    public withRemote(remote: string): CloneInfo {
+        this.remote = remote;
+        return this;
+    }
 }

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -1,4 +1,4 @@
-import { ScenarioWorld } from "../ScenarioWorld"
+import { ScenarioWorld, RepoId } from "../ScenarioWorld"
 import { Result } from "../Result"
 import { CommandPlan, EventPlan, Plan } from "../../operations/Handlers"
 import { GraphNode } from "../../tree/PathExpression"
@@ -25,6 +25,8 @@ export interface HandlerScenarioWorld<T extends Plan> extends ScenarioWorld {
      * Define the given repo
      */
     defineRepo(owner: string, name: string, branchOrSha: string, p: Project);
+
+    defineRepo(repoId: RepoId, p: Project);
 
     /**
      * Return a single plan. Throws an exception if no plan was recorded

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
@@ -1,8 +1,8 @@
-import { Project } from "../../model/Core"
-import { ProjectEditor } from "../../operations/ProjectEditor"
-import { ProjectGenerator } from "../../operations/ProjectGenerator"
-import { ScenarioWorld } from "../ScenarioWorld"
-import { Result } from "../Result"
+import { Project } from "../../model/Core";
+import { ProjectEditor } from "../../operations/ProjectEditor";
+import { ProjectGenerator } from "../../operations/ProjectGenerator";
+import { ScenarioWorld } from "../ScenarioWorld";
+import { Result } from "../Result";
 
 /**
  * Subinterface of ScenarioWorld specific to
@@ -11,24 +11,29 @@ import { Result } from "../Result"
 export interface ProjectScenarioWorld extends ScenarioWorld {
 
     /**
+     * Set the project fixture
+     */
+    setProject(p: Project): void;
+
+    /**
      * Return a project editor from the local context identified by name
      */
-    editor(name: string): ProjectEditor
+    editor(name: string): ProjectEditor;
 
     /**
      * Return a project generator from the local context identified by name
      */
-    generator(name: string): ProjectGenerator
+    generator(name: string): ProjectGenerator;
 
     /**
      * Edit the project with the given editor, validating parameters
      */
-    editWith(ed: ProjectEditor, params: {})
+    editWith(ed: ProjectEditor, params: {});
 
     /**
      * Create a project using the given generator named projectName, validating parameters
      */
-    generateWith(gen: ProjectGenerator, projectName: string, params: {})
+    generateWith(gen: ProjectGenerator, projectName: string, params: {});
 
     /**
      * How many modifications did editors in this scenario make?  Note
@@ -36,17 +41,17 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
      * generator 'populate' method does not contribute to the number
      * of modifications returned by this method.
      */
-    modificationsMade(): number
+    modificationsMade(): number;
 
     /**
      * Did editing fail?
      */
-    failed(): boolean
+    failed(): boolean;
 
     /**
      * How many editors were run in the execution of this scenario?
      */
-    editorsRun(): number
+    editorsRun(): number;
 }
 
 // Callback for given and when steps
@@ -57,11 +62,11 @@ type ThenCallback = (Project, ProjectScenarioWorld?, ...args) => Result | boolea
 
 interface Definitions {
 
-    Given(s: string, f: SetupCallback): void
+    Given(s: string, f: SetupCallback): void;
 
-    When(s: string, f: SetupCallback): void
+    When(s: string, f: SetupCallback): void;
 
-    Then(s: string, f: ThenCallback): void
+    Then(s: string, f: ThenCallback): void;
 
 }
 
@@ -69,15 +74,15 @@ interface Definitions {
 declare var com_atomist_rug_test_gherkin_GherkinRunner$_definitions: Definitions
 
 export function Given(s: string, f: SetupCallback) {
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f)
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Given(s, f);
 }
 
 export function When(s: string, f: SetupCallback) {
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f)
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.When(s, f);
 }
 
 export function Then(s: string, f: ThenCallback) {
-    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f)
+    com_atomist_rug_test_gherkin_GherkinRunner$_definitions.Then(s, f);
 }
 
 /**
@@ -99,4 +104,4 @@ export function rugAssertEqual(a, b) {
 
 // Import well-known step definitions. It's nicer
 // to have them in a separate file.
-import "./WellKnownSteps.js"
+import "./WellKnownSteps.js";

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
@@ -1,4 +1,5 @@
-import {Given, When, Then} from "./Core"
+import { Given, When, Then } from "./Core"
+import { CloneInfo } from "../ScenarioWorld"
 
 // Register well-known steps
 
@@ -7,6 +8,21 @@ import {Given, When, Then} from "./Core"
  */
 Given("an empty project", p => {
     /* Nothing to do */
+});
+
+/**
+ * Cloned content from GitHub
+ */
+Given("github ([^/]+)/([^/]+)", (p, world, owner: string, name: string) => {
+    const repo = new CloneInfo(owner, name);
+    const project = world.cloneRepo(repo);
+    world.setProject(project);
+});
+
+Given("github ([^/]+)/([^/]+)/([^/]+)", (p, world, owner: string, name: string, branch) => {
+    const repo = new CloneInfo(owner, name).withBranch(branch);
+    const project = world.cloneRepo(repo);
+    world.setProject(project);
 });
 
 /**

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/command/LooksInRealProjectsSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/command/LooksInRealProjectsSteps.ts
@@ -1,0 +1,31 @@
+
+import { CloneInfo } from "@atomist/rug/test/ScenarioWorld"
+
+import { Given, When, Then, HandlerScenarioWorld } from "@atomist/rug/test/handler/Core"
+import { rugAssertEqual as assertEqual } from "@atomist/rug/test/handler/Core"
+
+import * as cortex from "@atomist/rug/cortex/stub/Types"
+
+Given("a sleepy country", f => {
+})
+When("a visionary leader enters", world => {
+   const handler = world.commandHandler("LooksInProjects")
+   const owner = "atomist";
+   const repoName1 = "rugs";
+   const p = world.emptyProject("p1");
+   p.addFile("pom.xml", "<xml></xml>")
+   let repo = new cortex.Repo().withOwner(owner).withName(repoName1);
+   world.defineRepo(owner, repoName1, "master", p);
+   world.addToRootContext(repo);
+
+   const repoName2 = "rug";
+   const repoId = new CloneInfo(owner, repoName2);
+   const p2 = world.cloneRepo(repoId);
+   let repo2 = new cortex.Repo().withOwner(owner).withName(repoName2);
+   world.defineRepo(repoId, p2);
+   world.addToRootContext(repo2);
+   world.invokeHandler(handler, {});
+})
+Then("excitement ensues", world => {
+    assertEqual(world.plan().messages.length, 2);
+})

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/RealEditSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/RealEditSteps.ts
@@ -1,0 +1,7 @@
+
+// We need this to ensure that well-known steps are imported
+import { Given, When, Then, ProjectScenarioWorld } from "@atomist/rug/test/project/Core";
+
+Given("a visionary leader", p => {
+    //
+});

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/real_edit.feature
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/real_edit.feature
@@ -1,0 +1,7 @@
+Feature: Real edit
+  Test editing a real project
+
+  Scenario: Edit a real project
+    Given github atomist/rug
+    Then file at src/main/scala/com/atomist/graph/GraphNode.scala should exist
+

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/real_edit_with_branch.feature
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/real_edit_with_branch.feature
@@ -1,0 +1,7 @@
+Feature: Real edit
+  Test editing a real project
+
+  Scenario: Edit a real project
+    Given github atomist/rug/master
+    Then file at src/main/scala/com/atomist/graph/GraphNode.scala should exist
+

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
@@ -118,8 +118,13 @@ class GherkinRunnerCommandHandlerTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "verify path expression drilling into projects" in {
-    val stepsFile = "LooksInProjectsSteps.ts"
+  it should "verify path expression drilling into projects" in
+    drillIntoProject("LooksInProjectsSteps.ts")
+
+  it should "verify path expression drilling into projects with cloning" in
+    drillIntoProject("LooksInRealProjectsSteps.ts")
+
+    private def drillIntoProject(stepsFile: String) {
     val passingFeature1Steps =
       TestUtils.requiredFileInPackage(this, stepsFile)
     val passingFeature1StepsFile = passingFeature1Steps.withPath(

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
@@ -209,6 +209,29 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
     assert(run.result.isInstanceOf[Failed])
   }
 
+  it should "access a real project" in
+    edit("real_edit.feature")
+
+  it should "access a branch of a real project" in
+    edit("real_edit_with_branch.feature")
+
+  private def edit(feature: String): Unit = {
+    val el = new TestExecutionListener
+    val as = SimpleFileBasedArtifactSource(
+      StringFileArtifact(
+        ".atomist/tests/project/RealEditSteps.ts",
+        TestUtils.contentOf(this, "RealEditSteps.ts")),
+      StringFileArtifact(
+        ".atomist/tests/project/real_edit.feature",
+        TestUtils.contentOf(this, feature))
+    )
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas), Option(RugArchiveReader(cas)), Seq(el))
+    val run = grt.execute()
+    assert(run.testCount > 0)
+    assert(run.result === Passed)
+  }
+
   class TestExecutionListener extends GherkinExecutionListenerAdapter {
 
     var fsCount = 0


### PR DESCRIPTION
Adds the ability to clone repos from GitHub in Gherkin tests. This is convenient for testing against real projects.

Future enhancements may allow for caching, but this provides the core support.

Breaks interface with CLI, as discussed with @cdupuis 