### PR TITLE
Improve archive loading performance by selecting specific directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+-   Improve archive loading performance by creating new ArtifactSource with only
+    Rug content, instead of filtering all files in original archive
+
 -   Throw exceptions if there is more than one Rug with the same name
     in an archive https://github.com/atomist/rug/issues/561
 

--- a/src/main/scala/com/atomist/project/archive/AtomistConfig.scala
+++ b/src/main/scala/com/atomist/project/archive/AtomistConfig.scala
@@ -31,26 +31,9 @@ trait AtomistConfig {
   def testsDirectory: String
 
   /**
-    * Reviewers directory under Atomist root or root of archive.
-    */
-  def reviewersDirectory: String
-
-  /**
-    * Executors directory under Atomist root or root of archive.
-    */
-  def executorsDirectory: String
-
-  /**
     * Handlers directory under Atomist root or root of archive.
     */
   def handlersDirectory: String
-
-  /**
-    * Extension for Rug files.
-    */
-  def rugExtension: String
-
-  def testExtension: String
 
   def jsExtension: String
 
@@ -60,70 +43,52 @@ trait AtomistConfig {
 
   def templatesRoot = s"$atomistRoot/$templatesDirectory"
 
-  def reviewersRoot = s"$atomistRoot/$reviewersDirectory"
-
-  def executorsRoot = s"$atomistRoot/$executorsDirectory"
-
   def handlersRoot = s"$atomistRoot/$handlersDirectory"
 
   def testsRoot = s"$atomistRoot/$testsDirectory"
 
-  val defaultRugFileBase = "default"
-
-  /**
-    * Default path of Rug program to create when a string is passed in.
-    */
-  def defaultRugFilepath = s"$editorsRoot/$defaultRugFileBase$rugExtension"
-
-  /**
-    * Default path of TypeScript program to create when a string is passed in.
-    */
-  def defaultTypeScriptFilepath = s"$editorsRoot/$defaultRugFileBase.ts"
 
   /**
     * Return the atomist content only
+    *
     * @param rugArchive artifact source
     * @return only the Atomist content from the archive
     */
-  def atomistContent(rugArchive: ArtifactSource): ArtifactSource =
-    rugArchive.filter(d => d.path.startsWith(atomistRoot), f => f.path.startsWith(atomistRoot))
+  def atomistContent(rugArchive: ArtifactSource): ArtifactSource = {
 
-  def isRugSource(f: FileArtifact): Boolean = {
-    f.name.endsWith(rugExtension) && isAtomistSource(f)
+    //find files in dir (if any)
+    def files(dir: String): Seq[FileArtifact] = {
+      rugArchive.findDirectory(dir) match {
+        case Some(found) => found.allFiles
+        case _ => Nil
+      }
+    }
 
+    val atomistFiles = files(editorsRoot) ++ files(generatorsRoot) ++ files(handlersRoot) ++ files(testsRoot)
+    ArtifactSource.fromFiles(atomistFiles: _*)
   }
 
-  def isJsSource(f:FileArtifact): Boolean = {
+
+  def isJsSource(f: FileArtifact): Boolean = {
     f.name.endsWith(jsExtension) && isAtomistSource(f)
   }
 
-  def isJsTest(f:FileArtifact): Boolean = {
+  def isJsTest(f: FileArtifact): Boolean = {
     // TODO fix hard coding
     f.name.endsWith(jsExtension) && f.path.startsWith(s"$atomistRoot/test")
   }
 
   def isAtomistSource(f: FileArtifact): Boolean = {
-      f.path.startsWith(editorsRoot) ||
+    f.path.startsWith(editorsRoot) ||
       f.path.startsWith(generatorsRoot) ||
-      f.path.startsWith(reviewersRoot) ||
-      f.path.startsWith(executorsRoot) ||
       f.path.startsWith(handlersRoot) ||
       f.path.startsWith(handlersDirectory) ||
       f.path.startsWith(editorsDirectory) ||
-      f.path.startsWith(generatorsDirectory) ||
-      f.path.startsWith(reviewersDirectory) ||
-      f.path.startsWith(executorsDirectory)
-  }
-
-  def isRugTest(f: FileArtifact): Boolean = {
-    f.name.endsWith(testExtension) && (
-      f.path.startsWith(testsRoot) ||
-        f.path.startsWith(testsDirectory)
-      )
+      f.path.startsWith(generatorsDirectory)
   }
 
   def isJsHandler(f: FileArtifact): Boolean = {
-    f.name.endsWith(jsExtension) &&  (f.path.startsWith(handlersRoot) ||
+    f.name.endsWith(jsExtension) && (f.path.startsWith(handlersRoot) ||
       f.path.startsWith(handlersDirectory))
   }
 
@@ -142,17 +107,9 @@ object DefaultAtomistConfig extends AtomistConfig {
 
   override val templatesDirectory = "templates"
 
-  override val reviewersDirectory = "reviewers"
-
-  override val executorsDirectory = "executors"
-
   override val handlersDirectory = "handlers"
 
   override val testsDirectory = "tests"
 
-  override val rugExtension = ".rug"
-
   override val jsExtension = ".js"
-
-  override def testExtension: String = ".rt"
 }

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptProjectOperationTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptProjectOperationTest.scala
@@ -235,23 +235,23 @@ class JavaScriptProjectOperationTest extends FlatSpec with Matchers {
 
   it should "run simple editor and throw an exception for default parameter value not matching pattern" in {
     assertThrows[InvalidRugParameterDefaultValue] {
-      invokeAndVerifyEditorWithDefaults(StringFileArtifact(s".atomist/reviewers/SimpleEditor.ts",
+      invokeAndVerifyEditorWithDefaults(StringFileArtifact(s".atomist/editors/SimpleEditor.ts",
         SimpleEditorWithInvalidDefaultParameterValuePattern))
     }
   }
 
   it should "run simple editor compiled from TypeScript and validate the default from allowed values correctly" in {
-    invokeAndVerifyEditorWithDefaults(StringFileArtifact(s".atomist/reviewers/SimpleEditor.ts", SimpleEditorWithValidDefaultParameterValueFromAlternation))
+    invokeAndVerifyEditorWithDefaults(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleEditorWithValidDefaultParameterValueFromAlternation))
   }
 
   it should "run simple editor and throw an exception for default parameter value not in list" in {
     assertThrows[InvalidRugParameterDefaultValue] {
-      invokeAndVerifyEditorWithDefaults(StringFileArtifact(s".atomist/reviewers/SimpleEditor.ts", SimpleEditorWithInvalidDefaultParameterValueAlternation))
+      invokeAndVerifyEditorWithDefaults(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleEditorWithInvalidDefaultParameterValueAlternation))
     }
   }
 
   it should "create two separate js objects for each operation" in {
-    val tsf = StringFileArtifact(s".atomist/reviewers/SimpleEditor.ts", SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters)
+    val tsf = StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleEditorInvokingOtherEditorAndAddingToOurOwnParameters)
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
     val jsed = RugArchiveReader(as).editors.head.asInstanceOf[JavaScriptProjectEditor]
     val v1 = jsed.cloneVar(jsed.jsc, jsed.jsVar)

--- a/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/handler/command/GherkinRunnerCommandHandlerTest.scala
@@ -99,7 +99,7 @@ class GherkinRunnerCommandHandlerTest extends FlatSpec with Matchers {
     val passingFeature1Steps =
       TestUtils.requiredFileInPackage(this, stepsFile)
     val passingFeature1StepsFile = passingFeature1Steps.withPath(
-      s".atomist/test/handlers/command/$stepsFile")
+      s".atomist/tests/handlers/command/$stepsFile")
 
     val handlerName = "RunsMatchingPathExpressionCommandHandler.ts"
     val handlerFile = requiredFileInPackage(this, "CommandHandlers.ts").withPath(atomistConfig.handlersRoot + "/command/" + handlerName)
@@ -128,7 +128,7 @@ class GherkinRunnerCommandHandlerTest extends FlatSpec with Matchers {
     val passingFeature1Steps =
       TestUtils.requiredFileInPackage(this, stepsFile)
     val passingFeature1StepsFile = passingFeature1Steps.withPath(
-      s".atomist/test/handlers/command/$stepsFile")
+      s".atomist/tests/handlers/command/$stepsFile")
 
     val handlerName = "LooksInProjects.ts"
     val handlerFile = requiredFileInPackage(this, "CommandHandlers.ts").withPath(atomistConfig.handlersRoot + "/command/" + handlerName)

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
@@ -6,18 +6,18 @@ import com.atomist.source.{FileArtifact, StringFileArtifact}
 object ProjectTestTargets {
 
   val PassingSimpleTsFile: FileArtifact =
-    TestUtils.requiredFileInPackage(this, "PassingSimple.ts").withPath(".atomist/test/project/Simple_definitions.ts")
+    TestUtils.requiredFileInPackage(this, "PassingSimple.ts").withPath(".atomist/tests/project/Simple_definitions.ts")
 
   val FailingSimpleTsFile: FileArtifact =
-    TestUtils.requiredFileInPackage(this, "FailingSimple.ts").withPath(".atomist/test/project/Simple_definitions.ts")
+    TestUtils.requiredFileInPackage(this, "FailingSimple.ts").withPath(".atomist/tests/project/Simple_definitions.ts")
 
-  val EditorWithoutParametersTsFile = StringFileArtifact(".atomist/test/project/Simple_definitions.ts",
+  val EditorWithoutParametersTsFile = StringFileArtifact(".atomist/tests/project/Simple_definitions.ts",
     TestUtils.requiredFileInPackage(this, "EditorWithoutParametersSteps.ts").content)
 
-  val EditorWithParametersStepsFile = StringFileArtifact(".atomist/test/project/Simple_definitions.ts",
+  val EditorWithParametersStepsFile = StringFileArtifact(".atomist/tests/project/Simple_definitions.ts",
     TestUtils.requiredFileInPackage(this, "EditorWithParametersSteps.ts").content)
 
-  val EditorWithBadParametersStepsFile = StringFileArtifact(".atomist/test/project/Simple_definitions.ts",
+  val EditorWithBadParametersStepsFile = StringFileArtifact(".atomist/tests/project/Simple_definitions.ts",
     TestUtils.requiredFileInPackage(this, "EditorWithBadParametersSteps.ts").content)
 
   val CorruptionFeature =


### PR DESCRIPTION
On travis-rugs (after npm install), this improved the performance of `rug describe archive -l` from average of 18s to 2.5s (on my machine) over 5 runs.