### PR TITLE
Remove Scala Futures from PlanRunner API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   **BREAKING** Removed all usage of Scala `Future` in `PlanRunner`
+    and corresponding APIs
 -   Updated JavaParser to 3.2.8
 -   Updated artifact-source to 1.0.0-m.5
 

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanResultInterpreter.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanResultInterpreter.scala
@@ -28,7 +28,7 @@ object PlanResultInterpreter {
           case _: PlanLogError => true
           case result: InstructionResult if result.response.status == Failure => true
           case result: NestedPlanRun =>
-            val planResult = Await.result(result.planResult, 5.minutes)
+            val planResult = result.planResult
             hasLogFailure(log.tail ++ planResult.log)
           case _ => hasLogFailure(log.tail)
         }

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanResultLogger.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanResultLogger.scala
@@ -26,7 +26,7 @@ class PlanResultLogger(val logger: Logger) {
             logger.error("Failure running plan.", result)
             log.tail
           case result: NestedPlanRun =>
-            val planResult = Await.result(result.planResult, 5.minutes)
+            val planResult = result.planResult
             log.tail ++ planResult.log
           case _ => log.tail
         }

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanRunner.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanRunner.scala
@@ -9,5 +9,5 @@ import scala.concurrent.Future
   * Run a plan's instructions and send its messages
   */
 trait PlanRunner {
-  def run(plan: Handlers.Plan, callbackInput: Option[Response]): Future[PlanResult]
+  def run(plan: Handlers.Plan, callbackInput: Option[Response]): PlanResult
 }

--- a/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
+++ b/src/main/scala/com/atomist/rug/runtime/plans/PlanUtils.scala
@@ -75,11 +75,7 @@ object PlanUtils {
         case InstructionResult(instruction, response) =>
           BabyTree(s"Received $response back from ${instructionToString(instruction)}")
         case NestedPlanRun(plan, planResult) =>
-          Await.ready(planResult, 10.seconds)
-          val result = planResult.value.get match {
-            case Failure(exception) => BabyTree(s"Future failed with ${exception.getMessage}")
-            case Success(value) => awaitAndTreeLogEvents(s"Future completed", value.log)
-          }
+          val result = awaitAndTreeLogEvents(s"Future completed", planResult.log)
           val planChild = planToTree(plan)
           BabyTree("Nested plan run", Seq(planChild, result))
       }

--- a/src/main/scala/com/atomist/rug/spi/Handlers.scala
+++ b/src/main/scala/com/atomist/rug/spi/Handlers.scala
@@ -199,7 +199,7 @@ object Handlers {
 
   case class InstructionResult(instruction: Instruction, response: Response) extends PlanLogEvent
 
-  case class NestedPlanRun(plan: Plan, planResult: Future[PlanResult]) extends PlanLogEvent
+  case class NestedPlanRun(plan: Plan, planResult: PlanResult) extends PlanLogEvent
 
   case class InstructionError(instruction: Instruction, error: Throwable) extends PlanLogError
 

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptCommandHandlerTest.scala
@@ -106,7 +106,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
         Seq(SimpleParameterValue("very", "cool"))
       }
     }, rugResolver = Some(resolver)), loggerOption = Some(NOPLogger.NOP_LOGGER))
-    val results = Await.result(runner.run(plan, None), 10.seconds)
+    val results = runner.run(plan, None)
     val single = PlanResultInterpreter.interpret(results)
     assert(single.status == Status.Success)
   }
@@ -169,7 +169,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
         Seq(SimpleParameterValue("very", "cool"))
       }
     }))
-    Await.result(runner.run(handlers.head.handle(null, SimpleParameterValues.Empty).get, None), 10.seconds).log.foreach {
+    runner.run(handlers.head.handle(null, SimpleParameterValues.Empty).get, None).log.foreach {
       case i:
         InstructionResult =>
         assert(i.response.status === Status.Success)
@@ -200,7 +200,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
     val runner = new LocalPlanRunner(null, new LocalInstructionRunner(responseHandler, null, null, new TestSecretResolver(null) {
       override def resolveSecrets(secrets: Seq[Secret]): Seq[ParameterValue] = Nil
     }, rugResolver = Some(resolver)), loggerOption = Some(NOPLogger.NOP_LOGGER))
-    val results = Await.result(runner.run(plan, None), 10.seconds)
+    val results = runner.run(plan, None)
     val msg = results.log(1).asInstanceOf[InstructionResult].response.body.get.asInstanceOf[Plan].local.head.body
     assert(msg.contains("Cannot find Rug Function NonExistent"))
   }
@@ -224,7 +224,7 @@ class JavaScriptCommandHandlerTest extends FlatSpec with Matchers {
         Seq(SimpleParameterValue("very", "cool"))
       }
     }, rugResolver = Some(resolver)), loggerOption = Some(NOPLogger.NOP_LOGGER))
