### PR TITLE
Make Language Extensions easier

### DIFF
--- a/.atomist/TreePrinter.ts
+++ b/.atomist/TreePrinter.ts
@@ -1,0 +1,81 @@
+import {TextTreeNode} from "@atomist/rug/tree/PathExpression";
+
+export function drawTree(baby: TextTreeNode): string {
+    return draw<TextTreeNode>((a) => a.children(), (a) => `${a.nodeName()} = ${a.value()}`, baby);
+}
+
+/**
+ * TreeNodePrinter utility.
+ * It lets you draw a cute tree like
+ *
+
+ Grandma
+ ├─┬ Dad
+ | ├── Sister
+ | └─┬ Me
+ |   ├── Daughter
+ |   └── Son
+ └── Aunt
+
+ *
+ * To use it, pass two functions:
+ * @param children how to access child nodes
+ * @param info how to print a node
+ * @param topOfTree and then the top-level node!
+ *
+ * @return String. Print it yourself
+ */
+export function draw<T>(children: (T) => T[], info: (T) => string, topOfTree: T): string {
+
+    function drawInternal(tn: T): string[] {
+        if (children(tn).length === 0) {
+            return [info(tn)]
+        }
+        else {
+            return [info(tn)].concat(printChildren(children(tn)))
+        }
+    }
+
+    function printChildren(ch: T[]): string[] {
+        console.log(ch.toString());
+        let last = ch[ch.length - 1];
+        let notLast = ch.slice(0, ch.length - 1);
+
+        let lastLine = prefixChildLines(children(last).length > 0, true, drawInternal(last));
+        let earlierLines = [].concat.apply([], notLast.map(tn => prefixChildLines(children(tn).length > 0, false, drawInternal(tn))));
+
+        return earlierLines.concat(lastLine)
+    }
+
+    return drawInternal(topOfTree).join("\n");
+}
+// this won't be pretty on Windows
+const LAST_TREE_NODE = "└── ";
+const LAST_TREE_NODE_WITH_CHILDREN = "└─┬ ";
+const TREE_NODE = "├── ";
+const TREE_NODE_WITH_CHILDREN = "├─┬ ";
+const TREE_CONNECTOR = "| ";
+const FILLER = "  ";
+
+function prefixChildLines(hasChildren: boolean, last: boolean, childLines: string[]): string[] {
+
+    let head = childLines[0];
+    let rest = childLines.slice(1);
+
+    let connector = last ? FILLER : TREE_CONNECTOR;
+    let firstLine = firstLineOfChildPrefix(hasChildren, last) + head;
+    let restLines = rest.map((a) => connector.concat(a));
+    return [firstLine].concat(restLines);
+
+}
+
+function firstLineOfChildPrefix(hasChildren: boolean, last: boolean): string {
+    return (hasChildren && last) ? LAST_TREE_NODE_WITH_CHILDREN :
+        ((hasChildren && !last) ? TREE_NODE_WITH_CHILDREN :
+            ((!hasChildren && last) ? LAST_TREE_NODE :
+                ((!hasChildren && !last) ? TREE_NODE :
+                    "the impossible has happened")));
+}
+
+
+

--- a/.atomist/package.json
+++ b/.atomist/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@atomist/rug": "0.13.0"
+    "@atomist/rugs": "1.0.0-m.4"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ Temporary Items
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /.jscache
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     invocations [#587][587]
 -   Added `Identifiable` instruction that can be used for `DirectedMessage`
     and `ResponseMessage`
+-   Rug Language Extensions can provide a preprocessing (and postprocessing) step.
+    This lets them do string manipulation before parsing, and undo it afterward.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Remove some more remnants of reviewers
 -   Harmonized much of the Rug loading code between project operations and
     handlers
+-   RugLanguageExtensions may return a smaller interface, `ParsedNode` from 
+    their parsing method `fileToRawNode`, instead of requiring `PositionedTreeNode`.
     
 ### Fixed
 

--- a/src/main/scala/com/atomist/rug/kind/grammar/TypeUnderFile.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/TypeUnderFile.scala
@@ -41,11 +41,13 @@ abstract class TypeUnderFile
   }
 
   private def toView(f: FileArtifactBackedMutableView): Option[TreeNode] = {
-    val inner = fileToRawNode(f.currentBackingObject) match {
+    val preprocessedFile = f.currentBackingObject.withContent(preprocess(f.content))
+    val inner = fileToRawNode(preprocessedFile) match {
       case Some(ptn: ParsedNode) =>
         Some(TextTreeNodeLifecycle.makeWholeFileNodeReady(name,
           PositionedTreeNode.fromParsedNode(ptn),
-          f))
+          f,
+          preprocess, postprocess))
       case None => None
       case x => throw new RuntimeException(s"What is $x")
     }
