### PR TITLE
Make HandlerContext available to ResponseHandlers #587

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Added `HandlerContext` as second parameter to `ResponseHandler.handle`
+    invocations [587]
 -   Added `Identifiable` instruction that can be used for `DirectedMessage`
     and `ResponseMessage`
 
@@ -29,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Fixed handling of fields set with Object.defineProperty (now enumerable)
 -   @Editor, @Generator, and @EventHandler decorators now allow 'name' to be
     omitted. If you omit the name, it uses the name of the class.
+
+[587]: https://github.com/atomist/rug/issues/587
 
 ## [1.0.0-m.3] - 2017-05-09
 

--- a/src/main/scala/com/atomist/rug/runtime/ResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/ResponseHandler.scala
@@ -1,11 +1,12 @@
 package com.atomist.rug.runtime
 
 import com.atomist.param.ParameterValues
+import com.atomist.rug.runtime.js.RugContext
 import com.atomist.rug.spi.Handlers.{Plan, Response}
 
 /**
   * Handles responses from other Rugs & Executions
   */
 trait ResponseHandler extends ParameterizedRug{
-  def handle(response: Response, params: ParameterValues) : Option[Plan]
+  def handle(ctx: RugContext, response: Response, params: ParameterValues) : Option[Plan]
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
@@ -52,7 +52,7 @@ class JavaScriptResponseHandler (jsc: JavaScriptContext,
     with ParameterizedSupport
     with JavaScriptUtils {
 
-  override def handle(response: Response, params: ParameterValues): Option[Plan] = {
+  override def handle(ctx: RugContext, response: Response, params: ParameterValues): Option[Plan] = {
     //TODO this handle method is almost identical to the command handler - extract it
     val validated = addDefaultParameterValues(params)
     validateParameters(validated)
@@ -62,7 +62,8 @@ class JavaScriptResponseHandler (jsc: JavaScriptContext,
       handler,
       "handle",
       Some(validated),
-      jsScalaHidingProxy(jsResponse(coerced.msg.orNull, coerced.code.getOrElse(-1), coerced.body.getOrElse(Nil)))) match {
+      jsScalaHidingProxy(jsResponse(coerced.msg.orNull, coerced.code.getOrElse(-1), coerced.body.getOrElse(Nil))),
+      jsScalaHidingProxy(ctx)) match {
       case plan: ScriptObjectMirror => ConstructPlan(plan, Some(this))
       case other => throw new InvalidHandlerResultException(s"$name ResponseHandler did not return a recognized response ($other) when invoked with ${params.toString()}")
     }

--- a/src/main/scala/com/atomist/rug/runtime/plans/LocalInstructionRunner.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/LocalInstructionRunner.scala
@@ -93,7 +93,7 @@ class LocalInstructionRunner(currentRug: Rug,
               case Some(rug: ResponseHandler) =>
                 callbackInput match {
                   case Some(response) =>
-                    val planOption = rug.handle(response, parameters)
+                    val planOption = rug.handle(rugContext, response, parameters)
                     Response(Success, None, None, planOption)
                   case c =>
                     throw new BadPlanException(s"Callback input was not recognized: $c")

--- a/src/main/typescript/rug/operations/Handlers.ts
+++ b/src/main/typescript/rug/operations/Handlers.ts
@@ -1,4 +1,3 @@
-import { Parameter } from "./RugOperation";
 import {
   GraphNode,
   Match,
@@ -6,6 +5,7 @@ import {
   PathExpressionEngine,
   TreeNode,
 } from "../tree/PathExpression";
+import { Parameter } from "./RugOperation";
 
 export interface RugCoordinate {
   readonly name: string;
@@ -115,7 +115,7 @@ export interface HandleEvent<R extends GraphNode, M extends GraphNode> {
 }
 
 export interface HandleResponse<T> {
-  handle(response: Response<T>): EventPlan | CommandPlan;
+  handle(response: Response<T>, ctx?: HandlerContext): EventPlan | CommandPlan;
 }
 
 /**

--- a/src/test/resources/com/atomist/rug/runtime/js/ResponseHandlerAccessingContext.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/ResponseHandlerAccessingContext.ts
@@ -1,0 +1,18 @@
+import {Respond, Instruction, Response, CommandPlan, HandlerContext} from '@atomist/rug/operations/Handlers'
+import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
+import {EventHandler, ParseJson, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+import {Project} from '@atomist/rug/model/Core'
+import {HandleResponse, HandleEvent, HandleCommand} from '@atomist/rug/operations/Handlers'
+
+@ResponseHandler("kittyDesc")
+class KittiesResponder implements HandleResponse<any>{
+ handle(response: Response<any>, ctx: HandlerContext) : CommandPlan {
+
+    if(!ctx.pathExpressionEngine){
+        throw new Error("It's got nothing to to with 'nam, Walter!");
+    }
+    return new CommandPlan();
+  }
+}
+
+export let kit = new KittiesResponder();

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
@@ -248,7 +248,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
 
 class TestResponseHandler(r: ResponseHandler) extends ResponseHandler {
 
-  override def handle(response: Response, params: ParameterValues): Option[Plan] = {
+  override def handle(ctx: RugContext, response: Response, params: ParameterValues): Option[Plan] = {
     None
   }
 


### PR DESCRIPTION
It's optional in the `HandleResponse` interface, and is exactly the same as that exposed in CommandHandlers...just EventHandlers to go! ;)