-    val results = Await.result(runner.run(plan, None), 10.seconds)
+    val results = runner.run(plan, None)
     val msg = results.log.head.asInstanceOf[InstructionResult].response.body.get.asInstanceOf[RugRuntimeException].getMessage
     assert(msg.contains("uh oh"))
   }

--- a/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/JavaScriptEventHandlerTest.scala
@@ -192,7 +192,7 @@ class JavaScriptEventHandlerTest extends FlatSpec with Matchers with DiagrammedA
     val handler = ops.commandHandlers.find(p => p.name == "LicenseAdder").get
     val plan = handler.handle(LocalRugContext(TestTreeMaterializer), SimpleParameterValues(SimpleParameterValue("license", "agpl")))
     val runner = new LocalPlanRunner(null, new LocalInstructionRunner(handler, null, null, null))
-    val response = Await.result(runner.run(plan.get, None), 120.seconds)
+    val response = runner.run(plan.get, None)
     assert(response.log.size === 1)
     response.log.foreach {
       case error: InstructionError => assert(error.error.getMessage === "Cannot find Rug Function HTTP")
@@ -258,7 +258,7 @@ class JavaScriptEventHandlerTest extends FlatSpec with Matchers with DiagrammedA
     }))
     val actualPlan = handlers.head.handle(LocalRugContext(TestTreeMaterializer), SysEvent)
     assert(actualPlan.nonEmpty)
-    Await.result(runner.run(actualPlan.get, None), 10.seconds).log.foreach {
+    runner.run(actualPlan.get, None).log.foreach {
       case i:
         InstructionResult =>
         assert(i.response.status === Status.Success)

--- a/src/test/scala/com/atomist/rug/runtime/js/PlanBuilderTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/js/PlanBuilderTest.scala
@@ -108,7 +108,7 @@ class PlanBuilderTest extends FunSpec with Matchers with OneInstancePerTest with
         Seq(SimpleParameterValue("very", "cool"))
       }
     }, rugResolver = Some(resolver)))
-    val result = Await.result(runner.run(plan, None), 10.seconds)
+    val result = runner.run(plan, None)
     assert(PlanResultInterpreter.interpret(result).status == Success)
   }
 

--- a/src/test/scala/com/atomist/rug/runtime/plans/PlanResultInterpreterTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/PlanResultInterpreterTest.scala
@@ -14,9 +14,9 @@ class PlanResultInterpreterTest extends FunSpec with Matchers with DiagrammedAss
   val successfulInstructionResult = InstructionResult(Edit(Detail("edit1", None, Nil, None)), Response(Success))
   val failureInstructionResult = InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Failure))
   val errorInstructionResult = InstructionError(Edit(Detail("edit3", None, Nil, None)), new IllegalStateException("doh!"))
-  val successfulNestedPlan = NestedPlanRun(Plan(None,Nil,Nil, Nil), Future {PlanResult(Seq(successfulInstructionResult))})
-  val failureNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), Future {PlanResult(Seq(failureInstructionResult))})
-  val errorNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), Future {PlanResult(Seq(errorInstructionResult))})
+  val successfulNestedPlan = NestedPlanRun(Plan(None,Nil,Nil, Nil), PlanResult(Seq(successfulInstructionResult)))
+  val failureNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), PlanResult(Seq(failureInstructionResult)))
+  val errorNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), PlanResult(Seq(errorInstructionResult)))
 
   it ("should interpret empty plan result as success") {
     val planResult = PlanResult(Nil)

--- a/src/test/scala/com/atomist/rug/runtime/plans/PlanResultLoggerTest.scala
+++ b/src/test/scala/com/atomist/rug/runtime/plans/PlanResultLoggerTest.scala
@@ -19,9 +19,9 @@ class PlanResultLoggerTest extends FunSpec with Matchers with DiagrammedAssertio
   val successfulInstructionResult = InstructionResult(Edit(Detail("edit1", None, Nil, None)), Response(Success))
   val failureInstructionResult = InstructionResult(Edit(Detail("edit2", None, Nil, None)), Response(Failure))
   val errorInstructionResult = InstructionError(Edit(Detail("edit3", None, Nil, None)), new IllegalStateException("doh!"))
-  val successfulNestedPlan = NestedPlanRun(Plan(None,Nil,Nil, Nil), Future {PlanResult(Seq(successfulInstructionResult))})
-  val failureNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), Future {PlanResult(Seq(failureInstructionResult))})
-  val errorNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), Future {PlanResult(Seq(errorInstructionResult))})
+  val successfulNestedPlan = NestedPlanRun(Plan(None,Nil,Nil, Nil), PlanResult(Seq(successfulInstructionResult)))
+  val failureNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), PlanResult(Seq(failureInstructionResult)))
+  val errorNestedPlan = NestedPlanRun(Plan(None,Nil, Nil, Nil), PlanResult(Seq(errorInstructionResult)))
 
   it ("should interpret empty plan result as success") {
     val planResult = PlanResult(Nil)


### PR DESCRIPTION
This is to remove runtime complications with using Scala's global `ExecutionContext`.

Those changes have been tested in `rug-runner`. 