### PR TITLE
Make slice impl more true to JS

### DIFF
--- a/src/main/scala/com/atomist/util/lang/JavaScriptArray.scala
+++ b/src/main/scala/com/atomist/util/lang/JavaScriptArray.scala
@@ -202,13 +202,19 @@ class JavaScriptArray[T](val toProxy: java.util.List[T])
             case _ =>
               val head = args.head.asInstanceOf[Int]
               val begin = if (head >= 0) head else lyst.size() + head
-              args.length match {
-                case 1 => new JavaScriptArray[T](lyst.subList(begin, lyst.size()))
-                case _ =>
-                  val theEnd = args(1).asInstanceOf[Int]
-                  val end = if (theEnd >= 0) theEnd else lyst.size() + theEnd
-                  new JavaScriptArray[T](lyst.subList(begin, end))
-              }
+              if (head >= lyst.size()) {
+                new util.ArrayList[T]()
+              } else
+                args.length match {
+                  case 1 => new JavaScriptArray[T](lyst.subList(begin, lyst.size()))
+                  case _ =>
+                    val theEnd = args(1).asInstanceOf[Int]
+                    val end =
+                      if (theEnd > lyst.size()) lyst.size()
+                      else if (theEnd >= 0) theEnd
+                      else lyst.size() + theEnd
+                    new JavaScriptArray[T](lyst.subList(begin, end))
+                }
           }
         }
       }
@@ -361,7 +367,7 @@ class JavaScriptArray[T](val toProxy: java.util.List[T])
         override def call(thiz: scala.Any, args: AnyRef*): AnyRef = {
           val map = args.head.asInstanceOf[ScriptObjectMirror]
           val res = new JavaScriptArray[AnyRef](new util.ArrayList[AnyRef]())
-          for(i <- 0 until lyst.size()){
+          for (i <- 0 until lyst.size()) {
             val thisArg = if (args.length > 1) args(1) else thiz
             res.add(map.call(thisArg, lyst.get(i).asInstanceOf[Object], i.asInstanceOf[Integer], lyst))
           }

--- a/src/test/scala/com/atomist/util/lang/JavaScriptArrayTest.scala
+++ b/src/test/scala/com/atomist/util/lang/JavaScriptArrayTest.scala
@@ -109,6 +109,17 @@ class JavaScriptArrayTest extends FlatSpec with Matchers {
       |       if(sliced4[0] != "is" || sliced4[2] != "good") {
       |          throw new Error("Negative end slice failed")
       |       }
+      |
+      |       let sliced5: string[] = this.lyst.slice(10)
+      |       if(sliced5.length !== 0) {
+      |          throw new Error("Begin past end slice failed")
+      |       }
+      |
+      |       let sliced6: string[] = this.lyst.slice(0, 10)
+      |       if(sliced6.length !== this.lyst.length) {
+      |          throw new Error("end past end slice failed")
+      |       }
+      |
       |       let sorted: string[] = this.lyst.sort()
       |
       |       if(sorted[0] != "a" || sorted[4] != "movie"){


### PR DESCRIPTION
Slice with out-of-bounds numbers works OK in JS, so we should allow them here instead of failing with exceptions.