@@ -71,6 +73,9 @@ abstract class TypeUnderFile
     */
   def fileToRawNode(f: FileArtifact): Option[ParsedNode]
 
+  def preprocess(originalContent: String): String = originalContent
+
+  def postprocess(preprocessedContent: String): String = preprocessedContent
 
 }
 

--- a/src/main/scala/com/atomist/rug/kind/grammar/TypeUnderFile.scala
+++ b/src/main/scala/com/atomist/rug/kind/grammar/TypeUnderFile.scala
@@ -28,27 +28,30 @@ abstract class TypeUnderFile
   override def runtimeClass: Class[_ <: GraphNode] = classOf[OverwritableTextTreeNode]
 
   override def findAllIn(context: GraphNode): Option[Seq[TreeNode]] = context match {
-      case pmv: ProjectMutableView =>
-        Some(pmv
-          .files
-          .asScala
-          .filter(f => isOfType(f.currentBackingObject))
-          .flatMap(toView)
-        )
-      case f: FileMutableView if isOfType(f.currentBackingObject) =>
-        Some(toView(f).toSeq)
-      case _ => None
-    }
+    case pmv: ProjectMutableView =>
+      Some(pmv
+        .files
+        .asScala
+        .filter(f => isOfType(f.currentBackingObject))
+        .flatMap(toView)
+      )
+    case f: FileMutableView if isOfType(f.currentBackingObject) =>
+      Some(toView(f).toSeq)
+    case _ => None
+  }
 
   private def toView(f: FileArtifactBackedMutableView): Option[TreeNode] = {
     val inner = fileToRawNode(f.currentBackingObject) match {
-      case Some(ptn: PositionedTreeNode) =>
-        Some(TextTreeNodeLifecycle.makeWholeFileNodeReady(name, ptn, f))
+      case Some(ptn: ParsedNode) =>
+        Some(TextTreeNodeLifecycle.makeWholeFileNodeReady(name,
+          PositionedTreeNode.fromParsedNode(ptn),
+          f))
       case None => None
       case x => throw new RuntimeException(s"What is $x")
     }
     inner.map(createView(_, f))
   }
+
 
   /**
     * Subclasses can override this if they want to customize the top level node created:
@@ -66,5 +69,27 @@ abstract class TypeUnderFile
     * @param f file with content to parse
     * @return a PositionedTreeNode
     */
-  def fileToRawNode(f: FileArtifact): Option[PositionedTreeNode]
+  def fileToRawNode(f: FileArtifact): Option[ParsedNode]
+
+
 }
+
+/**
+  * minimum information a Rug Language Extension needs to provide
+  * in order for us to construct the TextTreeNodes that let us drill
+  * into the file in a path expression.
+  */
+trait ParsedNode {
+  def nodeName: String
+
+  def parsedNodes: Seq[ParsedNode]
+
+  def startOffset: Int
+
+  def endOffset: Int
+}
+
+case class SimpleParsedNode(override val nodeName: String,
+                            override val startOffset: Int,
+                            override val endOffset: Int,
+                            override val parsedNodes: Seq[ParsedNode] = Seq()) extends ParsedNode

--- a/src/main/scala/com/atomist/tree/content/text/ImmutablePositionedTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/ImmutablePositionedTreeNode.scala
@@ -36,7 +36,7 @@ object ImmutablePositionedTreeNode {
       from.significance)
   }
 
