### PR TITLE
Add ability to start a generator with an empty repo or Git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Ability to implement the `startingPoint` method in a generator to
+    start with an empty repo or the content of a Git repo, if the runtime permits.
 -   Added `HandlerContext` as second parameter to `ResponseHandler.handle`
     invocations [587]
 -   Added `Identifiable` instruction that can be used for `DirectedMessage`

--- a/src/main/scala/com/atomist/project/generate/ProjectGenerator.scala
+++ b/src/main/scala/com/atomist/project/generate/ProjectGenerator.scala
@@ -3,6 +3,8 @@ package com.atomist.project.generate
 import com.atomist.param.ParameterValues
 import com.atomist.project.ProjectOperation
 import com.atomist.project.common.InvalidParametersException
+import com.atomist.rug.kind.core.ProjectContext
+import com.atomist.rug.runtime.js.LocalRugContext
 import com.atomist.source.ArtifactSource
 
 /**
@@ -14,5 +16,5 @@ trait ProjectGenerator
   extends ProjectOperation {
 
   @throws(classOf[InvalidParametersException])
-  def generate(projectName: String, poa: ParameterValues): ArtifactSource
+  def generate(projectName: String, pvs: ParameterValues, ProjectContext: ProjectContext = new ProjectContext(LocalRugContext)): ArtifactSource
 }

--- a/src/main/scala/com/atomist/rug/kind/core/ProjectMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/core/ProjectMutableView.scala
@@ -567,4 +567,9 @@ class ProjectContext(ctx: RugContext) extends RugContext {
   override def treeMaterializer: TreeMaterializer = ctx.treeMaterializer
 
   override def contextRoot(): GraphNode = ctx.contextRoot()
+
+  def gitProjectLoader: AnyRef = new jsGitProjectLoader(ctx.repoResolver)
+
+  @ExposeAsFunction
+  def emptyProject() = new ProjectMutableView(originalBackingObject = EmptyArtifactSource("!!ThisValueWillBeOverwritten"))
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsGitProjectLoader.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsGitProjectLoader.scala
@@ -1,0 +1,31 @@
+package com.atomist.rug.runtime.js.interop
+
+import com.atomist.rug.kind.core.{ProjectMutableView, RepoResolver}
+
+/**
+  * Backs the TypeScript GitProjectLoader interface
+  */
+class jsGitProjectLoader(rr: Option[RepoResolver]) {
+
+  /**
+    * Resolve the latest in the given branch. Throw exception if unable to.
+    */
+  def loadBranch(owner: String, repoName: String, branch: String): ProjectMutableView = {
+    val as = rr.map(_.resolveBranch(owner, repoName, branch)).getOrElse(
+      throw new IllegalStateException(s"No RepoResolver available to resolve $owner:$repoName:branch=$branch")
+    )
+    new ProjectMutableView(originalBackingObject = as)
+  }
+
+  /**
+    * Resolve the tree for this sha. Throw exception if unable to.
+    */
+  def loadSha(owner: String, repoName: String, sha: String): ProjectMutableView = {
+    val as = rr.map(_.resolveSha(owner, repoName, sha)).getOrElse(
+      throw new IllegalStateException(s"No RepoResolver available to resolve $owner:$repoName:sha=$sha")
+    )
+    new ProjectMutableView(originalBackingObject = as)
+  }
+
+}
+

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
@@ -6,8 +6,8 @@ import com.atomist.project.common.InvalidParametersException
 import com.atomist.project.edit.{FailedModificationAttempt, ModificationAttempt, ProjectEditor, SuccessfulModification}
 import com.atomist.project.generate.ProjectGenerator
 import com.atomist.rug.RugNotFoundException
-import com.atomist.rug.kind.core.ProjectMutableView
-import com.atomist.rug.runtime.js.JavaScriptProjectOperation
+import com.atomist.rug.kind.core.{ProjectContext, ProjectMutableView}
+import com.atomist.rug.runtime.js.{JavaScriptProjectOperation, LocalRugContext}
 import com.atomist.rug.runtime.js.interop.NashornUtils
 import com.atomist.rug.test.gherkin._
 import com.atomist.source.EmptyArtifactSource
