### PR TITLE
Report unimplemented Given/When Gherkin steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   **BREAKING** Removed Spring and Spring project types. These don't belong in
     `rug` and will resurface in a separate project.
-    
+
 -   Add instructions to DirectedMessage and ResponseMessage.  Add optional id to
     Presentable instruction.
+-   Missing implementations of Given and When steps now are returned
+    as NotYetImplemented in testing results [#570][570]
 
 ### Fixed
 
@@ -35,7 +37,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     in an archive https://github.com/atomist/rug/issues/561
 
 -   Fix StackOverflow when calling toString on LinkableContainerTreeNode.
-    Can't recurse as this is a graph not a tree. 
+    Can't recurse as this is a graph not a tree.
+
+[570]: https://github.com/atomist/rug/issues/570
 
 ## [1.0.0-m.2] - 2017-04-26
 

--- a/src/test/scala/com/atomist/rug/test/gherkin/GherkinReaderTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/GherkinReaderTest.scala
@@ -72,8 +72,52 @@ object GherkinReaderTest {
       |    Then everything's done
     """.stripMargin
 
+  val NotImplementedGivenFeature =
+    """
+      |Feature: Australian political history
+      |  This is a test
+      |  to demonstrate that the Gherkin DSL
+      |  is a good fit for Rug BDD testing
+      |
+      |  Scenario: Australian politics, 1972-1991
+      |    Given an empty project
+      |    Given a visionary leader
+      |    Given rising inequality
+      |    When politics takes its course
+      |    Then parameters were valid
+      |    Then changes were made
+      |    Then one edit was made
+      |    Then the rage is maintained
+      |    Then the rage has a name
+    """.stripMargin
+
+  val NotImplementedWhenFeature =
+    """
+      |Feature: Australian political history
+      |  This is a test
+      |  to demonstrate that the Gherkin DSL
+      |  is a good fit for Rug BDD testing
+      |
+      |  Scenario: Australian politics, 1972-1991
+      |    Given an empty project
+      |    Given a visionary leader
+      |    When politics takes its course
+      |    When income disparity widens
+      |    Then parameters were valid
+      |    Then changes were made
+      |    Then one edit was made
+      |    Then the rage is maintained
+      |    Then the rage has a name
+    """.stripMargin
+
   val SimpleFeatureFile = StringFileArtifact(".atomist/tests/project/Simple.feature", Simple)
 
   val TwoScenarioFeatureFile = StringFileArtifact(".atomist/tests/project/Two.feature", TwoScenarios)
+
+  val NotImplementedGivenFeatureFile = StringFileArtifact(".atomist/tests/project/NotImplemented.feature",
+    NotImplementedGivenFeature)
+
+  val NotImplementedWhenFeatureFile = StringFileArtifact(".atomist/tests/project/NotImplemented.feature",
+    NotImplementedWhenFeature)
 
 }

--- a/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
+++ b/src/test/scala/com/atomist/rug/test/gherkin/project/GherkinRunnerAgainstProjectTest.scala
@@ -46,6 +46,22 @@ class GherkinRunnerAgainstProjectTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "fail if Given step is not implemented" in {
+    val as = SimpleFileBasedArtifactSource(NotImplementedGivenFeatureFile, PassingSimpleTsFile)
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas))
+    val run = grt.execute()
+    assert(run.result.isInstanceOf[NotYetImplemented])
+  }
+
+  it should "fail if When step is not implemented" in {
+    val as = SimpleFileBasedArtifactSource(NotImplementedWhenFeatureFile, PassingSimpleTsFile)
+    val cas = TypeScriptBuilder.compileWithModel(as)
+    val grt = new GherkinRunner(new JavaScriptContext(cas))
+    val run = grt.execute()
+    assert(run.result.isInstanceOf[NotYetImplemented])
+  }
+
   it should "run an editor without parameters" in {
     val as = SimpleFileBasedArtifactSource(
       alpEditorsFile,


### PR DESCRIPTION
Include unimplemented TypeScript Given and When steps in the testing
results.  The CLI seems to handle the change fine, reporting them in
the same manner it does unimplemented Then steps.

Closes #570