### PR TITLE
nodeName and nodeTags exposed as TypeScript properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   **BREAKING** `nodeName` and `nodeTags` on `GraphNode` TypeScript interface are now
+    properties. 
+-   **BREAKING** Removed deprecated `nodeType` function on `GraphNode` interface
 -   **BREAKING** Removed Spring and Spring project types. These don't belong in
     `rug` and will resurface in a separate project.
 

--- a/src/main/scala/com/atomist/graph/GraphNode.scala
+++ b/src/main/scala/com/atomist/graph/GraphNode.scala
@@ -13,12 +13,8 @@ import com.atomist.util.{Visitable, Visitor}
   */
 trait GraphNode extends Visitable {
 
-  @ExportFunction(readOnly = true, description = "Name of the node")
+  @ExportFunction(readOnly = true, description = "Name of the node", exposeAsProperty = true)
   def nodeName: String
-
-  @deprecated("Please don't use this", "0.10.0")
-  @ExportFunction(readOnly = true, description = "Tags attached to the node")
-  def nodeType: Set[String] = nodeTags
 
   /**
     * Tags for the node, such as "File" or "JavaType". There may be multiple
@@ -27,7 +23,7 @@ trait GraphNode extends Visitable {
     *
     * @return tags for the node.
     */
-  @ExportFunction(readOnly = true, description = "Tags attached to the node")
+  @ExportFunction(readOnly = true, description = "Tags attached to the node", exposeAsProperty = true)
   def nodeTags: Set[String] = Set(Typed.typeToTypeName(getClass))
 
   def hasTag(tag: String): Boolean = nodeTags.contains(tag)

--- a/src/main/scala/com/atomist/rug/kind/impact/Impact.scala
+++ b/src/main/scala/com/atomist/rug/kind/impact/Impact.scala
@@ -22,7 +22,7 @@ class Impact(_parent: GraphNode, before: ArtifactSource, after: ArtifactSource)
   @ExportFunction(readOnly = true, description = "Parent of the impact")
   def parent: GraphNode = _parent
 
-  @ExportFunction(readOnly = true, description = "Name of the node")
+  @ExportFunction(readOnly = true, description = "Name of the node", exposeAsProperty = true)
   override def nodeName: String = "impact"
 
   @ExportFunction(readOnly = true, description = "Node content")
@@ -67,7 +67,7 @@ abstract class FileImpact(_parent: TreeNode) extends ParentAwareTreeNode {
   @ExportFunction(readOnly = true, description = "Node content")
   override def value: String = ???
 
-  @ExportFunction(readOnly = true, description = "Name of the node")
+  @ExportFunction(readOnly = true, description = "Name of the node", exposeAsProperty = true)
   override def nodeName: String = getClass.getSimpleName
 
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProvider.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProvider.scala
@@ -35,7 +35,7 @@ class JavaScriptBackedTypeProvider(
   */
 class ScriptObjectBackedTreeNode(som: ScriptObjectMirror) extends TreeNode {
 
-  override def nodeName: String = stringFunction(som, "nodeName")
+  override def nodeName: String = stringProperty(som, "nodeName")
 
   lazy val kids: Seq[TreeNode] =
     toScalaSeq(som.callMember("children")) map {
@@ -43,7 +43,7 @@ class ScriptObjectBackedTreeNode(som: ScriptObjectMirror) extends TreeNode {
     }
 
   override def nodeTags: Set[String] =
-    toScalaSeq(som.callMember("nodeTags")).map(s => Objects.toString(s)).toSet
+    toScalaSeq(som.get("nodeTags")).map(s => Objects.toString(s)).toSet
 
   override def value: String = stringFunction(som, "value")
 

--- a/src/main/scala/com/atomist/rug/runtime/js/migrations/BringUpToDate.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/migrations/BringUpToDate.scala
@@ -1,0 +1,10 @@
+package com.atomist.rug.runtime.js.migrations
+
+/**
+  * Keep this migration current to bring rugs up to date.
+  */
+object BringUpToDate {
+
+  val Migration: Migration = NodeNameToProperty andThen NodeTagsToProperty
+
+}

--- a/src/main/scala/com/atomist/rug/runtime/js/migrations/GraphNodeFunctionsToProperties.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/migrations/GraphNodeFunctionsToProperties.scala
@@ -1,0 +1,5 @@
+package com.atomist.rug.runtime.js.migrations
+
+object NodeNameToProperty extends LiteralJavaScriptReplacementMigration("GraphNode.nodeName is now a property, not a function", "nodeName()", "nodeName")
+
+object NodeTagsToProperty extends LiteralJavaScriptReplacementMigration("GraphNode.nodeTags is now a property, not a function", "nodeTags()", "nodeTags")

--- a/src/main/scala/com/atomist/rug/runtime/js/migrations/LiteralJavaScriptReplacementMigration.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/migrations/LiteralJavaScriptReplacementMigration.scala
@@ -1,0 +1,23 @@
+package com.atomist.rug.runtime.js.migrations
+
+import com.atomist.source.{ArtifactSource, FileArtifact, SimpleFileEditor}
+
+/**
+  * Convenient superclass for migrations that do a simple find and replace in JS source
+  */
+abstract class LiteralJavaScriptReplacementMigration(val description: String, toReplace: String, replaceWith: String) extends Migration {
+
+  final override def migrate(from: ArtifactSource, log: (String) => Unit): ArtifactSource = {
+    def processFile(f: FileArtifact): FileArtifact = {
+      if (f.content.contains(toReplace)) {
+        val newContent = f.content.replaceAllLiterally(toReplace, replaceWith)
+        log(s"Ran migration [$name] on [${f.path}]: $description")
+        f.withContent(newContent)
+      }
+      else
+        f
+    }
+
+    from ✎ SimpleFileEditor(f => f.path.startsWith(".atomist") && f.name.endsWith(".js"), processFile)
+  }
+}

--- a/src/main/scala/com/atomist/rug/runtime/js/migrations/Migration.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/migrations/Migration.scala
@@ -1,0 +1,34 @@
+package com.atomist.rug.runtime.js.migrations
+
+import com.atomist.source.ArtifactSource
+
+/**
+  * Interface to be implemented by migrations, which can modify
+  * the ArtifactSource of a Rug to a presently compatible version.
+  */
+trait Migration {
+
+  def name: String = getClass.getSimpleName.replace("$", "")
+
+  /**
+    * Human-readable description of this migration and why it was needed
+    */
+  def description: String
+
+  /**
+    * Perform the given migration, emitting log message(s) that can be displayed to the
+    * user to encourage them to fix this Rug
+    */
+  def migrate(from: ArtifactSource, log: String => Unit): ArtifactSource
+
+  def andThen(that: Migration): Migration =
+    new Migration {
+      override def name: String = s"${Migration.this.name}.${that.name}"
+
+      override def description = s"${Migration.this.description}; ${that.description}"
+
+      override def migrate(from: ArtifactSource, logger: String => Unit): ArtifactSource =
+        that.migrate(Migration.this.migrate(from, logger), logger)
+    }
+
+}

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -67,7 +67,8 @@ class TypeScriptInterfaceGenerator(typeRegistry: TypeRegistry = DefaultTypeRegis
       if (exposeAsProperty) {
         // Emit property only
         s"${comment(indent)}${indent}readonly $name: $returnType;"
-      } else {
+      }
+      else {
         // Emit function
         s"${comment(indent)}$indent$name(${params.mkString(", ")}): $returnType;"
       }

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -78,18 +78,11 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
   private def graphNodeImpl(name: String): String = {
     // Create fields to make JSON stringification more revealing
     helper.indented(
-      s"""|private _nodeName = "$name";
-          |private _nodeTags = [ "$name", "-dynamic" ];
+      s"""|nodeName: string = "$name";
           |
-          |${helper.toJsDoc(GraphNodeMethodImplementationDoc)}
-          |nodeName(): string {
-          |${indent}return this._nodeName;
-          |}
+          |nodeTags: string[] = [ "$name", "-dynamic" ];
           |
-          |${helper.toJsDoc(GraphNodeMethodImplementationDoc)}
-          |nodeTags(): string[] {
-          |${indent}return this._nodeTags;
-          |}""".stripMargin, 1)
+          |""".stripMargin, 1)
   }
 
   private def toFieldName(m: MethodInfo): String = "_" + m.name

--- a/src/main/typescript/node_modules/@atomist/rug/ast/DecoratingPathExpressionEngine.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/DecoratingPathExpressionEngine.ts
@@ -56,7 +56,7 @@ export class DecoratingPathExpressionEngine extends TransformingPathExpressionEn
      * @param n TreeNode we wish to decorate
      */
     protected decoratorClassName(n: TreeNode) {
-        return n.nodeName().charAt(0).toUpperCase() + n.nodeName().substr(1) + "Ops"
+        return n.nodeName.charAt(0).toUpperCase() + n.nodeName.substr(1) + "Ops"
     }
 
     public save<N extends RichTextTreeNode>(n: TreeNode, expr: string): N[] {

--- a/src/main/typescript/node_modules/@atomist/rug/ast/TreeDiff.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/TreeDiff.ts
@@ -5,7 +5,7 @@ import { TextTreeNode } from "../tree/PathExpression"
  * Check whether two nodes are structurally equivalent
  */
 export function structurallyEquivalent(a: TextTreeNode, b: TextTreeNode): boolean {
-    if (a.nodeName() !== b.nodeName())
+    if (a.nodeName !== b.nodeName)
         return false;
 
     if (a.children().length != b.children().length)

--- a/src/main/typescript/node_modules/@atomist/rug/ast/yaml/YamlPathExpressionEngine.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/ast/yaml/YamlPathExpressionEngine.ts
@@ -12,7 +12,7 @@ export class YamlPathExpressionEngine extends DecoratingPathExpressionEngine {
         if ((<any>n).value) { // It's a text node
             let ttn = n as TextTreeNode
 
-            // console.log(`Decorating [${n}] with tags [${n.nodeTags()}]`)
+            // console.log(`Decorating [${n}] with tags [${n.nodeTags}]`)
             if (helper.hasTag(n, "Scalar")) {
                 switch (ttn.value().charAt(0)) {
                     case '"':

--- a/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/PathExpression.ts
@@ -58,9 +58,9 @@ interface PointFormatInfo {
 
 interface GraphNode {
 
-    nodeName(): string
+    nodeName: string
 
-    nodeTags(): string[]
+    nodeTags: string[]
 
 }
 

--- a/src/main/typescript/node_modules/@atomist/rug/tree/TreeHelper.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/tree/TreeHelper.ts
@@ -7,7 +7,7 @@ import { TreeNode, TextTreeNode, ParentAwareTreeNode } from "./PathExpression"
 
 
 export function hasTag(n: TreeNode, t: string): boolean {
-    return n.nodeTags().indexOf(t) > -1
+    return n.nodeTags.indexOf(t) > -1
 }
 
 export function findPathFromAncestor(n: ParentAwareTreeNode, nodeTest: (TextTreeNode) => boolean): string {
@@ -20,10 +20,10 @@ export function findPathFromAncestor(n: ParentAwareTreeNode, nodeTest: (TextTree
         //console.log(`Gotcha: Parent is ${parent}`)
         // TODO what if it's not unique - need position, but then parent.children may reinitialize.
         // Not if a mutable container, admittedly
-        return `/${n.nodeName()}`
+        return `/${n.nodeName}`
     }
     else if (parent.parent()) { // Essentially an instanceof, which we can't do on an interface
-        return findPathFromAncestor(parent as ParentAwareTreeNode, nodeTest) + `/${n.nodeName()}`
+        return findPathFromAncestor(parent as ParentAwareTreeNode, nodeTest) + `/${n.nodeName}`
     }
     else
         return null
@@ -32,7 +32,7 @@ export function findPathFromAncestor(n: ParentAwareTreeNode, nodeTest: (TextTree
 export function findPathFromAncestorWithTag(n: ParentAwareTreeNode, tag: String): string {
     let r = findPathFromAncestor(
         n,
-        n => n.nodeTags().contains(tag))
+        n => n.nodeTags.contains(tag))
     return r
 }
 
@@ -62,7 +62,7 @@ export function findAncestor<N extends TreeNode>(n: ParentAwareTreeNode, nodeTes
 export function findAncestorWithTag<N extends TreeNode>(n: ParentAwareTreeNode, tag: string): N {
     let r = findAncestor<N>(
         n,
-        n => n.nodeTags().indexOf(tag) != -1
+        n => n.nodeTags.indexOf(tag) != -1
         )
     return r
 }
@@ -73,14 +73,14 @@ export type NodeStringifier = (TextTreeNode) => string
 
 export function nodeAndTagsStringifier(tn: TextTreeNode): string {
     if (tn.children().length == 0)
-      return `${tn.nodeName()}:[${tn.value()}]`;
-    return `${tn.nodeName()}:[${tn.nodeTags().join(", ")}]`;
+      return `${tn.nodeName}:[${tn.value()}]`;
+    return `${tn.nodeName}:[${tn.nodeTags.join(", ")}]`;
 }
 
 export function nodeAndValueStringifier(tn: TextTreeNode, maxLen: number = 30): string {
     if (tn.children().length == 0 || tn.value().length < maxLen)
-      return `${tn.nodeName()}:[${tn.value()}]`;
-    return `${tn.nodeName()}:len=${tn.value().length}`;
+      return `${tn.nodeName}:[${tn.value()}]`;
+    return `${tn.nodeName}:len=${tn.value().length}`;
 }
 
 
@@ -124,16 +124,16 @@ export function nodeReplacer(nodeStringifier: NodeStringifier = nodeAndValueStri
                // TextTreeNode
                return {
                   __kind__: "TextTreeNode",
-                  name: value.nodeName(),
-                  tags: value.nodeTags().join(","),
+                  name: value.nodeName,
+                  tags: value.nodeTags.join(","),
                   structure: nodeStringifier(value)
               }
          }
          else if (value.nodeTags) {
              return {
                  __kind__: "GraphNode",
-                 name: value.nodeName(),
-                 tags: value.nodeTags().join(","),
+                 name: value.nodeName,
+                 tags: value.nodeTags.join(","),
                  toString: value + ""
              }
          }

--- a/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/ChangeException.ts
@@ -25,13 +25,13 @@ class ChangeException implements ProjectEditor {
       eng.with<TextTreeNode>(project, catchClause, cc => {
         //console.log(`The catch clause was '${cc.value()} at ${cc.formatInfo()}'`)
         if (cc.formatInfo == null)
-          throw new Error(`Format info was null for ${cc.nodeName()}`)
+          throw new Error(`Format info was null for ${cc.nodeName}`)
         if (cc.formatInfo.start.lineNumberFrom1 < 5 || cc.formatInfo.start.lineNumberFrom1 > 100)
           throw new Error(`Format info values are wacky in ${cc.formatInfo}`)
         let c2 = cc as any // We need to do this to get to the children
         let classType = c2.class_type
         if (classType.parent().value() != cc.value())
-          throw new Error(`Unexpected value for parent of ${classType.nodeName()}: ${classType.parent()}`)
+          throw new Error(`Unexpected value for parent of ${classType.nodeName}: ${classType.parent()}`)
         classType.update(this.newException)
         count++
       })

--- a/src/test/resources/com/atomist/rug/kind/csharp/NavigateTree.ts
+++ b/src/test/resources/com/atomist/rug/kind/csharp/NavigateTree.ts
@@ -23,13 +23,13 @@ class NavigateTree implements ProjectEditor {
       eng.with<TextTreeNode>(project, catchClause, cc => {
         //console.log(`The catch clause was '${cc.value()} at ${cc.formatInfo}'`)
         if (cc.formatInfo == null)
-          throw new Error(`Format info was null for ${cc.nodeName()}`)
+          throw new Error(`Format info was null for ${cc.nodeName}`)
         if (cc.formatInfo.start.lineNumberFrom1 < 5 || cc.formatInfo.start.lineNumberFrom1 > 100)
           throw new Error(`Format info values are wacky in ${cc.formatInfo}`)
         let c2 = cc as any // We need to do this to get to the children using functions
         let classType = c2.class_type
         if (classType.parent().value() != cc.value())
-          throw new Error(`Unexpected value for parent of ${classType.nodeName()}: ${classType.parent()}`)
+          throw new Error(`Unexpected value for parent of ${classType.nodeName}: ${classType.parent()}`)
 
         let inFile: File = treeHelper.findAncestorWithTag<File>(classType, "File")
         if (inFile != null) {

--- a/src/test/resources/com/atomist/rug/kind/java20/ClassAnnotated.ts
+++ b/src/test/resources/com/atomist/rug/kind/java20/ClassAnnotated.ts
@@ -15,7 +15,7 @@ class ClassAnnotated implements EditProject {
         eng.with<JavaSource>(project, '//JavaSource()', j => {
             eng.with<JavaType>(j, '//JavaType()', jt => {
                 jt.children()
-                .filter(n => n.nodeName() == "JavaConstructor")
+                .filter(n => n.nodeName == "JavaConstructor")
                 .forEach(k => {
                     let ctor = k as JavaConstructor
                     if (ctor.parametersSize() == 1 ) {

--- a/src/test/resources/com/atomist/rug/kind/java23/ClassAnnotated.ts
+++ b/src/test/resources/com/atomist/rug/kind/java23/ClassAnnotated.ts
@@ -19,7 +19,7 @@ class ClassAnnotated implements EditProject {
             eng.with<JavaType>(j, '//JavaType()', c => {
                 eng.with<JavaField>(c, '//JavaField()', f => {
                     //console.log(`f.type.name = [${f.type.name}]`)
-                    if (f.nodeName().indexOf("Field") > -1 && f.type.name.indexOf("Dog") > -1) {
+                    if (f.nodeName.indexOf("Field") > -1 && f.type.name.indexOf("Dog") > -1) {
                         f.addAnnotation("com.someone", "FooBar")
                     }
                 })

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/MutatingBanana.ts
@@ -32,9 +32,9 @@ class Fruiterer implements TreeNode {
 
   parent() { return this.file }
 
-  nodeName(): string { return "fruiterer" }
+  nodeName: string = "fruiterer";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   children() { return [ new MutatingBanana(this.file), new Pear() ] }
 
@@ -46,9 +46,9 @@ class MutatingBanana implements TreeNode {
 
   parent() { return this.file }
 
-  nodeName(): string { return "mutatingBanana" }
+  nodeName: string = "mutatingBanana";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   children() { return [] }
 
@@ -61,9 +61,9 @@ class Pear implements TreeNode {
 
   parent() { return null }
 
-  nodeName(): string { return "pear" }
+  nodeName: string = "pear";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   children() { return [] }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleBanana.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/SimpleBanana.ts
@@ -20,9 +20,9 @@ class Banana implements TreeNode {
 
   parent() { return null }
 
-  nodeName(): string { return "banana" }
+  nodeName: string = "banana";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   value(): string { return "yellow" }
 

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/TwoLevel.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/TwoLevel.ts
@@ -32,9 +32,9 @@ class Fruiterer implements TreeNode {
 
   parent() { return null}
 
-  nodeName(): string { return "fruiterer" }
+  nodeName: string = "fruiterer";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   value(): string { return "" }
 
@@ -48,9 +48,9 @@ class Banana implements TreeNode {
 
   parent() { return null}
 
-  nodeName(): string { return "banana" }
+  nodeName: string = "banana";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   value(): string { return "yellow" }
 
@@ -62,9 +62,9 @@ class Pear implements TreeNode {
 
   parent() { return null}
 
-  nodeName(): string { return "pear" }
+  nodeName: string = "pear";
 
-  nodeTags(): string[] { return [ this.nodeName()] }
+  nodeTags: string[] = [ this.nodeName];
 
   value(): string { return "green" }
 

--- a/src/test/resources/com/atomist/rug/test/gherkin/handler/event/Nodes.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/handler/event/Nodes.ts
@@ -11,10 +11,10 @@ export class Commit implements GraphNode {
 
     private _sha: string
 
-    nodeName(): string {  return "Commit" }
+    nodeName: string = "Commit"
 
     // Node we need -dynamic to allow dispatch in the proxy
-    nodeTags(): string[] { return [ "Commit", "-dynamic" ] }
+    nodeTags: string[] = [ "Commit", "-dynamic" ]
 
     withMadeBy(p: Person): Commit {
         this._madeBy = p 
@@ -39,9 +39,9 @@ export class Person implements GraphNode {
     constructor(private _name: string) {} 
 
     // Intentionally make this different to the name, to test
-    nodeName(): string {  return "A person" }
+    nodeName: string = "A person";
 
-    nodeTags(): string[] { return [ "Person", "-dynamic" ] }
+    nodeTags: string[] = [ "Person", "-dynamic" ];
 
     get name(): string {  return this._name }
 
@@ -56,12 +56,10 @@ export class Person implements GraphNode {
 
 export class GitHubId implements GraphNode {
 
-    constructor(private _id: string) {}
+    constructor(public id: string) {}
 
-    nodeName(): string {  return this._id }
+    nodeName: string = this.id;
 
-    nodeTags(): string[] { return [ "GitHubId", "-dynamic" ] }
-
-    get id(): string {  return this._id }
+    nodeTags: string[] = [ "GitHubId", "-dynamic" ];
 
 }

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/JavaScriptBackedTypeProviderTest.scala
@@ -8,12 +8,12 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
 
-  it should "invoke tree finder with one level only" in {
+  "JavaScriptTypeProvider" should "invoke tree finder with one level only" in {
     val jsed = TestUtils.editorInSideFile(this, "SimpleBanana.ts")
     val target = ParsingTargets.SpringIoGuidesRestServiceSource
     jsed.modify(target, SimpleParameterValues.Empty) match {
       case _: NoModificationNeeded =>
-      case _ => ???
+      case x => fail(s"Unexpectd: $x")
     }
   }
 
@@ -21,8 +21,8 @@ class JavaScriptBackedTypeProviderTest extends FlatSpec with Matchers {
     val jsed = TestUtils.editorInSideFile(this, "TwoLevel.ts")
     val target = ParsingTargets.SpringIoGuidesRestServiceSource
     jsed.modify(target, SimpleParameterValues.Empty) match {
-      case nmn: NoModificationNeeded =>
-      case _ => ???
+      case _: NoModificationNeeded =>
+      case x => fail(s"Unexpectd: $x")
     }
   }
 

--- a/src/test/scala/com/atomist/rug/runtime/js/interop/RuntimeExceptionHandlingTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/interop/RuntimeExceptionHandlingTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class RuntimeExceptionHandlingTest extends FlatSpec with Matchers {
 
-  it should "report correct position for null pointer exception in single file" in {
+  "runtime exception handling" should "report correct position for null pointer exception in single file" in {
     val jsed = TestUtils.editorInSideFile(this, "DeliberateNpe.ts")
     val target = ParsingTargets.SpringIoGuidesRestServiceSource
     try {

--- a/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
+++ b/src/test/scala/com/atomist/tree/pathexpression/PathExpressionEngineTest.scala
@@ -429,7 +429,7 @@ class PathExpressionEngineTest extends FlatSpec with Matchers {
 
     override def childNodeTypes: Set[String] = Set("RecursiveNode")
 
-    @ExportFunction(readOnly = true, description = "Name of the node")
+    @ExportFunction(readOnly = true, description = "Name of the node", exposeAsProperty = true)
     override def nodeName: String = "recurse"
   }
 


### PR DESCRIPTION
Fixes #559.

Breaking change but justified in terms of consistency and because the error messages resulting from attempting to access this functions as properties were confusing