-  def pad(typeName: String, pupae: Seq[PositionedTreeNode], initialSource: String): OverwritableTextInFile = {
+  def pad(typeName: String, pupae: Seq[PositionedTreeNode], initialSource: String): OverwritableTextTreeNode = {
     val wrapper = ImmutablePositionedTreeNode("wrapper",
       OffsetInputPosition(0),
       OffsetInputPosition(initialSource.length),
@@ -45,9 +45,7 @@ object ImmutablePositionedTreeNode {
       TreeNode.Signal)
     val collapsed = collapseNoise(wrapper)
     val resolved = fightWithSiblings(collapsed)
-    val result = padInternal(resolved, initialSource)
-
-    new OverwritableTextInFile(typeName, result.allKidsIncludingPadding)
+    padInternal(resolved, initialSource)
   }
 
   private def collapseNoise(n: PositionedTreeNode): ImmutablePositionedTreeNode = {
@@ -92,8 +90,8 @@ object ImmutablePositionedTreeNode {
   private def padInternal(pupae: PositionedTreeNode, initialSource: String): OverwritableTextTreeNode = {
 
     def padding(from: Int, to: Int): TreeNode = {
-      val content = initialSource.substring(from, to)
       val name = s"padding[$from-$to]"
+      val content = initialSource.substring(from, to)
       PaddingTreeNode(name, content)
     }
 

--- a/src/main/scala/com/atomist/tree/content/text/PositionedTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/content/text/PositionedTreeNode.scala
@@ -1,15 +1,45 @@
 package com.atomist.tree.content.text
 
+import com.atomist.rug.kind.grammar.ParsedNode
 import com.atomist.tree.TreeNode
 
 /**
-  * A TreeNode that knows its position in input.
+  * These are the beginnings of TreeNodes. They come in from parsing
+  * They can't be updated, and shouldn't really know their value.
+  *
+  * Goal: these should not implement TreeNode. They aren't path-expression-ready
+  * they have to go through TextTreeNodeLifecycle first, to be turned into
+  * proper TextTreeNodes that know value and can be updated. (Those maintain
+  * position using padding instead of offsets, so the updates work.)
+  *
+  * ParsedNode is the minimal interface that Rug Language Extensions must supply when
+  * parsing a file. It's implemented here for backwards compatibility, so that
+  * existing extensions which supply full PositionedTreeNodes can continue to do so.
   */
-trait PositionedTreeNode extends TreeNode with Positioned {
+trait PositionedTreeNode extends TreeNode with Positioned with ParsedNode {
+
+  override def parsedNodes: Seq[ParsedNode] = childNodes.map(_.asInstanceOf[ParsedNode])
+
+  override def startOffset: Int = startPosition.offset
+
+  override def endOffset: Int = endPosition.offset
 
   def hasSamePositionAs(that: PositionedTreeNode): Boolean =
     this.startPosition.offset == that.startPosition.offset
 
   def includes(pos: InputPosition): Boolean =
     this.startPosition.offset <= pos.offset && this.endPosition.offset >= pos.offset
+}
+
+object PositionedTreeNode {
+  def fromParsedNode(ptn: ParsedNode): PositionedTreeNode = ptn match {
+    case alreadyThere: PositionedTreeNode => alreadyThere
+    case _ =>
+      ImmutablePositionedTreeNode.apply(ptn.nodeName,
+        OffsetInputPosition(ptn.startOffset),
+        OffsetInputPosition(ptn.endOffset),
+        ptn.parsedNodes.map(fromParsedNode),
+        Set(),
+        TreeNode.Signal)
+  }
 }

--- a/src/main/scala/com/atomist/tree/utils/NodeUtils.scala
+++ b/src/main/scala/com/atomist/tree/utils/NodeUtils.scala
@@ -1,6 +1,7 @@
 package com.atomist.tree.utils
 
 import com.atomist.graph.GraphNode
+import com.atomist.rug.kind.grammar.ParsedNode
 import com.atomist.tree.TreeNode
 import com.atomist.tree.content.text.PositionedTreeNode
 import org.springframework.util.ReflectionUtils
@@ -62,8 +63,8 @@ object NodeUtils {
     case _ => ""
   }
 
-  def positionedValue(gn: GraphNode, in: String): String = gn match {
-    case pn: PositionedTreeNode => in.substring(pn.startPosition.offset, pn.endPosition.offset)
+  def positionedValue(gn: Object, in: String): String = gn match {
+    case pn: ParsedNode => in.substring(pn.startOffset, pn.endOffset)
     case _ => ???
   }
 

--- a/src/test/resources/com/atomist/rug/kind/PandaParsingTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/rug/kind/PandaParsingTypeScriptTest.ts
@@ -10,6 +10,9 @@ class PandaParsingTypeScriptTest {
     @Parameter({pattern: Pattern.any})
     changePandasInCurliesTo: string;
 
+    @Parameter({pattern: Pattern.any})
+    changeFirstPandaInEachLineTo: string;
+
     edit(project: Project) {
 
         let eng: PathExpressionEngine = project.context.pathExpressionEngine;
@@ -17,10 +20,16 @@ class PandaParsingTypeScriptTest {
         let pandafile = eng.scalar<Project, File>(project, `/my.panda`);
         let parsedPanda = eng.scalar<File, TextTreeNode>(pandafile, "/Panda()");
 
-        eng.with<TextTreeNode>(parsedPanda, `/curly/word`, pandaWord => {
+        eng.with<TextTreeNode>(parsedPanda, `//curly/word`, pandaWord => {
             pandaWord.update(this.changePandasInCurliesTo);
+        });
+
+        eng.with<TextTreeNode>(parsedPanda, `/line/word[1]`, pandaWord => {
+            //console.log("Found first word in line: " + (pandaWord.parent() as TextTreeNode).value());
+            pandaWord.update(this.changeFirstPandaInEachLineTo);
         })
 
     }
 }
+
 export let editor = new PandaParsingTypeScriptTest();

--- a/src/test/resources/com/atomist/rug/kind/PandaParsingTypeScriptTest.ts
+++ b/src/test/resources/com/atomist/rug/kind/PandaParsingTypeScriptTest.ts
@@ -1,18 +1,18 @@
-import { Project, File } from '@atomist/rug/model/Core'
-import { Editor } from '@atomist/rug/operations/Decorators'
-import { PathExpressionEngine, TextTreeNode } from '@atomist/rug/tree/PathExpression'
-import { Parameter } from "@atomist/rug/operations/Decorators";
-import { Pattern } from "@atomist/rug/operations/RugOperation";
+import {Project, File} from '@atomist/rug/model/Core'
+import {Editor} from '@atomist/rug/operations/Decorators'
+import {PathExpressionEngine, TextTreeNode} from '@atomist/rug/tree/PathExpression'
+import {Parameter} from "@atomist/rug/operations/Decorators";
+import {Pattern} from "@atomist/rug/operations/RugOperation";
 
 @Editor("PandaParsingTypeScriptTest", "Uses PandaParsing from TypeScript")
 class PandaParsingTypeScriptTest {
 
-    @Parameter({ pattern: Pattern.any })
+    @Parameter({pattern: Pattern.any})
     changePandasInCurliesTo: string;
 
     edit(project: Project) {
 
-        let eng : PathExpressionEngine = project.context.pathExpressionEngine;
+        let eng: PathExpressionEngine = project.context.pathExpressionEngine;
 
         let pandafile = eng.scalar<Project, File>(project, `/my.panda`);
         let parsedPanda = eng.scalar<File, TextTreeNode>(pandafile, "/Panda()");

--- a/src/test/scala/com/atomist/rug/kind/grammar/AbstractTypeUnderFileTest.scala
+++ b/src/test/scala/com/atomist/rug/kind/grammar/AbstractTypeUnderFileTest.scala
@@ -8,7 +8,7 @@ import com.atomist.rug.kind.DefaultTypeRegistry
 import com.atomist.rug.kind.core.ProjectMutableView
 import com.atomist.source.{ArtifactSource, FileArtifact, SimpleFileBasedArtifactSource}
 import com.atomist.tree.TreeNode
-import com.atomist.tree.content.text.TextTreeNodeLifecycle
+import com.atomist.tree.content.text.{PositionedTreeNode, TextTreeNodeLifecycle}
 import com.atomist.tree.pathexpression.{ExpressionEngine, PathExpressionEngine}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -35,7 +35,7 @@ abstract class AbstractTypeUnderFileTest extends FlatSpec with Matchers {
     withClue(s"files named ${filesOfType.map(_.path).mkString(",")}") {
       val parsedFiles = filesOfType.map(cs => (cs, typeBeingTested.fileToRawNode(cs)))
         .map(tup => tup._2.getOrElse(fail(s"Cannot parse file\n[${tup._1.content}]")))
-      val goodFileCount = parsedFiles.count(tree => tree.childNodes.nonEmpty)
+      val goodFileCount = parsedFiles.count(tree => tree.parsedNodes.nonEmpty)
       goodFileCount should be >= (1)
     }
   }
@@ -56,7 +56,7 @@ abstract class AbstractTypeUnderFileTest extends FlatSpec with Matchers {
     val pmv = new ProjectMutableView(as, as)
     val fmv = pmv.files.get(0)
     val parsed = typeBeingTested.fileToRawNode(file).get
-    val nodes = TextTreeNodeLifecycle.makeReady(typeBeingTested.name, Seq(parsed), fmv)
+    val nodes = TextTreeNodeLifecycle.makeReady(typeBeingTested.name, Seq(PositionedTreeNode.fromParsedNode(parsed)), fmv)
     nodes.head.update(nodes.head.value) // trigger an update to file contents
     fmv.content
   }


### PR DESCRIPTION
Please don't squash.

Two improvements for language extensions:
* smaller interface to provide for parsed nodes
* optional preprocess/postprocess steps for cleverness 
this will be useful for the Elm one