### PR TITLE
Pass parameters to ResponseHandlers blindly if none declared & some passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   Parameters passed to ResponseHandlers with no declared parameters are now
+    set directly on the instance. This can be used to avoid using @Parameter
+    declarations
 -   Handle project generate failures
 -   **BREAKING** remove ProjectEditor & ProjectGenerator interfaces.
     This also removes support for legacy parameter[] Parameter declarations

--- a/src/main/scala/com/atomist/project/archive/ArchiveRugResolver.scala
+++ b/src/main/scala/com/atomist/project/archive/ArchiveRugResolver.scala
@@ -35,7 +35,7 @@ class ArchiveRugResolver(graph: Dependency,
     val found = finders.flatMap(finder => finder.find(jsc, Some(resolver)))
     val grouped = found.groupBy(_.name).collect{case x if x._2.size > 1 => x._1}
     if(grouped.nonEmpty){
-      throw new DuplicateRugException(s"Duplicate rugs found in archive: ${grouped.mkString}", found)
+      throw new DuplicateRugException(s"The following rugs have duplicates in the archive: ${grouped.mkString(", ")}", found)
     }else{
       found
     }

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
@@ -1,6 +1,6 @@
 package com.atomist.rug.runtime.js
 
-import com.atomist.param.{Parameter, ParameterValues, ParameterizedSupport, Tag}
+import com.atomist.param._
 import com.atomist.project.archive.RugResolver
 import com.atomist.rug.runtime.js.interop.jsScalaHidingProxy
 import com.atomist.rug.{InvalidHandlerException, InvalidHandlerResultException}
@@ -66,6 +66,22 @@ class JavaScriptResponseHandler (jsc: JavaScriptContext,
       jsScalaHidingProxy(ctx)) match {
       case plan: ScriptObjectMirror => ConstructPlan(plan, Some(this))
       case other => throw new InvalidHandlerResultException(s"$name ResponseHandler did not return a recognized response ($other) when invoked with ${params.toString()}")
+    }
+  }
+
+  /**
+    * If a field doesn't exist on the handler already, create it,
+    * but only if no @Parameter annotations are there
+    * This is handy to avoid use @Parameter decorators
+    */
+  override protected def setParameters(clone: ScriptObjectMirror, params: Seq[ParameterValue]): Unit = {
+    super.setParameters(clone, params)
+    if(parameters.isEmpty){
+      params.foreach(p => {
+        if(!clone.hasMember(p.getName)){
+          clone.setMember(p.getName, p.getValue);
+        }
+      })
     }
   }
 }

--- a/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/PlanBuilder.scala
@@ -161,6 +161,7 @@ class PlanBuilder {
           o.getMember(name) match {
             case null => false
             case ScriptRuntime.UNDEFINED => false
+            case o: ScriptObjectMirror if o.isFunction => false
             case _ => true
           }
         })

--- a/src/test/resources/com/atomist/rug/runtime/js/ResponseHandlerWithInjectedValues.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/ResponseHandlerWithInjectedValues.ts
@@ -1,0 +1,28 @@
+import {Respond, Instruction, Response, CommandPlan, HandlerContext} from '@atomist/rug/operations/Handlers'
+import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
+import {EventHandler, ParseJson, ResponseHandler, CommandHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+import {Project} from '@atomist/rug/model/Core'
+import {HandleResponse, HandleEvent, HandleCommand} from '@atomist/rug/operations/Handlers'
+
+@ResponseHandler("Description")
+class SomeHandler implements HandleResponse<any>{
+
+
+ public somenum: number; //doesn't appear in JS
+ public something: string = "original";
+
+ handle(response: Response<any>, ctx: HandlerContext) : CommandPlan {
+
+    if(this.somenum === undefined){
+        throw new Error("We should have set this")
+    }
+
+    if(this.something !== "original"){
+        throw new Error("We should not have touched this");
+    }
+
+    return new CommandPlan();
+  }
+}
+
+export let kit = new SomeHandler();

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandlerTest.scala
@@ -115,4 +115,17 @@ class JavaScriptResponseHandlerTest extends FlatSpec with Matchers {
     val response = Response(Status.Success, Some("It worked! :p"), Some(204))
     val plan = handler.handle(LocalRugContext(TestTreeMaterializer), response, SimpleParameterValues.Empty)
   }
+
+  val responseHandlerWithInjectedValues = StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
+    contentOf(this, "ResponseHandlerWithInjectedValues.ts"))
+
+  it should "add set parameters to the handler instance if the field doesn't exist already and there's no parameter annotation" in {
+    val rugArchive = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(responseHandlerWithInjectedValues))
+    val finder = new JavaScriptResponseHandlerFinder()
+    val handlers = finder.find(new JavaScriptContext(rugArchive))
+    handlers.size should be(1)
+    val handler = handlers.head
+    val response = Response(Status.Success, Some("It worked! :p"), Some(204))
+    val plan = handler.handle(LocalRugContext(TestTreeMaterializer), response, SimpleParameterValues(SimpleParameterValue("somenum", "10"), SimpleParameterValue("something", "woot")))
+  }
 }


### PR DESCRIPTION
This enables us to emit handler chains automatically, allow upstream handlers to pass arbitrary parameters to downstream ones, setting the properties directly on the instance (if no property by that name already exists).

I'm using this for auto-generating handler chains, but given the experience is that response handlers are rarely reused/resuable, this could be used generally too.