### PR TITLE
Add types to Gherkin well-known steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Added ability to indicate in TypeScript generated interfaces when a
     JVM method being exposed is marked as `@Deprecated`
 -   Ability to test when a scenario aborts [#569][569]
+-   Types to Gherkin well-known step callback signatures [#574][574]
 
 ### Changed
 
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [566]: https://github.com/atomist/rug/issues/566
 [561]: https://github.com/atomist/rug/issues/561
 [570]: https://github.com/atomist/rug/issues/570
+[574]: https://github.com/atomist/rug/issues/574
 
 ## [1.0.0-m.2] - 2017-04-26
 

--- a/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/AbstractExecutableFeature.scala
@@ -85,7 +85,7 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
             AssertionResult(step.getText, Failed(t.getMessage))
         }
       case None =>
-        AssertionResult(step.getText, NotYetImplemented(step.getText))
+        AssertionResult(step.getText, NotYetImplemented("Then " + step.getText))
     }
   }
 
@@ -113,7 +113,7 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
             None
         }
       case None =>
-        Some(AssertionResult(step.getText, NotYetImplemented(step.getText)))
+        Some(AssertionResult(step.getText, NotYetImplemented("When " + step.getText)))
     }
   }
 
@@ -132,7 +132,7 @@ abstract class AbstractExecutableFeature[W <: ScenarioWorld](
             None
         }
       case None =>
-        Some(AssertionResult(step.getText, NotYetImplemented(step.getText)))
+        Some(AssertionResult(step.getText, NotYetImplemented("Given " + step.getText)))
     }
   }
 

--- a/src/main/typescript/node_modules/@atomist/rug/test/Result.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/Result.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Result of executing a single test.
  */

--- a/src/main/typescript/node_modules/@atomist/rug/test/ScenarioWorld.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/ScenarioWorld.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Project } from "../model/Project";
 
 /**

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/Core.ts
@@ -1,9 +1,26 @@
-import { Project } from "../../model/Core";
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project } from "../../model/Project";
 import { CommandPlan, EventPlan, Plan } from "../../operations/Handlers";
 import { GraphNode } from "../../tree/PathExpression";
 import { Result } from "../Result";
 import { RepoId, ScenarioWorld } from "../ScenarioWorld";
 import "./WellKnownSteps";
+
 /**
  * All handler scenario worlds expose the plan,
  * if constructed by code under test.

--- a/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/handler/WellKnownSteps.ts
@@ -1,36 +1,63 @@
-import { Given, Then, When } from "./Core";
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    CommandHandlerScenarioWorld, EventHandlerScenarioWorld, Given, Then, When,
+} from "./Core";
 
 // Register well-known steps
 
 /**
  * Nothing.  Typical starting point for command handler testing.
  */
-Given("nothing", (w) => { return; });
+Given("nothing", (w: CommandHandlerScenarioWorld) => {
+    return;
+});
 
 /**
  * Generic event handler registrtion.
  */
-Given("([a-zA-Z0-9]+) handler", (world, handlerName) =>
-    world.registerHandler(handlerName),
-);
+Given("([a-zA-Z0-9]+) handler", (w: EventHandlerScenarioWorld, handlerName: string) => {
+    w.registerHandler(handlerName);
+});
 
 /**
  * No event handler was triggered.
  */
-Then("no handler fired", (world) =>
-    world.plan() === null,
-);
+Then("no handler fired", (w: EventHandlerScenarioWorld) => {
+    return w.plan() === null;
+});
+
+/**
+ * Valid command handler parameters.
+ */
+Then("handler parameters were valid", (w: CommandHandlerScenarioWorld) => {
+    return w.invalidParameters() === null;
+});
 
 /**
  * Invalid command handler parameters.
  */
-Then("handler parameters were invalid", (world) =>
-    world.invalidParameters() != null,
-);
+Then("handler parameters were invalid", (w: CommandHandlerScenarioWorld) => {
+    return w.invalidParameters() !== null;
+});
 
 /**
  * The returned plan has no messages.
  */
