### PR TITLE
Use TypeScript classname if name parameter to decorator not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   If the first parameter to a Rug Kind TypeScript decorator is
+    omitted, the constructor's name is used instead. E.g. it is now
+    possible to declare a command handler with:
+    `@CommandHandler("description only")`
 -   **BREAKING** Gherkin handler step 'parameters were invalid'
     renamed to 'handler parameters were invalid' [#566][566]
 -   **BREAKING** Removed Spring and Spring project types, these don't

--- a/src/main/scala/com/atomist/rug/BadRugException.scala
+++ b/src/main/scala/com/atomist/rug/BadRugException.scala
@@ -78,8 +78,8 @@ class InvalidSecretException(msg: String)
 class RugNotFoundException(msg: String)
   extends BadRugException(msg)
 
-class BadPlanException(msg: String)
-  extends BadRugException(msg)
+class BadPlanException(msg: String, rootCause: Throwable = null)
+  extends BadRugException(msg, rootCause)
 
 class MissingRugException(msg: String)
   extends BadRugException(msg)

--- a/src/main/scala/com/atomist/rug/runtime/js/BaseJavaScriptHandlerFinder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/BaseJavaScriptHandlerFinder.scala
@@ -2,9 +2,12 @@ package com.atomist.rug.runtime.js
 
 import com.atomist.param.{Parameter, Tag}
 import com.atomist.project.archive.RugResolver
+import com.atomist.rug.BadPlanException
 import com.atomist.rug.runtime.Rug
 import jdk.nashorn.api.scripting.ScriptObjectMirror
+
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 /**
   * Some common things used to extract handlers from nashorn
@@ -41,12 +44,22 @@ abstract class BaseJavaScriptHandlerFinder[T <: Rug]
     * Is the supplied thing valid at all?
     */
   protected def isValidHandler(obj: ScriptObjectMirror): Boolean = {
-    obj.hasMember("__kind") && obj.hasMember("__name") && obj.hasMember("__description") && obj.hasMember("handle")
+    obj.hasMember("__kind") && obj.hasMember("__description") && obj.hasMember("handle") &&
+      (obj.hasMember("__name") || obj.hasMember("constructor"))
   }
 
   protected def extractHandler(jsc: JavaScriptContext, handler: ScriptObjectMirror): Option[T]
 
-  protected def name(obj: ScriptObjectMirror): String = obj.getMember("__name").asInstanceOf[String]
+  protected def name(obj: ScriptObjectMirror): String = {
+    if(obj.hasMember("__name")){
+      obj.getMember("__name").asInstanceOf[String]
+    }else{
+      Try(obj.getMember("constructor").asInstanceOf[ScriptObjectMirror].getMember("name").asInstanceOf[String]) match {
+        case Success(name) => name
+        case Failure(error) => throw new BadPlanException(s"Could not determine name of Rug", error)
+      }
+    }
+  }
 
   protected def description(obj: ScriptObjectMirror): String = obj.getMember("__description").asInstanceOf[String]
 

--- a/src/main/typescript/node_modules/@atomist/rug/operations/Decorators.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/operations/Decorators.ts
@@ -54,14 +54,18 @@ function MappedParameter(foreignKey: string) {
  */
 
 function ruglike(fn: string, kind: string, msg: string) {
-  return (name: string, description: string) => {
+  return (nameOrDescription: string, description?: string) => {
     // tslint:disable-next-line:ban-types
     return (ctr: Function) => {
       if (typeof ctr.prototype[fn] !== "function") {
         throw new Error(`${msg}`);
       }
-      ctr.prototype.__name = name;
-      ctr.prototype.__description = description;
+      if (description === undefined) {
+        ctr.prototype.__description = nameOrDescription;
+      }else {
+        ctr.prototype.__description = description;
+        ctr.prototype.__name = nameOrDescription;
+      }
       ctr.prototype.__kind = kind;
     };
   };

--- a/src/test/resources/com/atomist/rug/runtime/js/interop/HandlerWithoutExplicitName.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/interop/HandlerWithoutExplicitName.ts
@@ -1,0 +1,15 @@
+import {HandleCommand, HandleResponse, ResponseMessage, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
+import {CommandHandler, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+
+@CommandHandler("Have a function throw an exception")
+class FunctionKiller implements HandleCommand{
+
+  handle(ctx: HandlerContext) : CommandPlan {
+
+    let result = new CommandPlan()
+    result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "woot", exception: true}},});
+    return result;
+  }
+}
+
+export let command = new FunctionKiller();

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
@@ -233,6 +233,17 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
     assert(plan.messages.head.asInstanceOf[LocallyRenderedMessage].instructions.head.id.get === "123")
   }
 
+  val handlerWithoutExplicitName =
+    StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
+      contentOf(this, "HandlerWithoutExplicitName.ts"))
+
+  it should "should be able to extract name from constructor" in {
+    val rugArchive = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(handlerWithoutExplicitName))
+    val resolver = SimpleRugResolver(rugArchive)
+    val rugs = resolver.resolvedDependencies.rugs
+    val com = rugs.commandHandlers.head
+    assert(com.name == "FunctionKiller")
+  }
 }
 
 class TestResponseHandler(r: ResponseHandler) extends ResponseHandler {


### PR DESCRIPTION
I didn't know this was possible before, and it won't work if we use other ways of constructing things, but should be OK for whenever we use the class decorators.