### PR TITLE
Allow editWith and generateWith world operations without parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   Allow `editWith` and `generateWith` calls in Gherkin tests without parameters
 -   Parameters passed to ResponseHandlers with no declared parameters are now
     set directly on the instance. This can be used to avoid using @Parameter
     declarations
@@ -41,12 +42,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   @Editor, @Generator, and @EventHandler decorators now allow 'name' to be
     omitted. If you omit the name, it uses the name of the class.
 
-<<<<<<< HEAD
+
 [593]: https://github.com/atomist/rug/issues/593
-=======
 [554]: https://github.com/atomist/rug/issues/554
 [595]: https://github.com/atomist/rug/issues/595
->>>>>>> Expose underlying decorator logic #595 and hide their defined properties #554
 [587]: https://github.com/atomist/rug/issues/587
 
 ## [1.0.0-m.3] - 2017-05-09

--- a/src/main/scala/com/atomist/rug/test/gherkin/ScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/ScenarioWorld.scala
@@ -76,13 +76,13 @@ abstract class ScenarioWorld(val definitions: Definitions, rugs: Option[Rugs], c
   }
 
   protected def parameters(params: Any): ParameterValues = {
-    val m: Map[String, Object] = params match {
+    params match {
       case som: ScriptObjectMirror =>
         // The user has created a new JavaScript object, as in { foo: "bar" },
         // to pass up as an argument to the invoked editor. Extract its properties
-        NashornUtils.extractProperties(som)
+        SimpleParameterValues(NashornUtils.extractProperties(som))
+      case _ => SimpleParameterValues.Empty
     }
-    SimpleParameterValues(m)
   }
 
   protected case class RepoIdentification(owner: String, name: String, branch: Option[String], sha: Option[String])

--- a/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
+++ b/src/main/scala/com/atomist/rug/test/gherkin/project/ProjectScenarioWorld.scala
@@ -7,8 +7,8 @@ import com.atomist.project.edit.{FailedModificationAttempt, ModificationAttempt,
 import com.atomist.project.generate.ProjectGenerator
 import com.atomist.rug.RugNotFoundException
 import com.atomist.rug.kind.core.{ProjectContext, ProjectMutableView}
-import com.atomist.rug.runtime.js.{JavaScriptProjectOperation, LocalRugContext}
 import com.atomist.rug.runtime.js.interop.NashornUtils
+import com.atomist.rug.runtime.js.{JavaScriptProjectOperation, LocalRugContext}
 import com.atomist.rug.test.gherkin._
 import com.atomist.source.EmptyArtifactSource
 
@@ -62,6 +62,7 @@ class ProjectScenarioWorld(
     }
   }
 
+
   /**
     * Edit a project with the given editor, passed in from JavaScript.
     * We expect the JavaScript op to have been populated.
@@ -69,6 +70,11 @@ class ProjectScenarioWorld(
   def generateWith(generator: ProjectGenerator, projectName: String, params: Any): Unit = {
     val resultAs = generator.generate(projectName, parameters(params), new ProjectContext(LocalRugContext))
     project.updateTo(resultAs)
+  }
+
+  // for calling from nashorn which doesn't like default parameter values!
+  def generateWith(generator: ProjectGenerator, projectName: String): Unit = {
+    generateWith(generator, projectName, null)
   }
 
   /**
@@ -90,6 +96,10 @@ class ProjectScenarioWorld(
       case Left(unknown) =>
         throw unknown
     }
+  }
+  // for calling from nashorn which doesn't like default parameter values!
+  def editWith(editor: ProjectEditor): Unit = {
+    editWith(editor, null)
   }
 
   def modificationsMade: Boolean = editorResults.exists {

--- a/src/main/typescript/rug/test/project/Core.ts
+++ b/src/main/typescript/rug/test/project/Core.ts
@@ -45,12 +45,12 @@ export interface ProjectScenarioWorld extends ScenarioWorld {
     /**
      * Edit the project with the given editor, validating parameters
      */
-    editWith(ed: EditProject, params: {});
+    editWith(ed: EditProject, params?: {});
 
     /**
      * Create a project using the given generator named projectName, validating parameters
      */
-    generateWith(gen: PopulateProject, projectName: string, params: {});
+    generateWith(gen: PopulateProject, projectName: string, params?: {});
 
     /**
      * Did the editor make modifications in this scenario?  Note

--- a/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithoutParametersSteps.ts
+++ b/src/test/resources/com/atomist/rug/test/gherkin/project/EditorWithoutParametersSteps.ts
@@ -8,7 +8,7 @@ Given("a visionary leader", p => {
 })
 When("politics takes its course", (p, w) => {
     let world = w as ProjectScenarioWorld;
-    world.editWith(world.editor("AlpEditor"), {});
+    world.editWith(world.editor("AlpEditor"));
 });
 Then("one edit was made", (p, world) => {
     return world.editorsRun() == 1;


### PR DESCRIPTION
Without this, we see plenty tests containing:

```typescript
project.editWith("ChangeLogEditor", { } );
```

which is ugly, especially in JS world.