@@ -67,7 +67,7 @@ class ProjectScenarioWorld(
     * We expect the JavaScript op to have been populated.
     */
   def generateWith(generator: ProjectGenerator, projectName: String, params: Any): Unit = {
-    val resultAs = generator.generate(projectName, parameters(params))
+    val resultAs = generator.generate(projectName, parameters(params), new ProjectContext(LocalRugContext))
     project.updateTo(resultAs)
   }
 

--- a/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
@@ -5,6 +5,7 @@ import com.atomist.param.{Parameter, ParameterValues, Tag}
 import com.atomist.project.common.InvalidParametersException
 import com.atomist.project.edit._
 import com.atomist.project.generate.ProjectGenerator
+import com.atomist.rug.kind.core.ProjectContext
 import com.atomist.rug.spi.ReflectiveFunctionExport.exportedOperations
 import com.atomist.rug.spi._
 import com.atomist.source._
@@ -151,9 +152,9 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
     .setDefaultValue(DefaultFilename))
 
   @throws[InvalidParametersException](classOf[InvalidParametersException])
-  override def generate(projectName: String, poa: ParameterValues): ArtifactSource = {
-    val createdFiles = emitTypes(poa)
-    new SimpleFileBasedArtifactSource("Rug user model", createdFiles ++ emitCombinedTypes(poa))
+  override def generate(projectName: String, pvs: ParameterValues, ctx: ProjectContext): ArtifactSource = {
+    val createdFiles = emitTypes(pvs)
+    new SimpleFileBasedArtifactSource("Rug user model", createdFiles ++ emitCombinedTypes(pvs))
   }
 
   override def modify(as: ArtifactSource, poa: ParameterValues): ModificationAttempt = {

--- a/src/main/typescript/rug/operations/GitProjectLoader.ts
+++ b/src/main/typescript/rug/operations/GitProjectLoader.ts
@@ -1,0 +1,19 @@
+
+import { Project } from "../model/Core";
+
+/**
+ * Use to load projects backed by git repositories.
+ */
+export interface GitProjectLoader {
+
+    /**
+     * Resolve the latest in the given branch. Throw exception if not found.
+     */
+     loadBranch(owner: string, repoName: string, branch: string): Project;
+
+    /**
+     * Resolve the tree for this sha. Throw exception if not found.
+     */
+    loadSha(owner: string, repoName: string, sha: string): Project;
+
+}

--- a/src/main/typescript/rug/operations/ProjectEditor.ts
+++ b/src/main/typescript/rug/operations/ProjectEditor.ts
@@ -1,6 +1,6 @@
 import { Project } from "../model/Core";
 import { PathExpressionEngine } from "../tree/PathExpression";
-import { RugOperation } from "./RugOperation";
+import { GitProjectLoader } from "./GitProjectLoader";
 
 export interface ProjectContext {
 
@@ -8,6 +8,17 @@ export interface ProjectContext {
    * Use to run path expressions against any node available in a project operation
    */
   pathExpressionEngine: PathExpressionEngine;
+
+  /**
+   * RepoResolver to use in loading repositories.
+   */
+  gitProjectLoader: GitProjectLoader;
+
+  /**
+   * Create an empty project
+   */
+  emptyProject();
+
 }
 
 export interface EditProject {

--- a/src/test/scala/com/atomist/rug/runtime/js/EditorTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/EditorTest.scala
@@ -4,6 +4,7 @@ import com.atomist.param.{ParameterValues, SimpleParameterValues, Tag}
 import com.atomist.project.ProjectOperation
 import com.atomist.project.common.IllformedParametersException
 import com.atomist.project.edit._
+import com.atomist.rug.kind.core.{FixedBranchRepoResolver, ProjectContext, ProjectMutableView, RepoResolver}
 import com.atomist.rug.{RugArchiveReader, SimpleRugResolver, TestUtils}
 import com.atomist.rug.ts.TypeScriptBuilder
 import com.atomist.source.{ArtifactSource, FileArtifact, SimpleFileBasedArtifactSource, StringFileArtifact}
@@ -34,20 +35,20 @@ object EditorTest {
 
   val SimpleEditorWithBasicParameter =
     s"""
-      |import {Project} from '@atomist/rug/model/Core'
-      |import {Parameter, Editor} from '@atomist/rug/operations/Decorators'
-      |
+       |import {Project} from '@atomist/rug/model/Core'
+       |import {Parameter, Editor} from '@atomist/rug/operations/Decorators'
+       |
       |@Editor("Simple", "My simple editor")
-      |class SimpleEditor {
-      |
+       |class SimpleEditor {
+       |
       |    @Parameter({description: "Content", pattern: "$ContentPattern"})
-      |    content: string
-      |
+       |    content: string
+       |
       |    edit(project: Project)  {
-      |        project.addFile("src/from/typescript", "Anders Hjelsberg is God")
-      |    }
-      |}
-      |export let myeditor = new SimpleEditor()
+       |        project.addFile("src/from/typescript", "Anders Hjelsberg is God")
+       |    }
+       |}
+       |export let myeditor = new SimpleEditor()
     """.stripMargin
 
   val SimpleEditorWithBasicNameParameter =
@@ -173,6 +174,60 @@ object EditorTest {
       |export let gen = new SimpleGenerator()
     """.stripMargin
 
+  val SimpleGeneratorLoadingEmptyRepo =
+    """
+      |import {Project} from '@atomist/rug/model/Core'
+      |import {ProjectContext} from '@atomist/rug/operations/ProjectEditor'
+      |import {Generator} from '@atomist/rug/operations/Decorators'
+      |
+      |@Generator("My simple Generator")
+      |class SimpleGenerator {
+      |
+      |     content: string = "woot"
+      |
+      |     startingPoint(defaultProject: Project, pc: ProjectContext): Project {
+      |       return pc.emptyProject();
+      |     }
+      |
+      |     populate(project: Project) {
+      |        let len: number = this.content.length;
+      |        if(project.name != "woot"){
+      |           throw Error(`Project name should be woot, but was ${project.name}`)
+      |        }
+      |        if (project.totalFileCount != 0) throw "I got files";
+      |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
+      |    }
+      |}
+      |export let gen = new SimpleGenerator()
+    """.stripMargin
+
+  val SimpleGeneratorLoadingExternalRepo =
+    """
+      |import {Project} from '@atomist/rug/model/Core'
+      |import {ProjectContext} from '@atomist/rug/operations/ProjectEditor'
+      |import {Generator} from '@atomist/rug/operations/Decorators'
+      |
+      |@Generator("My simple Generator")
+      |class SimpleGenerator {
+      |
+      |     content: string = "woot"
+      |
+      |     startingPoint(defaultProject: Project, pc: ProjectContext): Project {
+      |       return pc.gitProjectLoader.loadBranch("atomist", "rug", "master");
+      |     }
+      |
+      |     populate(project: Project) {
+      |        let len: number = this.content.length;
+      |        if(project.name != "woot"){
+      |           throw Error(`Project name should be woot, but was ${project.name}`)
+      |        }
+      |        if (!project.findFile("1")) throw "I got no expected file from git";
+      |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
+      |    }
+      |}
+      |export let gen = new SimpleGenerator()
+    """.stripMargin
+
   val SimpleEditorTaggedAndMeta =
     s"""
        |import {Project} from '@atomist/rug/model/Core'
@@ -195,16 +250,16 @@ object EditorTest {
        |export let myeditor = new SimpleEditor()
     """.stripMargin
 
-    val SimpleTsUtil =
-      """
-        |export class Bar {
-        |   doWork() : void {
-        |      let num: number = 100;
-        |      num += 1;
-        |      //etc.
-        |   }
-        |}
-      """.stripMargin
+  val SimpleTsUtil =
+    """
+      |export class Bar {
+      |   doWork() : void {
+      |      let num: number = 100;
+      |      num += 1;
+      |      //etc.
+      |   }
+      |}
+    """.stripMargin
 
   val SimpleEditorWithRelativeDependency =
     """
@@ -226,44 +281,44 @@ object EditorTest {
       |export let myeditor = new SimpleEditor()
     """.stripMargin
 
-    val EditorInjectedWithPathExpressionObject: String =
-      """import {Project,File} from '@atomist/rug/model/Core'
-        |import {Match, PathExpression, PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
-        |import {Parameter, Editor, Tags} from '@atomist/rug/operations/Decorators'
-        |
-        |class PomFile extends PathExpression<Project,File> {
-        |
-        |    constructor() { super(`/File()[@name='pom.xml']`) }
-        |}
-        |
-        |@Tags("java", "maven")
-        |@Editor("Constructed", "A nice little editor")
-        |class ConstructedEditor {
-        |
-        |    @Parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
-        |    packageName: string
-        |
-        |    edit(project: Project) {
-        |
-        |      let eng: PathExpressionEngine = project.context.pathExpressionEngine;
-        |      let m = eng.evaluate<Project,File>(project, new PomFile())
-        |
-        |      let t: string = `param=${this.packageName},filecount=${m.root.fileCount}`
-        |      for (let n of m.matches) {
-        |        t += `Matched file=${n.path}`;
-        |        n.append("randomness")
-        |        }
-        |
-        |        let s: string = ""
-        |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
-        |        for (let f of project.files)
-        |            s = s + `File [${f.path}] containing [${f.content}]\n`
-        |        project.describeChange(
-        |        `${t}\n\nEdited Project containing ${project.fileCount} files: \n${s}`)
-        |    }
-        |  }
-        |  export let myeditor = new ConstructedEditor()
-        | """.stripMargin
+  val EditorInjectedWithPathExpressionObject: String =
+    """import {Project,File} from '@atomist/rug/model/Core'
+      |import {Match, PathExpression, PathExpressionEngine} from '@atomist/rug/tree/PathExpression'
+      |import {Parameter, Editor, Tags} from '@atomist/rug/operations/Decorators'
+      |
+      |class PomFile extends PathExpression<Project,File> {
+      |
+      |    constructor() { super(`/File()[@name='pom.xml']`) }
+      |}
+      |
+      |@Tags("java", "maven")
+      |@Editor("Constructed", "A nice little editor")
+      |class ConstructedEditor {
+      |
+      |    @Parameter({description: "The Java package name", displayName: "Java Package", pattern: "^.*$", maxLength: 100})
+      |    packageName: string
+      |
+      |    edit(project: Project) {
+      |
+      |      let eng: PathExpressionEngine = project.context.pathExpressionEngine;
+      |      let m = eng.evaluate<Project,File>(project, new PomFile())
+      |
+      |      let t: string = `param=${this.packageName},filecount=${m.root.fileCount}`
+      |      for (let n of m.matches) {
+      |        t += `Matched file=${n.path}`;
+      |        n.append("randomness")
+      |        }
+      |
+      |        let s: string = ""
+      |        project.addFile("src/from/typescript", "Anders Hjelsberg is God");
+      |        for (let f of project.files)
+      |            s = s + `File [${f.path}] containing [${f.content}]\n`
+      |        project.describeChange(
+      |        `${t}\n\nEdited Project containing ${project.fileCount} files: \n${s}`)
+      |    }
+      |  }
+      |  export let myeditor = new ConstructedEditor()
+      | """.stripMargin
 
   val EditorInjectedWithPathExpression: String =
     TestUtils.contentOf(this, "EditorInjectedWithPathExpression.ts")
@@ -314,7 +369,7 @@ class EditorTest extends FlatSpec with Matchers {
 
   import EditorTest._
 
-  it should "allow use of name/description fields if we are using annotations" in {
+  "Editors and Generators" should "allow use of name/description fields if we are using annotations" in {
     invokeAndVerifySimple(StringFileArtifact(s".atomist/editors/SimpleEditor.ts", SimpleEditorWithBasicNameParameter))
   }
 
@@ -400,7 +455,7 @@ class EditorTest extends FlatSpec with Matchers {
   }
 
   it should "have the PathExpressionEngine injected and use an object path expression" in {
-    val (ed,sm) = invokeAndVerifyConstructed(StringFileArtifact(s".atomist/editors/ConstructedEditor.ts",
+    val (ed, sm) = invokeAndVerifyConstructed(StringFileArtifact(s".atomist/editors/ConstructedEditor.ts",
       EditorInjectedWithPathExpressionObject))
     assert(ed.description === "A nice little editor")
     assert(sm.changeLogEntries.size === 1)
@@ -442,7 +497,38 @@ class EditorTest extends FlatSpec with Matchers {
     assert(p.getMaxLength === 100)
   }
 
-  private  def invokeAndVerifyConstructed(tsf: FileArtifact): (JavaScriptProjectEditor, SuccessfulModification) = {
+  it should "load empty repo in generator" in {
+    val tsf = SimpleFileBasedArtifactSource(
+      StringFileArtifact(".atomist/generators/Thing.ts", SimpleGeneratorLoadingEmptyRepo),
+      StringFileArtifact("I dont", "want this"))
+    val as = TypeScriptBuilder.compileWithModel(tsf)
+
+    val jsed = RugArchiveReader(as).generators.head.asInstanceOf[JavaScriptProjectGenerator]
+
+    val prj = jsed.generate("woot", SimpleParameterValues(Map("content" -> "Anders Hjelsberg is God")))
+    jsed
+  }
+
+  it should "load external repo in generator" in {
+    val tsf = SimpleFileBasedArtifactSource(
+      StringFileArtifact(".atomist/generators/Thing.ts", SimpleGeneratorLoadingExternalRepo),
+      StringFileArtifact("I dont", "want this"))
+    val as = TypeScriptBuilder.compileWithModel(tsf)
+
+    val jsed = RugArchiveReader(as).generators.head.asInstanceOf[JavaScriptProjectGenerator]
+
+    val project = SimpleFileBasedArtifactSource(
+      StringFileArtifact("1","1"),
+      StringFileArtifact("2", "2")
+    )
+    val ctx = new ProjectContext(LocalRugContext) {
+      override def repoResolver: Option[RepoResolver] = Some(FixedBranchRepoResolver("atomist", "rug", "master", project))
+    }
+    val prj = jsed.generate("woot", SimpleParameterValues(Map("content" -> "Anders Hjelsberg is God")), ctx)
+    jsed
+  }
+
+  private def invokeAndVerifyConstructed(tsf: FileArtifact): (JavaScriptProjectEditor, SuccessfulModification) = {
     val as = SimpleFileBasedArtifactSource(tsf)
     val jsed = RugArchiveReader(TypeScriptBuilder.compileWithModel(as)).editors.head.asInstanceOf[JavaScriptProjectEditor]
     assert(jsed.name === "Constructed")
@@ -450,25 +536,25 @@ class EditorTest extends FlatSpec with Matchers {
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
     jsed.modify(target, SimpleParameterValues(Map("packageName" -> "com.atomist.crushed"))) match {
       case sm: SuccessfulModification =>
-        sm.result.findFile("pom.xml").get.content.contains("randomness") should be (true)
+        sm.result.findFile("pom.xml").get.content.contains("randomness") should be(true)
         (jsed, sm)
       case _ => ???
     }
   }
 
-  private  def invokeAndVerifySimpleGenerator(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptProjectGenerator = {
+  private def invokeAndVerifySimpleGenerator(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptProjectGenerator = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf))
 
     val jsed = RugArchiveReader(as).generators.head.asInstanceOf[JavaScriptProjectGenerator]
     assert(jsed.name === "SimpleGenerator")
 
-    val prj = jsed.generate("woot", SimpleParameterValues( Map("content" -> "Anders Hjelsberg is God")))
+    val prj = jsed.generate("woot", SimpleParameterValues(Map("content" -> "Anders Hjelsberg is God")))
     assert(prj.id.name === "woot")
 
     jsed
   }
 
-  private  def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptProjectEditor = {
+  private def invokeAndVerifySimple(tsf: FileArtifact): JavaScriptProjectEditor = {
     val as = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(tsf) + StringFileArtifact(s".atomist/editors/OtherEditor.ts", OtherEditor))
 
     val jsed = RugArchiveReader(as).editors.head.asInstanceOf[JavaScriptProjectEditor]
@@ -485,12 +571,12 @@ class EditorTest extends FlatSpec with Matchers {
     jsed
   }
 
-  private  def invokeAndVerifyIdempotentSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptProjectEditor = {
+  private def invokeAndVerifyIdempotentSimple(tsf: FileArtifact, others: Seq[ProjectOperation] = Nil): JavaScriptProjectEditor = {
     val as = SimpleFileBasedArtifactSource(tsf)
     val jsed = RugArchiveReader(TypeScriptBuilder.compileWithModel(as)).editors.head.asInstanceOf[JavaScriptProjectEditor]
     assert(jsed.name === "Simple")
 
-//    jsed.addToArchiveContext(others)
+    //    jsed.addToArchiveContext(others)
 
     val target = SimpleFileBasedArtifactSource(StringFileArtifact("pom.xml", "nasty stuff"))
 
@@ -502,9 +588,9 @@ class EditorTest extends FlatSpec with Matchers {
 
         jsed.modify(sm.result, p) match {
           case _: NoModificationNeeded => //yay
-           //yay
+          //yay
           case sm: SuccessfulModification =>
-              fail("That should not have reported modification")
+            fail("That should not have reported modification")
           case _ => ???
         }
       case _ => ???


### PR DESCRIPTION
Backward compatible. Solves 2 important cases:

- It's now possible to start with an empty repo, regardless of the content of a generator's Rug archive. This is useful when emitting content programmatically, rather than transforming static content.
- It's now possible to start with a git reference. This means we can point a generator at _any_ accessible repo.