### PR TITLE
Changes to support Integration Testing in Rug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Add internal support for `Scope` on Rugs. Currently this is only used
+    on Response Handlers, and will be used to change the visibility of 
+    auto-generated ones so they are not indexed, displayed etc by the CLI
+    or Bot.
 -   Add support for @IntegrationTest decorator. TypeScript Classes with
     this decorator will behave much like Command Handlers, except in that
-    they will have additional metadata allowing the CLU/Runtime to behave
+    they will have additional metadata allowing the CLI or runtime to behave
     differently when required.
 -   Exposed underlying TypeScript class decorator logic so that they can
     be called directly to emit Rugs programmatically [#595][595]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Add support for @IntegrationTest decorator. TypeScript Classes with
+    this decorator will behave much like Command Handlers, except in that
+    they will have additional metadata allowing the CLU/Runtime to behave
+    differently when required.
 -   Exposed underlying TypeScript class decorator logic so that they can
     be called directly to emit Rugs programmatically [#595][595]
 -   Allow `commitMessage` to be set on `Edit` instructions [#593][593]

--- a/src/main/scala/com/atomist/rug/BadRugException.scala
+++ b/src/main/scala/com/atomist/rug/BadRugException.scala
@@ -4,6 +4,7 @@ import javax.script.ScriptException
 
 import com.atomist.project.edit.ProjectEditor
 import com.atomist.rug.runtime.Rug
+import com.atomist.rug.runtime.RugScopes.Scope
 import com.atomist.util.scalaparsing.ErrorInfo
 
 abstract class BadRugException(msg: String, rootCause: Throwable = null)
@@ -88,6 +89,10 @@ class DuplicateRugException(msg: String, knownRugs: Seq[Rug])
    extends BadRugException(msg)
 
 class InvalidTestDescriptorException(msg: String)
+  extends BadRugException(msg)
+
+
+class InvalidRugScopeException(msg: String, validScopes: Seq[Scope])
   extends BadRugException(msg)
 
 class EditorNotFoundException(msg: String)

--- a/src/main/scala/com/atomist/rug/BadRugException.scala
+++ b/src/main/scala/com/atomist/rug/BadRugException.scala
@@ -85,8 +85,10 @@ class MissingRugException(msg: String)
   extends BadRugException(msg)
 
 class DuplicateRugException(msg: String, knownRugs: Seq[Rug])
-   extends BadRugException(msg) {
-}
+   extends BadRugException(msg)
+
+class InvalidTestDescriptorException(msg: String)
+  extends BadRugException(msg)
 
 class EditorNotFoundException(msg: String)
   extends BadRugException(msg) {

--- a/src/main/scala/com/atomist/rug/runtime/ResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/ResponseHandler.scala
@@ -7,6 +7,8 @@ import com.atomist.rug.spi.Handlers.{Plan, Response}
 /**
   * Handles responses from other Rugs & Executions
   */
-trait ResponseHandler extends ParameterizedRug{
+trait ResponseHandler
+  extends ParameterizedRug
+  with ScopedRug {
   def handle(ctx: RugContext, response: Response, params: ParameterValues) : Option[Plan]
 }

--- a/src/main/scala/com/atomist/rug/runtime/ScopedRug.scala
+++ b/src/main/scala/com/atomist/rug/runtime/ScopedRug.scala
@@ -1,0 +1,29 @@
+package com.atomist.rug.runtime
+
+import com.atomist.rug.InvalidRugScopeException
+import com.atomist.rug.runtime.RugScopes.Scope
+
+/**
+  * Used to describe the visibility of a Rug
+  */
+trait ScopedRug {
+  def scope: Scope
+}
+
+object RugScopes {
+
+  sealed abstract class Scope(name: String)
+  case object ARCHIVE extends Scope("archive")
+  case object DEFAULT extends Scope("default")
+
+  def allScopes: Seq[Scope] = Seq(ARCHIVE, DEFAULT)
+
+  def from(name: String): Scope = {
+    name match {
+      case "archive" => ARCHIVE
+      case "default" => DEFAULT
+      case _ => throw new InvalidRugScopeException(s"'$name' is not a known scope", allScopes)
+    }
+  }
+}
+

--- a/src/main/scala/com/atomist/rug/runtime/TestDescriptor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/TestDescriptor.scala
@@ -1,0 +1,8 @@
+package com.atomist.rug.runtime
+
+/**
+  * Used to describe tests on a Rug
+  * @param kind
+  * @param description
+  */
+case class TestDescriptor (kind: String, description: String)

--- a/src/main/scala/com/atomist/rug/runtime/TestDescriptor.scala
+++ b/src/main/scala/com/atomist/rug/runtime/TestDescriptor.scala
@@ -2,7 +2,7 @@ package com.atomist.rug.runtime
 
 /**
   * Used to describe tests on a Rug
-  * @param kind
+  * @param kind what kind of test. Currently only "integration" exists and we don't yet make use of it.
   * @param description
   */
 case class TestDescriptor (kind: String, description: String)

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptResponseHandler.scala
@@ -2,11 +2,12 @@ package com.atomist.rug.runtime.js
 
 import com.atomist.param._
 import com.atomist.project.archive.RugResolver
+import com.atomist.rug.runtime.RugScopes.Scope
 import com.atomist.rug.runtime.js.interop.jsScalaHidingProxy
-import com.atomist.rug.{InvalidHandlerException, InvalidHandlerResultException}
 import com.atomist.rug.runtime.plans.{JsonResponseCoercer, NullResponseCoercer, ResponseCoercer}
-import com.atomist.rug.runtime.{ParameterizedRug, ResponseHandler, _}
+import com.atomist.rug.runtime.{ParameterizedRug, ResponseHandler}
 import com.atomist.rug.spi.Handlers.{Plan, Response}
+import com.atomist.rug.{InvalidHandlerException, InvalidHandlerResultException}
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 /**
@@ -17,7 +18,15 @@ class JavaScriptResponseHandlerFinder
   with JavaScriptUtils{
 
   override def create(jsc: JavaScriptContext, handler: ScriptObjectMirror, resolver: Option[RugResolver]): Option[JavaScriptResponseHandler] = {
-    Some(new JavaScriptResponseHandler(jsc, handler, name(handler), description(handler), parameters(handler), tags(handler), coerce(jsc,handler)))
+    Some(new JavaScriptResponseHandler(
+      jsc,
+      handler,
+      name(handler),
+      description(handler),
+      parameters(handler),
+      tags(handler),
+      coerce(jsc,handler),
+      scope(handler)))
   }
 
   /**
@@ -46,7 +55,8 @@ class JavaScriptResponseHandler (jsc: JavaScriptContext,
                                  override val description: String,
                                  override val parameters: Seq[Parameter],
                                  override val tags: Seq[Tag],
-                                 responseCoercer: ResponseCoercer)
+                                 responseCoercer: ResponseCoercer,
+                                 override val scope: Scope)
   extends ParameterizedRug
     with ResponseHandler
     with ParameterizedSupport

--- a/src/main/scala/com/atomist/rug/runtime/js/JavaScriptUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/JavaScriptUtils.scala
@@ -5,6 +5,8 @@ import javax.script.{ScriptContext, SimpleBindings}
 import com.atomist.param.{Parameter, ParameterValue, ParameterValues, Tag}
 import com.atomist.rug.{BadPlanException, InvalidRugParameterDefaultValue, InvalidRugParameterPatternException}
 import com.atomist.rug.parser.DefaultIdentifierResolver
+import com.atomist.rug.runtime.RugScopes
+import com.atomist.rug.runtime.RugScopes.Scope
 import com.atomist.rug.spi.Secret
 import jdk.nashorn.api.scripting.{ScriptObjectMirror, ScriptUtils}
 import jdk.nashorn.internal.runtime.ScriptRuntime
@@ -188,6 +190,13 @@ trait JavaScriptUtils {
         case Success(name) => name
         case Failure(error) => throw new BadPlanException(s"Could not determine name of Rug", error)
       }
+    }
+  }
+
+  protected def scope(obj: ScriptObjectMirror): Scope = {
+    obj.getMember("__scope") match {
+      case o: String => RugScopes.from(o)
+      case _ => RugScopes.DEFAULT
     }
   }
 

--- a/src/main/typescript/rug/operations/Decorators.ts
+++ b/src/main/typescript/rug/operations/Decorators.ts
@@ -95,6 +95,29 @@ export function CommandHandler(nameOrDescription: string, description?: string) 
   };
 }
 
+type TestKind = "integration";
+
+interface TestDescriptor {
+  description: string;
+  kind: TestKind;
+}
+
+export function IntegrationTest(description: string | TestDescriptor) {
+  return (obj: any) => {
+    if (typeof description === "string") {
+      declareCommandHandler(obj, description);
+      declareIntegrationTest(obj, { description, kind: "integration" });
+    } else {
+      declareCommandHandler(obj, description.description);
+      declareIntegrationTest(obj, description);
+    }
+  };
+}
+
+export function declareIntegrationTest(obj: any, descriptor: TestDescriptor) {
+  set_metadata(obj, "__test", descriptor);
+}
+
 export function declareCommandHandler(obj: any, description: string, name?: string) {
   declareRug(obj, "command-handler", description, name);
   return obj;

--- a/src/main/typescript/rug/operations/Decorators.ts
+++ b/src/main/typescript/rug/operations/Decorators.ts
@@ -114,6 +114,19 @@ export function IntegrationTest(description: string | TestDescriptor) {
   };
 }
 
+/**
+ * Describe to whom this rug is visible (not to be confused by ACLs)
+ * This stuff is not enforced, but specifies developer intent.
+ *
+ * @param obj - a rug
+ * @param scope
+ */
+export function setScope(obj: any, scope: Scope) {
+  set_metadata(obj, "__scope", scope);
+  return obj;
+}
+type Scope = "archive";
+
 export function declareIntegrationTest(obj: any, descriptor: TestDescriptor) {
   set_metadata(obj, "__test", descriptor);
 }

--- a/src/test/resources/com/atomist/rug/runtime/js/HandlerIntegrationTest.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/HandlerIntegrationTest.ts
@@ -1,0 +1,15 @@
+import {HandleCommand, HandleResponse, ResponseMessage, Response, HandlerContext, CommandPlan} from '@atomist/rug/operations/Handlers'
+import {IntegrationTest, ResponseHandler, Parameter, Tags, Intent} from '@atomist/rug/operations/Decorators'
+
+@IntegrationTest("Test some flow")
+class SomeTest implements HandleCommand{
+
+  handle(ctx: HandlerContext) : CommandPlan {
+
+    let result = new CommandPlan()
+    result.add({instruction: {kind: "execute", name: "ExampleFunction", parameters: {thingy: "woot", exception: true}},});
+    return result;
+  }
+}
+
+export let command = new SomeTest();

--- a/src/test/resources/com/atomist/rug/runtime/js/ResponseHandlerWithArchiveScope.ts
+++ b/src/test/resources/com/atomist/rug/runtime/js/ResponseHandlerWithArchiveScope.ts
@@ -1,0 +1,15 @@
+import {Respond, Instruction, Response, CommandPlan, HandlerContext} from '@atomist/rug/operations/Handlers'
+import {TreeNode, Match, PathExpression} from '@atomist/rug/tree/PathExpression'
+import {EventHandler, ParseJson, ResponseHandler, CommandHandler, Parameter, Tags, Intent, setScope } from '@atomist/rug/operations/Decorators'
+import {Project} from '@atomist/rug/model/Core'
+import {HandleResponse, HandleEvent, HandleCommand} from '@atomist/rug/operations/Handlers'
+
+@ResponseHandler("Description")
+class SomeHandler implements HandleResponse<any>{
+
+ handle(response: Response<any>, ctx: HandlerContext) : CommandPlan {
+    return new CommandPlan();
+  }
+}
+
+export let kit = setScope(new SomeHandler(), "archive")

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
@@ -258,6 +258,22 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
     val com = rugs.commandHandlers.head
     assert(com.name == "FunctionKiller")
   }
+
+  val handlerWithIntegrationTestDecorator =
+    StringFileArtifact(atomistConfig.handlersRoot + "/Handler.ts",
+      contentOf(this, "HandlerIntegrationTest.ts"))
+
+  it should "add test metadata if the @IntegrationTest decorator is used" in {
+    val rugArchive = TypeScriptBuilder.compileWithModel(SimpleFileBasedArtifactSource(handlerWithIntegrationTestDecorator))
+    val resolver = SimpleRugResolver(rugArchive)
+    val rugs = resolver.resolvedDependencies.rugs
+    assert(rugs.commandHandlers.nonEmpty)
+    val test = rugs.commandHandlers.head.asInstanceOf[JavaScriptCommandHandler]
+    assert(test.testDescriptor.nonEmpty)
+    val td = test.testDescriptor.get
+    assert(td.description == "Test some flow")
+    assert(td.kind == "integration")
+  }
 }
 
 class TestResponseHandler(r: ResponseHandler) extends ResponseHandler {

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
@@ -4,6 +4,7 @@ import com.atomist.param._
 import com.atomist.project.archive.{AtomistConfig, DefaultAtomistConfig}
 import com.atomist.project.common.MissingParametersException
 import com.atomist.rug.runtime.ResponseHandler
+import com.atomist.rug.runtime.RugScopes.Scope
 import com.atomist.rug.runtime.plans._
 import com.atomist.rug.spi.Handlers._
 import com.atomist.rug.spi.Secret
@@ -282,6 +283,7 @@ class TestResponseHandler(r: ResponseHandler) extends ResponseHandler {
     None
   }
 
+  override def scope: Scope = r.scope
   override def name: String = r.name
 
   override def description: String = r.description


### PR DESCRIPTION
@IntegrationTest decorator which declares a CommandHandler but has additional details about the test. This will allow us to show them differently in the CLI/Bot should we choose to do so. Adding @Intent will expose via the bot as normal.

Also, add basic scoping support for Rugs. Currently only for Response Handlers:

- "archive" scope means that a Rug should not be visible outside the archive
- "default" scope is what is set by default on all Response Handlers

This is _only_ exposed via `Decorators.ts/setScope` for now as discussions indicated we weren't sure how this would play out. @russmiles certainly thinks that this would be useful for some editors that are just used within archives when composing others.