### PR TITLE
Be specific about the XML Parser implementation

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/xml/XmlMutableView.scala
+++ b/src/main/scala/com/atomist/rug/kind/xml/XmlMutableView.scala
@@ -23,7 +23,7 @@ object XmlMutableView {
   }
 
   def documentToString(doc: Document): String = {
-    val tf = TransformerFactory.newInstance()
+    val tf = TransformerFactory.newInstance("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl", getClass.getClassLoader)
 
     tf.setAttribute("indent-number", 4)
 


### PR DESCRIPTION
The 'indent-number' property is only implemented by this impl, so specify it.

Without this, any other TransformerFactory on the classpath will be chosen instead. This causes this function to fail sometimes, depending on what other extensions are loaded.