### PR TITLE
Proxy optimization

### DIFF
--- a/src/main/scala/com/atomist/rug/kind/DefaultTypeRegistry.scala
+++ b/src/main/scala/com/atomist/rug/kind/DefaultTypeRegistry.scala
@@ -1,7 +1,9 @@
 package com.atomist.rug.kind
 
+import com.atomist.rug.spi.SimpleTypeRegistry
+
 /**
   * Load types found on the classpath using ServiceLoader
   * Does not include Cortex types.
   */
-object DefaultTypeRegistry extends ServiceLoaderTypeRegistry
+object DefaultTypeRegistry extends SimpleTypeRegistry(new ServiceLoaderTypeRegistry().types)

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -31,7 +31,7 @@ class jsSafeCommittingProxy(
 
   override def toString: String = s"SafeCommittingProxy#$hashCode around $node"
 
-  private val typ: Typed = Typed.typeFor(node, typeRegistry)
+  private lazy val typ: Typed = Typed.typeFor(node, typeRegistry)
 
   // Members the user has added dynamically in JavaScript,
   // for example in mixins

--- a/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
+++ b/src/main/scala/com/atomist/rug/runtime/js/interop/jsSafeCommittingProxy.scala
@@ -35,7 +35,7 @@ class jsSafeCommittingProxy(
 
   // Members the user has added dynamically in JavaScript,
   // for example in mixins
-  private var additionalMembers: Map[String, Object] = Map()
+  private lazy val additionalMembers = new scala.collection.mutable.HashMap[String,AnyRef]()
 
   //-----------------------------------------------------
   // Delegate GraphNode and TreeNode methods to backing node
@@ -76,10 +76,10 @@ class jsSafeCommittingProxy(
   override def setMember(name: String, value: Object): Unit = value match {
     case som: ScriptObjectMirror =>
       logger.debug(s"JavaScript code has added function member [$name]")
-      additionalMembers = additionalMembers ++ Map(name -> som)
+      additionalMembers.put(name, som)
     case x =>
       logger.debug(s"JavaScript code has added non-function member [$name]")
-      additionalMembers = additionalMembers ++ Map(name -> x)
+      additionalMembers.put(name, x)
   }
 
   override def getMember(name: String): AnyRef = {

--- a/src/main/scala/com/atomist/rug/spi/Typed.scala
+++ b/src/main/scala/com/atomist/rug/spi/Typed.scala
@@ -8,7 +8,10 @@ object Typed {
   def typeFor(node: GraphNode, typeRegistry: TypeRegistry): Typed = {
     val nodeTypes: Set[Typed] =
       node.nodeTags.flatMap(t => typeRegistry.findByName(t))
-    UnionType(nodeTypes)
+    nodeTypes.size match {
+      case 0 => TypeOperation.TreeNodeType
+      case _ => UnionType(nodeTypes)
+    }
   }
 
   private[spi] def trimSuffix(suffix: String, orig: String): String =
@@ -76,10 +79,10 @@ private case class UnionType(types: Set[Typed]) extends Typed {
   override def description: String = name
 
   // TODO what about duplicate names?
-  override val allOperations: Seq[TypeOperation] =
+  override lazy val allOperations: Seq[TypeOperation] =
     typesToUnion.flatMap(_.allOperations).toSeq
 
-  override val operations: Seq[TypeOperation] =
+  override lazy val operations: Seq[TypeOperation] =
     typesToUnion.flatMap(_.operations).toSeq
 
   override def toString: String =

--- a/src/main/scala/com/atomist/util/ServiceLoaderBackedExtensionProvider.scala
+++ b/src/main/scala/com/atomist/util/ServiceLoaderBackedExtensionProvider.scala
@@ -15,7 +15,7 @@ import scala.reflect.{ClassTag, _}
 class ServiceLoaderBackedExtensionProvider[T: ClassTag](val keyProvider: T => String)
   extends LazyLogging {
 
-  // The following can be cached as it creates issues in shared class loader hiarchies
+  // The following can be cached as it creates issues in shared class loader hierarchies
   def providerMap: Map[String, T] = {
     logger.debug(s"Loading providers of type ${classTag[T].runtimeClass.getName} and class loader ${Thread.currentThread().getContextClassLoader}")
     ServiceLoader.load(classTag[T].runtimeClass).asScala.map {

--- a/src/test/scala/com/atomist/tree/marshal/LinkedJsonGraphDeserializerTest.scala
+++ b/src/test/scala/com/atomist/tree/marshal/LinkedJsonGraphDeserializerTest.scala
@@ -1,9 +1,12 @@
 package com.atomist.tree.marshal
 
 import com.atomist.rug.TestUtils
+import com.atomist.rug.kind.DefaultTypeRegistry
+import com.atomist.rug.runtime.js.interop.jsSafeCommittingProxy
 import com.atomist.rug.ts.Cardinality
 import com.atomist.tree.TreeNode
 import com.atomist.tree.utils.NodeUtils
+import com.atomist.util.lang.JavaScriptArray
 import org.scalatest.{FlatSpec, Matchers}
 
 class LinkedJsonGraphDeserializerTest extends FlatSpec with Matchers {
@@ -84,5 +87,43 @@ class LinkedJsonGraphDeserializerTest extends FlatSpec with Matchers {
     val node = LinkedJsonGraphDeserializer.fromJson(withLinks)
     val x = node.toString
     assert(x.contains("HerokuApp"))
+  }
+
+  it should "meet satisfactory benchmarks" in {
+    val withLinks = TestUtils.contentOf(this, "withLinks.json")
+    val node = LinkedJsonGraphDeserializer.fromJson(withLinks)
+
+    val build = new jsSafeCommittingProxy(node, DefaultTypeRegistry)
+
+    val st = System.currentTimeMillis()
+
+    val passes = 100
+
+    for (i <- 1 to passes) {
+      assert(build.getMember("status") === "Passed")
+      val owner = build.getMember("ON").asInstanceOf[jsSafeCommittingProxy]
+      val channel = owner.getMember("CHANNEL")
+      val push = build.getMember("TRIGGERED_BY").asInstanceOf[jsSafeCommittingProxy]
+      val commits = push.getMember("CONTAINS").asInstanceOf[JavaScriptArray[_]]
+      assert(commits.lyst.size() === 1)
+    }
+    val et = System.currentTimeMillis() - st
+
+    println(s"$passes took $et milliseconds")
+    assert(et < passes * 10)
+
+    assert(node.relatedNodesNamed("status").head.asInstanceOf[TreeNode].value === "Passed")
+    val repo = node.relatedNodesNamed("ON").head
+    assert(repo.relatedNodesNamed("owner").size === 1)
+    assert(!repo.nodeTags.contains(Cardinality.One2Many))
+    assert(!node.nodeTags.contains(Cardinality.One2Many))
+
+    // Special node with cardinality
+    val contains = node.relatedNodesNamed("ONM").head
+    assert(contains.nodeTags.contains(Cardinality.One2Many))
+
+    val chatChannel = repo.relatedNodesNamed("CHANNEL").head
+    assert(chatChannel.relatedNodesNamed("name").size === 1)
+    assert(chatChannel.relatedNodesNamed("id").head.asInstanceOf[TreeNode].value === "channel-id")
   }
 }


### PR DESCRIPTION
Radical performance improvement when working with graph nodes.

This reduces the new benchmark in `LinkedJsonGraphDeserializerTest` from 10,000ms to around 60.

The problem was in inadvertently calling into `ServiceLoader` via `jsSafeCommittingProxy` -> `Typed.typeFor` -> `TypeRegistry.findByName(t)`

 Note: See @cdupuis comment on `ServiceLoaderBackedExtensionProvider`. Does the new behavior affect this?