### PR TITLE
Allow testing of aborted scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,32 +13,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Added ability to indicate in TypeScript generated interfaces when a
     JVM method being exposed is marked as `@Deprecated`
+-   Ability to test when a scenario aborts [#569][569]
 
 ### Changed
 
--   **BREAKING** Gherkin handler step 'parameters were invalid' renamed to
-    'handler parameters were invalid'.
-    https://github.com/atomist/rug/issues/566
-
--   **BREAKING** Removed Spring and Spring project types. These don't belong in
-    `rug` and will resurface in a separate project.
-
--   Add instructions to DirectedMessage and ResponseMessage.  Add optional id to
-    Presentable instruction.
+-   **BREAKING** Gherkin handler step 'parameters were invalid'
+    renamed to 'handler parameters were invalid' [#566][566]
+-   **BREAKING** Removed Spring and Spring project types, these don't
+    belong in `rug` and will resurface in a separate project
+-   Add instructions to DirectedMessage and ResponseMessage
+-   Add optional id to Presentable instruction
 -   Missing implementations of Given and When steps now are returned
     as NotYetImplemented in testing results [#570][570]
 
 ### Fixed
 
--   Improve archive loading performance by creating new ArtifactSource with only
-    Rug content, instead of filtering all files in original archive
-
+-   Improve archive loading performance by creating new ArtifactSource
+    with only Rug content, instead of filtering all files in original
+    archive
 -   Throw exceptions if there is more than one Rug with the same name
-    in an archive https://github.com/atomist/rug/issues/561
+    in an archive [#561][561]
+-   Fix StackOverflow when calling toString on
+    LinkableContainerTreeNode, can't recurse as this is a graph not a
+    tree.
 
--   Fix StackOverflow when calling toString on LinkableContainerTreeNode.
-    Can't recurse as this is a graph not a tree.
-
+[569]: https://github.com/atomist/rug/issues/569
+[566]: https://github.com/atomist/rug/issues/566
+[561]: https://github.com/atomist/rug/issues/561
 [570]: https://github.com/atomist/rug/issues/570
 
 ## [1.0.0-m.2] - 2017-04-26

--- a/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
@@ -45,6 +45,8 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
             runGiven(world, step)
           case "When " if !world.aborted =>
             runWhen(world, step)
+          case "Then " if step.getText == "the scenario aborted" =>
+            Some(AssertionResult(step.getText, Result(world.aborted, "Scenario aborted")))
           case "Then " if !world.aborted =>
             Some(runThen(world, step))
           case "Then " if world.aborted =>

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
@@ -2,18 +2,35 @@ import { Given, Then, When } from "./Core";
 
 // Register well-known steps
 
+/**
+ * Nothing.  Typical starting point for command handler testing.
+ */
+Given("nothing", (w) => { return; });
+
+/**
+ * Generic event handler registrtion.
+ */
 Given("([a-zA-Z0-9]+) handler", (world, handlerName) =>
     world.registerHandler(handlerName),
 );
 
+/**
+ * No event handler was triggered.
+ */
 Then("no handler fired", (world) =>
     world.plan() === null,
 );
 
+/**
+ * Invalid command handler parameters.
+ */
 Then("handler parameters were invalid", (world) =>
     world.invalidParameters() != null,
 );
 
+/**
+ * The returned plan has no messages.
+ */
 Then("plan has no messages", (world) => {
     return world.plan().messages().length === 0;
 });

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
@@ -5,14 +5,14 @@ import { CloneInfo } from "../ScenarioWorld";
 // Register well-known steps
 
 /**
- * Empty project
+ * Empty project.
  */
 Given("an empty project", (p) => {
     /* Nothing to do */
 });
 
 /**
- * Cloned content from GitHub
+ * Cloned content from GitHub.
  */
 Given("github ([^/]+)/([^/]+)", (p, world, owner: string, name: string) => {
     const repo = new CloneInfo(owner, name);
@@ -20,6 +20,9 @@ Given("github ([^/]+)/([^/]+)", (p, world, owner: string, name: string) => {
     world.setProject(project);
 });
 
+/**
+ * Cloned branch from GitHub.
+ */
 Given("github ([^/]+)/([^/]+)/([^/]+)", (p, world, owner: string, name: string, branch) => {
     const repo = new CloneInfo(owner, name).withBranch(branch);
     const project = world.cloneRepo(repo);
@@ -27,47 +30,50 @@ Given("github ([^/]+)/([^/]+)/([^/]+)", (p, world, owner: string, name: string, 
 });
 
 /**
- * ArchiveRoot project
+ * The entire contents of the Rug archive project.
  */
 Given("the archive root", (p) => {
     p.copyEditorBackingFilesPreservingPath("");
 });
 
 /**
- * The contents of this archive, excluding Atomist content
+ * The contents of this archive, excluding Atomist content.
  */
 Given("archive non Atomist content", (p) => {
     p.copyEditorBackingProject("");
 });
 
 /**
- * Editor made changes
+ * Editor made changes.
  */
 Then("changes were made", (p, world) => {
     return world.modificationsMade();
 });
 
 /**
- * Editor made NoChange
+ * Editor made NoChange.
  */
 Then("no changes were made", (p, world) => {
     return !world.modificationsMade();
 });
 
 /**
- * Valid parameters
+ * Valid parameters.
  */
 Then("parameters were valid", (p, world) => {
     return world.invalidParameters() == null;
 });
 
 /**
- * Invalid parameters
+ * Invalid parameters.
  */
 Then("parameters were invalid", (p, world) => {
     return world.invalidParameters() != null;
 });
 
+/**
+ * Generic file existence check.
+ */
 Then("file at ([^ ]+) should exist", (p, w, path: string) => {
     const f = p.findFile(path);
     if (f == null) {
@@ -75,6 +81,9 @@ Then("file at ([^ ]+) should exist", (p, w, path: string) => {
     }
 });
 
+/**
+ * Generic file content check.
+ */
 Then("file at ([^ ]+) should contain (.*)", (p, w, path: string, lookFor: string) => {
     const f = p.findFile(path);
     if (f == null) {
@@ -88,6 +97,11 @@ Then("file at ([^ ]+) should contain (.*)", (p, w, path: string, lookFor: string
 });
 
 /**
- * When step should fail
+ * When step should fail.
  */
 Then("it should fail", (p, world) => world.failed());
+
+/**
+ * The scenario was aborted due to an exception being thrown.
+ */
+Then("the scenario aborted", (p, w) => w.aborted());

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/ProjectTestTargets.scala
@@ -60,6 +60,23 @@ object ProjectTestTargets {
     ".atomist/tests/project/Generation.feature",
     GenerationFeature)
 
+  val GenerationFailureFeature =
+    """
+      |Feature: Generate a new project
+      |  This is a test
+      |  to see whether
+      |  we can test project generators
+      |
+      |  Scenario: New project should have content from template
+      |    Given an empty project
+      |    When run simple generator
+      |    Then the scenario aborted
+      |""".stripMargin
+
+  val GenerationFailureFeatureFile = StringFileArtifact(
+    ".atomist/tests/project/Generation.feature",
+    GenerationFailureFeature)
+
   /**
     * @param params map to string representation of param, e.g. including "
     */


### PR DESCRIPTION
Add special case of Gherkin `Then` case allowing tests to see if a
scenario was aborted due to an exception being thrown.  Add TypeScript
`Then the scenario was aborted` step implementation so it can be
discovered but it is not actually used.

Add Typescript `Given nothing` step implementation for command handler
testing.

Fix test that was passing due to the wrong failure, adding assertion
to make sure it does not happen again.

Clean up change log.

Closes #569 