### PR TITLE
Ability to generate deprecation warnings in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/1.0.0-m.2...HEAD
 
+### Added
+
+-   Added ability to indicate in TypeScript generated interfaces when a
+    JVM method being exposed is marked as `@Deprecated`
+
 ### Changed
 
 -   **BREAKING** Removed Spring and Spring project types. These don't belong in

--- a/src/main/scala/com/atomist/rug/kind/core/FileArtifactBackedMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileArtifactBackedMutableView.scala
@@ -29,6 +29,7 @@ abstract class FileArtifactBackedMutableView(originalBackingObject: FileArtifact
   @ExportFunction(readOnly = true,
     exposeAsProperty = true,
     description = "Is this file well-formed?")
+  @Deprecated
   final def isWellFormed: Boolean = wellFormed
 
   /**

--- a/src/main/scala/com/atomist/rug/kind/core/FileMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/FileMutableView.scala
@@ -34,11 +34,13 @@ class FileMutableView(
   @ExportFunction(readOnly = true,
     exposeAsProperty = true,
     description = "Is this a Java file?")
+  @Deprecated
   def isJava: Boolean = currentBackingObject.name.endsWith(".java")
 
   @ExportFunction(readOnly = true,
     exposeAsProperty = true,
     description = "Is this a Scala file?")
+  @Deprecated
   def isScala: Boolean = currentBackingObject.name.endsWith(".scala")
 
   @ExportFunction(readOnly = false, description = "Set entire file content to new string")
@@ -49,6 +51,7 @@ class FileMutableView(
 
   @ExportFunction(readOnly = true,
     description = "Does the file name (not path) contain the given string?")
+  @Deprecated
   def nameContains(@ExportFunctionParameterDescription(name = "what",
     description = "The string to use when looking for it in the file name or path")
                    what: String): Boolean =

--- a/src/main/scala/com/atomist/rug/spi/CommonViewOperations.scala
+++ b/src/main/scala/com/atomist/rug/spi/CommonViewOperations.scala
@@ -11,6 +11,7 @@ trait CommonViewOperations[T] extends MutableView[T] with LazyLogging {
 
   @ExportFunction(readOnly = false,
     description = "Cause the operation to fail with a fatal error")
+  @Deprecated
   final def fail(@ExportFunctionParameterDescription(name = "msg",
     description = "The message to be displayed")
                  msg: String): Unit = {
@@ -22,6 +23,7 @@ trait CommonViewOperations[T] extends MutableView[T] with LazyLogging {
     */
   @ExportFunction(readOnly = true,
     description = "Cause the editor to print to the console. Useful for debugging if running editors locally.")
+  @Deprecated
   final def println(@ExportFunctionParameterDescription(name = "msg",
     description = "The message to be displayed")
                     msg: String): Unit = {

--- a/src/main/scala/com/atomist/rug/spi/ReflectiveFunctionExport.scala
+++ b/src/main/scala/com/atomist/rug/spi/ReflectiveFunctionExport.scala
@@ -1,6 +1,6 @@
 package com.atomist.rug.spi
 
-import java.lang.reflect.{AnnotatedElement, Method}
+import java.lang.reflect.Method
 
 import org.springframework.util.ReflectionUtils
 
@@ -33,7 +33,8 @@ object ReflectiveFunctionExport {
             case ex => Some(ex)
           },
           exposeAsProperty = a.exposeAsProperty(),
-          exposeResultDirectlyToNashorn = a.exposeResultDirectlyToNashorn())
+          exposeResultDirectlyToNashorn = a.exposeResultDirectlyToNashorn(),
+          deprecated = m.isAnnotationPresent(classOf[Deprecated]))
       })
 
   private def extractExportedParametersAndDocumentation(m: Method): Array[TypeParameter] = {

--- a/src/main/scala/com/atomist/rug/spi/TypeOperation.scala
+++ b/src/main/scala/com/atomist/rug/spi/TypeOperation.scala
@@ -10,11 +10,12 @@ import com.atomist.tree.content.text.OutOfDateNodeException
 /**
   * Operation on an exported Rug type. Typically annotated with an [[ExportFunction]] annotation.
   *
-  * @param name        name of the type
-  * @param description description of the type. May be used in generated code
-  * @param example     optional example of usage of the operation
-  * @param definedOn   type we are defined on. May be an abstract superclass.
-  * @param exposeAsProperty    do we expose this as a property?
+  * @param name             name of the type
+  * @param description      description of the type. May be used in generated code
+  * @param example          optional example of usage of the operation
+  * @param definedOn        type we are defined on. May be an abstract superclass.
+  * @param exposeAsProperty do we expose this as a property?
+  * @param deprecated       is this operation deprecated?
   * @see ExportFunction
   * @see ExportProperty
   */
@@ -27,7 +28,8 @@ case class TypeOperation(
                           definedOn: Class[_],
                           example: Option[String],
                           exposeAsProperty: Boolean,
-                          exposeResultDirectlyToNashorn: Boolean = false) {
+                          exposeResultDirectlyToNashorn: Boolean = false,
+                          deprecated: Boolean = false) {
 
   import TypeOperation._
 

--- a/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
@@ -81,12 +81,15 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
 
     def returnsArray: Boolean = returnType.contains("[")
 
+    def deprecated: Boolean
+
     /** Return the underlying type if we return an array */
     def underlyingType: String = returnType.stripSuffix("[]")
 
     def comment(indent: String): String = {
       val builder = new StringBuilder(s"$indent/**\n")
-      builder ++= s"$indent  * ${description.getOrElse("")}\n"
+      val deprecationMessage = if (deprecated) "DEPRECATED - " else ""
+      builder ++= s"$indent  * ${deprecationMessage}${description.getOrElse("")}\n"
       builder ++= s"$indent  * \n"
 
       if (exposeAsProperty) {

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -60,7 +60,8 @@ class TypeScriptInterfaceGenerator(typeRegistry: TypeRegistry = DefaultTypeRegis
                                          params: Seq[MethodParam],
                                          returnType: String,
                                          description: Option[String],
-                                         exposeAsProperty: Boolean)
+                                         exposeAsProperty: Boolean,
+                                         deprecated: Boolean)
     extends MethodInfo {
 
     override def toString: String = {
@@ -76,7 +77,7 @@ class TypeScriptInterfaceGenerator(typeRegistry: TypeRegistry = DefaultTypeRegis
 
   protected def getMethodInfo(typeName: String, op: TypeOperation, params: Seq[MethodParam]): MethodInfo =
     InterfaceMethodInfo(typeName, op.name, params, helper.rugTypeToTypeScriptType(op.returnType, typeRegistry),
-      Some(op.description), op.exposeAsProperty)
+      Some(op.description), op.exposeAsProperty, op.deprecated)
 
   override def getGeneratedTypes(t: Typed, op: TypeOperation): Seq[GeneratedType] = {
     val generatedTypes = new ListBuffer[GeneratedType]

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptStubClassGenerator.scala
@@ -99,7 +99,8 @@ class TypeScriptStubClassGenerator(typeRegistry: TypeRegistry,
                                      params: Seq[MethodParam],
                                      returnType: String,
                                      description: Option[String],
-                                     exposeAsProperty: Boolean)
+                                     exposeAsProperty: Boolean,
+                                     deprecated: Boolean = false)
     extends MethodInfo {
 
     override def toString: String = {


### PR DESCRIPTION
- Adds ability to generate deprecation warnings in TypeScript generated interfaces for exposed JVM methods marked as `@Deprecated`.
- Deprecates some old methods from `FileMutableView` and other types