### PR TITLE
Remove confusion from toString

### DIFF
--- a/src/main/scala/com/atomist/tree/marshal/LinkableContainerTreeNode.scala
+++ b/src/main/scala/com/atomist/tree/marshal/LinkableContainerTreeNode.scala
@@ -31,9 +31,7 @@ private class LinkableContainerTreeNode(
   // to call toString on our child nodes
   override def toString: String = {
     getClass.getSimpleName + s": (${nodeTags.mkString(",")}); " +
-      childNodeNames.map(childName => {
-        childName + ":[" + childNodeNames.mkString(",") + "]"
-      }).mkString("; ")
+      childNodeNames.mkString("; ")
   }
 }
 


### PR DESCRIPTION
It was repeating the list of children after each child.

It looked like this, which is confusing:

com.atomist.rug.runtime.js.SourceLanguageRuntimeException: [SafeCommittingProxy#679511233 around LinkableContainerTreeNode: (ChatChannel,-dynamic); isDefault:[name,provider,normalizedName,id,team,isDefault]; team:[name,provider,normalizedName,id,team,isDefault]; normalizedName:[name,provider,normalizedName,id,team,isDefault]; provider:[name,provider,normalizedName,id,team,isDefault]; id:[name,provider,normalizedName,id,team,isDefault]; name:[name,provider,normalizedName,id,team,isDefault] is not an Object] at .atomist/handlers/event/BotJoinedChannel.ts:67/66
        console.log("Atomist was invited to " + Object.keys(match.root.channel).join(","));
