### PR TITLE
Avoid TypeScript keywords in function params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/rug/compare/1.0.0-m.6...HEAD
 
+### Changed
+
+-   Avoid TypeScript keywords in function parameter names [#664][664]
+    and clean up generated TypeScript
+
+[664]: https://github.com/atomist/rug/issues/664
+
 ## [1.0.0-m.6] - 2017-08-17
 
 [1.0.0-m.6]: https://github.com/atomist/rug/compare/1.0.0-m.5...1.0.0-m.6

--- a/pom.xml
+++ b/pom.xml
@@ -532,7 +532,7 @@
                                 </goals>
                                 <configuration>
                                     <!-- Pin versions to things we know are working. TS things tend to break! -->
-                                    <arguments>install --save-dev typescript@2.4.1 @types/node@8.0.11 typedoc@0.7.1 gulp@3.9.1 gulp-typedoc@2.0.2  @types/lodash@4.14.68</arguments>
+                                    <arguments>install --save-dev typescript@2.4.1 @types/node@8.0.11 typedoc@0.7.1 gulp@3.9.1 gulp-typedoc@2.0.2 @types/lodash@4.14.68</arguments>
                                 </configuration>
                                 <phase>process-test-resources</phase>
                             </execution>

--- a/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/AbstractTypeScriptGenerator.scala
@@ -89,23 +89,24 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
 
     def comment(indent: String): String = {
       val builder = new StringBuilder(s"$indent/**\n")
-      val deprecationMessage = if (deprecated) "DEPRECATED - " else ""
-      builder ++= s"$indent  * $deprecationMessage${description.getOrElse("")}\n"
-      builder ++= s"$indent  * \n"
+      val deprecationMessage = if (deprecated) " DEPRECATED -" else ""
+      val descriptionMessage = if (description.isDefined) s" ${description.get}" else ""
+      builder ++= s"$indent *$deprecationMessage$descriptionMessage\n"
+      builder ++= s"$indent *\n"
 
       if (exposeAsProperty) {
-        builder ++= s"$indent  * @property {$returnType} $name\n"
+        builder ++= s"$indent * @property {$returnType} $name\n"
       } else {
         if (params.nonEmpty) {
           for (p <- params)
-            yield builder ++= s"$indent  * ${p.comment}\n"
+            yield builder ++= s"$indent * ${p.comment}\n"
         }
 
         if (returnType != "void")
-          builder ++= s"$indent  * @returns {$returnType}\n"
+          builder ++= s"$indent * @returns {$returnType}\n"
       }
 
-      builder ++= s"$indent  */\n"
+      builder ++= s"$indent */\n"
       builder.toString
     }
 
@@ -225,11 +226,9 @@ abstract class AbstractTypeScriptGenerator(typeRegistry: TypeRegistry,
       output ++= config.imports
       output ++= t.specificImports
       output ++= getImports(generatedTypes, t)
+      output ++= s"\nexport { ${t.name} };"
       output ++= config.separator
-      output ++= s"export { ${t.name} };"
-      output ++= config.separator
-      output ++= t.toString
-      output ++= config.separator
+      output ++= t.toString + "\n"
       tsClassOrInterfaces += StringFileArtifact(s"$path${t.name}.ts", output.toString())
       alreadyGenerated += t
     }
@@ -294,7 +293,4 @@ object TypeGenerationConfig {
        |import { ProjectContext } from "@atomist/rug/operations/ProjectEditor";
        |""".stripMargin
 
-  val TestStubImports: String =
-    """|import { GraphNode } from "@atomist/rug/tree/PathExpression";
-       |""".stripMargin
 }

--- a/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
+++ b/src/main/scala/com/atomist/rug/ts/TypeScriptInterfaceGenerator.scala
@@ -50,7 +50,7 @@ class TypeScriptInterfaceGenerator(typeRegistry: TypeRegistry = DefaultTypeRegis
         output ++= s"\ninterface $name extends ${parent.mkString(", ")} {${config.separator}"
 
       output ++= methods.map(_.toString).mkString(config.separator)
-      output ++= s"${if (methods.isEmpty) "" else config.separator}}${indent.dropRight(1)}"
+      output ++= s"${if (methods.isEmpty) "" else config.separator}}"
       output.toString
     }
   }

--- a/src/main/scala/com/atomist/util/lang/CodeGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/CodeGenerationHelper.scala
@@ -16,7 +16,7 @@ class CodeGenerationHelper(indent: String = "    ") {
     */
   def indented(block: String, n: Int): String = {
     val padding = Array.fill[String](n)(indent).mkString("")
-    padding + block.replace("\n", s"\n$padding")
+    padding + block.replaceAll("\n(?!\n)", s"\n$padding")
   }
 
   /**

--- a/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
+++ b/src/main/scala/com/atomist/util/lang/TypeScriptGenerationHelper.scala
@@ -15,7 +15,7 @@ class TypeScriptGenerationHelper(indent: String = "    ")
     * Convert the block to a JsDoc style comment.
     */
   def toJsDoc(block: String): String = {
-    s"""|/*
+    s"""|/**
         | * ${block.replace("\n", "\n * ")}
         | */""".stripMargin
   }

--- a/src/test/scala/com/atomist/rug/rugdoc/TypeScriptStubClassGeneratorTest.scala
+++ b/src/test/scala/com/atomist/rug/rugdoc/TypeScriptStubClassGeneratorTest.scala
@@ -25,11 +25,7 @@ object TypeScriptStubClassGeneratorTest {
       override def edit(f: FileArtifact): FileArtifact =
       f.withContent(f.content
         .replace(TypeGenerationConfig.DefaultImports,
-          TypeScriptInterfaceGeneratorTest.InterfaceTestImports)
-        .replace(TypeGenerationConfig.TestStubImports,
-          s"""
-             |interface GraphNode {}
-        """.stripMargin))
+          TypeScriptInterfaceGeneratorTest.InterfaceTestImports))
     }
 
   def compile(output: ArtifactSource): ArtifactSource = {


### PR DESCRIPTION
Some object properties are TypeScript keywords, e.g., `default`.
Alter the generated builder methods to avoid using property names
exactly.  Clean up generated TypeScript code, ensuring semicolons,
adding access specifiers, imports, no trailing space, etc.

Towards #664