-Then("plan has no messages", (world) => {
-    return world.plan().messages().length === 0;
+Then("plan has no messages", (world: CommandHandlerScenarioWorld | EventHandlerScenarioWorld) => {
+    return world.plan().messages.length === 0;
 });

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/Core.ts
@@ -1,4 +1,20 @@
-import { Project } from "../../model/Core";
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project } from "../../model/Project";
 import { ProjectEditor } from "../../operations/ProjectEditor";
 import { ProjectGenerator } from "../../operations/ProjectGenerator";
 import { Result } from "../Result";
@@ -37,12 +53,12 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
     generateWith(gen: ProjectGenerator, projectName: string, params: {});
 
     /**
-     * How many modifications did editors in this scenario make?  Note
+     * Did the editor make modifications in this scenario?  Note
      * the initial population of a project prior to entering the
      * generator 'populate' method does not contribute to the number
      * of modifications returned by this method.
      */
-    modificationsMade(): number;
+    modificationsMade(): boolean;
 
     /**
      * Did editing fail?

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/Helpers.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/Helpers.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { File, Project } from "../../model/Core";
 
 /**

--- a/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
+++ b/src/main/typescript/node_modules/@atomist/rug/test/project/WellKnownSteps.ts
@@ -1,107 +1,124 @@
-import { Given, Then, When } from "./Core";
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Given, ProjectScenarioWorld, Then, When } from "./Core";
 
 import { CloneInfo } from "../ScenarioWorld";
+
+import { Project } from "../../model/Project";
 
 // Register well-known steps
 
 /**
  * Empty project.
  */
-Given("an empty project", (p) => {
-    /* Nothing to do */
+Given("an empty project", (p: Project) => {
+    return;
 });
 
 /**
  * Cloned content from GitHub.
  */
-Given("github ([^/]+)/([^/]+)", (p, world, owner: string, name: string) => {
-    const repo = new CloneInfo(owner, name);
-    const project = world.cloneRepo(repo);
-    world.setProject(project);
-});
+Given("github ([^/]+)/([^/]+)",
+    (p: Project, w: ProjectScenarioWorld, owner: string, name: string) => {
+        const repo = new CloneInfo(owner, name);
+        const project = w.cloneRepo(repo);
+        w.setProject(project);
+    },
+);
 
 /**
  * Cloned branch from GitHub.
  */
-Given("github ([^/]+)/([^/]+)/([^/]+)", (p, world, owner: string, name: string, branch) => {
-    const repo = new CloneInfo(owner, name).withBranch(branch);
-    const project = world.cloneRepo(repo);
-    world.setProject(project);
-});
+Given("github ([^/]+)/([^/]+)/([^/]+)",
+    (p: Project, w: ProjectScenarioWorld, owner: string, name: string, branch: string) => {
+        const repo = new CloneInfo(owner, name).withBranch(branch);
+        const project = w.cloneRepo(repo);
+        w.setProject(project);
+    },
+);
 
 /**
  * The entire contents of the Rug archive project.
  */
-Given("the archive root", (p) => {
+Given("the archive root", (p: Project) => {
     p.copyEditorBackingFilesPreservingPath("");
 });
 
 /**
  * The contents of this archive, excluding Atomist content.
  */
-Given("archive non Atomist content", (p) => {
-    p.copyEditorBackingProject("");
+Given("archive non Atomist content", (p: Project) => {
+    p.copyEditorBackingProject();
 });
 
 /**
  * Editor made changes.
  */
-Then("changes were made", (p, world) => {
-    return world.modificationsMade();
+Then("changes were made", (p: Project, w: ProjectScenarioWorld) => {
+    return w.modificationsMade();
 });
 
 /**
  * Editor made NoChange.
  */
-Then("no changes were made", (p, world) => {
-    return !world.modificationsMade();
+Then("no changes were made", (p: Project, w: ProjectScenarioWorld) => {
+    return !w.modificationsMade();
 });
 
 /**
  * Valid parameters.
  */
-Then("parameters were valid", (p, world) => {
-    return world.invalidParameters() == null;
+Then("parameters were valid", (p: Project, w: ProjectScenarioWorld) => {
+    return w.invalidParameters() === null;
 });
 
 /**
  * Invalid parameters.
  */
-Then("parameters were invalid", (p, world) => {
-    return world.invalidParameters() != null;
+Then("parameters were invalid", (p: Project, w: ProjectScenarioWorld) => {
+    return w.invalidParameters() !== null;
 });
 
 /**
  * Generic file existence check.
  */
-Then("file at ([^ ]+) should exist", (p, w, path: string) => {
-    const f = p.findFile(path);
-    if (f == null) {
-        throw new Error(`File at [${path}] expected, but not found`);
-    }
+Then("file at ([^ ]+) should exist", (p: Project, w: ProjectScenarioWorld, path: string) => {
+    return p.fileExists(path);
 });
 
 /**
  * Generic file content check.
  */
-Then("file at ([^ ]+) should contain (.*)", (p, w, path: string, lookFor: string) => {
-    const f = p.findFile(path);
-    if (f == null) {
-        throw new Error(`File at [${path}] expected, but not found`);
-    }
-
-    const idx = f.content.indexOf(lookFor);
-    if (idx === -1) {
-        throw new Error(`File at [${path}] did not contain [${lookFor}]. Content was\n${f.content}`);
-    }
-});
+Then("file at ([^ ]+) should contain (.*)",
+    (p: Project, w: ProjectScenarioWorld, path: string, searchString: string) => {
+        return p.fileContains(path, searchString);
+    },
+);
 
 /**
  * When step should fail.
  */
-Then("it should fail", (p, world) => world.failed());
+Then("it should fail", (p: Project, w: ProjectScenarioWorld) => {
+    w.failed();
+});
 
 /**
  * The scenario was aborted due to an exception being thrown.
  */
-Then("the scenario aborted", (p, w) => w.aborted());
+Then("the scenario aborted", (p: Project, w: ProjectScenarioWorld) => {
+    w.aborted();
+});


### PR DESCRIPTION
Add types to callback signatures of TypeScript implementations of the
Gherkin well-known steps for projects and handlers.  This uncovered a
few errors, including:

-   The Scala implementation of ProjectScenarioWorld.modificationsMade()
    returns a boolean, so changed its TypeScript interface to do the
    same
-   The Scala implementation of
    ProjectMutableView.copyEditorBackingProject() takes no arguments,
    so changed its use in the Given step to not pass any

Using specific types for the world parameter was preferred to using
the more generic, e.g., CommandHandlerScenarioWorld was used
preferentially to ScenarioWorld where possible.

Consistent names for the project and world callback arguments.

Closes #574

Add copyright and license information.

Import from specific files rather than mode/Core.

Include step name in unimplemented error, see #570.